### PR TITLE
Add delete-by stream primitive and test case

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1142,3 +1142,11 @@
   [index]
   (fn [event]
     (index/delete index event)))
+
+(defn delete-by [index fields]
+  "Deletes events with matching fields from the index. Takes two arguments: an index and a vector of fields or a single field as arguments. For instance, if you wanted to delete all events for a specific host when an event from it arrives, you could do (delete-by index :host)"
+  (let [match-fn (if (vector? fields) (apply juxt fields) fields)]
+    (fn [event]
+      (let [match (match-fn event)]
+        (doseq [event (filter #(= match (match-fn %)) index)]
+          (index/delete-exactly index event))))))

--- a/test/riemann/test/streams.clj
+++ b/test/riemann/test/streams.clj
@@ -813,6 +813,18 @@
            (doseq [state states] (d state))
            (is (= (vec (seq i)) []))))
 
+(deftest delete-by-test
+         (let [index (index/index)
+               update (update-index index)
+               delete (delete-by index :host)
+               states [{:host 1 :service "a" :state "ok"}
+                       {:host 2 :service "a" :state "critical"}
+                       {:host 1 :service "b" :state "warning"}]]
+               (doseq [state states] (update state))
+               (delete {:host 1})
+               (is (= (vec (seq index))
+                   [{:host 2 :service "a" :state "critical"}]))))
+
 (deftest ewma-timeless-test
          (test-stream (ewma-timeless 0)
                       (em 1 10 20 -100 4)


### PR DESCRIPTION
delete-by allows you to delete events from the index based on properties of the event. We use it to delete individual metrics (delete-by index [:host :service]) when we're performing upgrades but also to delete all metrics for a particular host when we retire hosts (delete-by index :host).
