### PR TITLE
more portable bash shebang

### DIFF
--- a/bin/riemann
+++ b/bin/riemann
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ -z "$1" ]
 then
   config="/etc/riemann/riemann.config"


### PR DESCRIPTION
Fixed shebang invocation to work on systems (e.g., FreeBSD, for example) where `bash` is not in `/bin` by default.
