### PR TITLE
lein run requires -- to pass additional parameters like /usr/local/etc/riemann.custom.config through to riemann

### DIFF
--- a/contributing.html
+++ b/contributing.html
@@ -44,7 +44,7 @@ too. If you use Riemann, <a href="mailto:aphyr@aphyr.com">send me an
 
     <p>You can run the server with</p>
 
-    <code><pre>lein run riemann.config</pre></code>
+    <code><pre>lein run -- riemann.config</pre></code>
 
     <p>and when you're ready to package, just <code>lein package</code>
     to build both regular and standalone jars, a debian package, tarball,


### PR DESCRIPTION
```
USAGE: lein run [--] [ARGS...]
Calls the -main function in the namespace specified as :main in project.clj.
You may use -- to escape the first argument in case it begins with `-' or `:'.
If your main function is not called "-main", you may use a namespaced symbol
like clojure.main/main.
```
