### PR TITLE
Add Java to deb dependencies.

### DIFF
--- a/tasks/leiningen/fatdeb.clj
+++ b/tasks/leiningen/fatdeb.clj
@@ -49,7 +49,7 @@
               :section "base"
               :priority "optional"
               :architecture "all"
-              :depends "bash"
+              :depends (join ", " ["bash" "default-jre | java2-runtime"])
               :maintainer (:email (:maintainer project))
               :description (:description project)})))
 


### PR DESCRIPTION
I fired up a fresh Linode, grabbed and installed the deb from the website, and ran `invoke-rc.d riemann start`. It returned with an exit code of 0, so I assumed all was well.

It wasn't!

I eventually tracked the issue down. I didn't have Java installed. It'd have been nice if `dpkg` had bailed, telling me that what I needed.

I've added the same Java dependency that the Debian/Ubuntu Clojure package uses:

http://bazaar.launchpad.net/~ubuntu-branches/ubuntu/raring/clojure1.4/raring/view/head:/debian/control#L17

Test plan: `lein fatdeb` still works...
