### PR TITLE
adds a teaser intro to the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,9 @@
-[http://riemann.io](http://riemann.io)
+# Riemann monitors distributed systems.
+
+Riemann aggregates events from your servers and applications with a powerful stream processing language.
+
+Find out more at [http://riemann.io](http://riemann.io)
+
 ===
 
 [![Build Status](https://travis-ci.org/aphyr/riemann.png)](https://travis-ci.org/aphyr/riemann)


### PR DESCRIPTION
To my eyes, the "more info" section on github seems so sparse with just the riemann.io link.  opinion?
