### PR TITLE
Add chain, else* and cond*

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1085,7 +1085,9 @@
             (second clauses)
             (throw (IllegalArgumentException.
                     "cond* requires an even number of form")))
-          (list 'else (cons 'riemann.streams/cond* (next (next clauses)))))))
+          (list 'else (cons 'riemann.streams/cond*
+                            (or (next (next clauses))
+                                (list 'riemann.streams/chain)))))))
 
 (defn update-index
   "Updates the given index with all events received."


### PR DESCRIPTION
Three functions to help build more concise streams.
- `chain` is  a dummy function which helps you jump to a different 
- `cond*` acts as a cond-like equivalent in streams
- `else*` is nice as the default operation for `cond*`
