### PR TITLE
Fix docstring consistency issue

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1470,7 +1470,7 @@ OA
   "Usable to perform flap detection, runs examines a moving-event-window of
   n events and determines if :field is the same across all them. If it is,
   runs passes on the last (newest) event of the window. In practice, this can be 
-  used nested within a (changed-state ...) to reduce 'flappiness' for 
+  used with (changed-state ...) as a child to reduce 'flappiness' for 
   state changes.
 
   (runs 3 :state prn) ; Print events where there are 3-in-a-row of a state."


### PR DESCRIPTION
I didn't change the docstring to indicate that I am sending the newest event, not the first of the window.
