### PR TITLE
add pagerduty to config context

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -14,6 +14,7 @@
   (:use [riemann.streams :exclude [update-index delete-from-index]])
   (:use riemann.email)
   (:use riemann.graphite)
+  (:use riemann.pagerduty)
   (:gen-class))
 
 (def ^{:doc "A default core."} core (core/core))


### PR DESCRIPTION
was taking riemann for whirl today, really enjoying it so far. 

was getting this exception when trying out the pagerduty stuff:

java.lang.RuntimeException: Unable to resolve symbol: pagerduty in this context, compiling:(null:20)

with (let [page (pagerduty "MY KEY") ...] ...) in my config. not familiar w/ clojure at all but
adding this line seems to fix it
