### PR TITLE
Pin Lamina to fix the build.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,6 +21,7 @@
                                        com.sun.jdmk/jmxtools
                                        com.sun.jmx/jmxri]]
     [aleph "0.3.0-beta15"]
+    [lamina "0.5.0-beta15"]
     [clj-http "0.4.1"]
     [cheshire "5.0.0"]
     [clj-librato "0.0.2"]


### PR DESCRIPTION
Riemann 0.2.0 depends on Aleph 0.3.0-beta15, which depends on Lamina 0.5.0-beta14:

https://github.com/ztellman/aleph/commit/7216a660af8773e781e50ea548ef32de961ff0e4

Unfortunately, Lamina 0.5.0-beta14 depends on a nonexistent release of Coda Hale's Metrics library:

https://github.com/ztellman/lamina/blob/0.5.0-beta14/project.clj#L7

Lamina 0.5.0-beta15 no longer depends on Metrics at all, so the issue is resolved:

https://github.com/ztellman/lamina/blob/0.5.0-beta15/project.clj#L4

As soon as a version of Aleph is released that depends on Lamina >= 0.5.0-beta15, this line can be removed from the project.clj.

Test plan: it actually builds now :-)
