### PR TITLE
Bump Aleph so Lamina can be unpinned.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,8 +20,7 @@
                                        javax.jms/jms
                                        com.sun.jdmk/jmxtools
                                        com.sun.jmx/jmxri]]
-    [aleph "0.3.0-beta15"]
-    [lamina "0.5.0-beta15"]
+    [aleph "0.3.0-beta16"]
     [clj-http "0.4.1"]
     [cheshire "5.0.0"]
     [clj-librato "0.0.2"]


### PR DESCRIPTION
The transitive dependency on Lamina was causing problems (fixed in
8f429796efcdadec836838bcf6c1362bd7846dbb) due to Lamina depending on a
vanishing Metrics snapshot. Lamina no longer depends on Metrics
(ztellman/lamina@f632319fb8b327e19a834b0694a6d2168ddbf205), and Aleph
0.3.0-beta16 now depends on that newer version of Lamina
(ztellman/aleph@58c4dd98ca85e428e3dba09fdceae8e76aac517c), so we're
good.
