### PR TITLE
Fix type error in graphite server.

### DIFF
--- a/src/riemann/transport/graphite.clj
+++ b/src/riemann/transport/graphite.clj
@@ -40,10 +40,9 @@
   "A closure which yields a graphite frame-decoder. Taking an argument
    which will be given to decode-graphite-line (hence the closure)"
   [parser-fn]
-  (fn []
-    (proxy [OneToOneDecoder] []
-      (decode [context channel message]
-        (decode-graphite-line message parser-fn)))))
+  (proxy [OneToOneDecoder] []
+    (decode [context channel message]
+      (decode-graphite-line message parser-fn))))
 
 (defn graphite-handler
   "Given a core and a MessageEvent, applies the message to core."


### PR DESCRIPTION
When you start a graphite server, there's a type error:

```
java.lang.ClassCastException: riemann.transport.graphite$graphite_frame_decoder$fn__7763 cannot be cast to org.jboss.netty.channel.ChannelHandler
    at riemann.transport.graphite$graphite_server$reify__7776.getPipeline(graphite.clj:66)
    at org.jboss.netty.channel.socket.nio.NioServerBoss.registerAcceptedChannel(NioServerBoss.java:134)
    at org.jboss.netty.channel.socket.nio.NioServerBoss.process(NioServerBoss.java:104)
    at org.jboss.netty.channel.socket.nio.AbstractNioSelector.run(AbstractNioSelector.java:313)
    at org.jboss.netty.channel.socket.nio.NioServerBoss.run(NioServerBoss.java:42)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:680)
```

This patch fixes it.
