### PR TITLE
Remove openjdk dependency from fatdeb to improve flexibility

### DIFF
--- a/tasks/leiningen/fatdeb.clj
+++ b/tasks/leiningen/fatdeb.clj
@@ -50,7 +50,7 @@
               :section "base"
               :priority "optional"
               :architecture "all"
-              :depends (join ", " ["bash" "default-jre-headless | java2-runtime-headless"])
+              :depends (join ", " ["bash"])
               :maintainer (:email (:maintainer project))
               :description (:description project)})))
 


### PR DESCRIPTION
This came up when using the opscode-cookbooks/java cookbook. If you install the oracle flavor, which installs via tarballs, the riemann deb will install but will break apt-get for everything else. It won't let you install anything else because riemann doesn't have openjdk like it expects. 

I vote that we remove java as a strict dependency to sidestep this problem.
