### PR TITLE
Add (adjust (fn ...) ...)

### DIFF
--- a/test/riemann/test/streams.clj
+++ b/test/riemann/test/streams.clj
@@ -710,11 +710,21 @@
            (is (= (set (deref out)) #{b e}))))
 
 (deftest adjust-test
-         (let [out (ref nil)
-               s (adjust [:state str " 2"] (register out))]
-           
-           (s {})
-           (is (= (deref out) {:state " 2"}))
-           
-           (s {:state "hey" :service "bar"})
-           (is (= (deref out) {:state "hey 2" :service "bar"}))))
+  (let [out (ref nil)
+        s (adjust [:state str " 2"] (register out))]
+
+    (s {})
+    (is (= (deref out) {:state " 2"}))
+
+    (s {:state "hey" :service "bar"})
+    (is (= (deref out) {:state "hey 2" :service "bar"})))
+
+  (let [out (ref nil)
+        s (adjust #(assoc % :metric (count (:tags %)))
+                  (register out))]
+
+    (s {:service "a" :tags []})
+    (is (= (deref out) {:service "a" :tags [] :metric 0}))
+
+    (s {:service "a" :tags ["foo" "bar"]})
+    (is (= (deref out) {:service "a" :tags ["foo" "bar"] :metric 2}))))


### PR DESCRIPTION
This change turns adjust into a multimethod that will work on a vector like
before, but now can also take a function to transform entire events.  This can
be useful if you want to modify one field based on the value of another.
