### PR TITLE
Add split* and split, as described in aphyr/riemann/#77

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1096,6 +1096,24 @@
        (when-let [stream# (some split-match (list ~@clauses))]
          (call-rescue ~'event [stream#])))))
 
+(defmacro splitp
+  "Takes a binary predicate, an expression and a set of
+   clauses.
+
+   For each clause, (pred test-expr expr) is evaluated, note
+   the order change from condp.
+
+   If a binary clause matches, its associated stream will be
+   executed."
+  [pred expr & clauses]
+  (let [clauses (for [[test-expr stream] (partition-all 2 clauses)]
+                  (if (nil? stream)
+                    [test-expr]
+                    [(where-rewrite (list pred test-expr expr)) stream]))]
+    `(fn [~'event]
+       (when-let [stream# (some split-match (list ~@clauses))]
+         (call-rescue ~'event [stream#])))))
+
 (defn update-index
   "Updates the given index with all events received."
   [index]

--- a/test/riemann/test/streams.clj
+++ b/test/riemann/test/streams.clj
@@ -227,6 +227,22 @@
        e))
     (is (= expect @res))))
 
+(deftest splitp-test
+  ;; same test as above, using splitp
+  (let [sup    (fn [threshold] (fn [{:keys [metric]}] (> metric threshold)))
+        res    (atom [])
+        events [{:metric 15} {:metric 8} {:metric 2}]
+        expect [{:metric 15 :state :crit}
+                {:metric 8 :state :warn}
+                {:metric 2 :state :ok}]]
+    (doseq [e events]
+      ((splitp <= metric
+               10 (with :state :crit (partial swap! res conj))
+               5  (with :state :warn (partial swap! res conj))
+              (with :state :ok (partial swap! res conj)))
+       e))
+    (is (= expect @res))))
+
 (deftest where*-test
          (test-stream (where* identity)
                       [true false nil 2]


### PR DESCRIPTION
implementation for split\* and split (as described here: aphyr/riemann/#77)
