### PR TITLE
Fix graphite-server method name bug

### DIFF
--- a/src/riemann/transport/graphite.clj
+++ b/src/riemann/transport/graphite.clj
@@ -46,7 +46,7 @@
   "Given a core and a MessageEvent, applies the message to core."
   [core e]
   (doseq [stream (:streams core)]
-    (stream (.getMsg e))))
+    (stream (.getMessage e))))
 
 (defn graphite-server
   "Start a graphite-server, some bits could be factored with tcp-server.


### PR DESCRIPTION
When I tried to get graphite-server running, it threw exceptions about a misnamed method -- `getMsg` instead of `getMessage` for `org.jboss.netty.channel.MessageEvent` objects. With this fix, graphite-server works just fine.
