### PR TITLE
repl/start-server! should take a hash-map instead of a vector

### DIFF
--- a/src/riemann/repl.clj
+++ b/src/riemann/repl.clj
@@ -23,8 +23,7 @@
   :port (default 5557)"
   [opts]
   (stop-server!)
-  (let [opts (merge {:port 5557 :host "127.0.0.1"} 
-                    (apply hash-map opts))]
+  (let [opts (merge {:port 5557 :host "127.0.0.1"} opts)]
     (def server (nrepl/start-server
                   :port (:port opts)
                   :bind (:host opts)))


### PR DESCRIPTION
This is what the rest of the code expects. Without this fix, this causes a crash:

``` clojure
(repl-server :host "0.0.0.0")
```
