### PR TITLE
produce unique names for snapshot debs

### DIFF
--- a/tasks/leiningen/fatdeb.clj
+++ b/tasks/leiningen/fatdeb.clj
@@ -83,7 +83,7 @@
     ; Jar
     (.mkdirs (file dir "usr" "lib" "riemann"))
     (copy (file (:root project) "target" 
-                (str "riemann-" (get-version project) "-standalone.jar"))
+                (str "riemann-" (:version project) "-standalone.jar"))
           (file dir "usr" "lib" "riemann" "riemann.jar"))
 
     ; Binary


### PR DESCRIPTION
replace SNAPSHOT with a date string to allow unique names, when publishing the output of fatdeb to a debian repository this helps publish updates in a straightforward way
