### PR TITLE
Add travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: clojure
+before_script: sed -i 's,"-d64",,' project.clj
+lein: lein2
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - openjdk6


### PR DESCRIPTION
The only trick is to remove -d64 before launching tests since travis doesn't support that, otherwise it's SOP
