### PR TITLE
Fix malformed event expiry

### DIFF
--- a/src/riemann/index.clj
+++ b/src/riemann/index.clj
@@ -52,16 +52,15 @@
 
       (expire [this]
               (filter
-               (fn [{:keys [ttl time]
+                (fn [{:keys [ttl time]
                      :or {ttl default-ttl
                           time (unix-time)}
                      :as state}]
-                 (when )
-                 (let [age (- (unix-time) time)]
-                   (when (> age ttl)
-                     (delete this state)
-                     true)))
-               (.values hm)))
+                  (let [age (- (unix-time) time)]
+                    (when (> age ttl)
+                      (delete this state)
+                      true)))
+                (.values hm)))
 
       (search [this query-ast]
               "O(n), sadly."


### PR DESCRIPTION
Default ttl provisionning was not done (`:ttl` vs `ttl`) and in some cases, streams can emit malformed events with no time which break expiry, provide a default in these cases as well.

I'm wondering if the default shouldn't rather be 0 to ensure expiry of these events, that's up for debate.
