### PR TITLE
Ensure that (:streams core) is always a vec.

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -100,7 +100,7 @@
   [& things]
   (locking core
     (swap! next-core assoc :streams
-           (concat (:streams @next-core) things))))
+           (reduce conj (:streams @next-core) things))))
 
 (defn index
   "Set the index used by this core. Returns the index."


### PR DESCRIPTION
Clojure.core/concat always returns a LazySeq, not a vec, and LazySeq has some
[synchronized badness](1).
