### PR TITLE
Change streams/moving-event-window to use take-last instead of subvec.

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -108,11 +108,7 @@
   (let [window (atom (vec []))]
     (fn [event]
       (let [w (swap! window (fn [w]
-                              (let [w (conj w event)
-                                    size (count w)]
-                                (if (< n size)
-                                  (subvec w (- size n))
-                                  w))))]
+                              (vec (take-last n (conj w event)))))]
         (call-rescue w children)))))
 
 (defn fixed-event-window


### PR DESCRIPTION
subvec maintains a reference to the head of the parent vector, which of
course causes memory leakage after a while. This version may be somewhat
less efficient (I've not profiled it) but memory usage will be stable.
