### PR TITLE
streams/where*: should only evaluate children once

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1376,12 +1376,14 @@ OA
       (partial prn \"Not expired!\")))"
   [f & children]
   (let [[true-kids else-kids] (where-partition-clauses children)]
-    `(fn stream# [event#]
-       (let [value# (~f event#)]
-         (if value#
-           (call-rescue event# ~true-kids)
-           (call-rescue event# ~else-kids))
-         value#))))
+    `(let [true-kids# ~true-kids
+           else-kids# ~else-kids]
+      (fn stream# [event#]
+         (let [value# (~f event#)]
+           (if value#
+             (call-rescue event# true-kids#)
+             (call-rescue event# else-kids#))
+           value#)))))
 
 (defmacro where
   "Passes on events where expr is true. Expr is rewritten using where-rewrite.

--- a/test/riemann/test/streams.clj
+++ b/test/riemann/test/streams.clj
@@ -437,7 +437,17 @@
            (is (= @bad
                   [{:service "bad" :metric 0}
                    {:metric 1}
-                   {:service "bad" :metric 1}]))))
+                   {:service "bad" :metric 1}])))
+
+         (testing "evaluates children once"
+                  ; Where should evaluate its children exactly once.
+                  (let [x (atom 0)
+                        s (where* (fn [e] true) (do (swap! x inc) identity))]
+                    (is (= @x 1))
+                    (s {:service "test"})
+                    (is (= @x 1))
+                    (s {:service "test"})
+                    (is (= @x 1)))))
 
 (deftest where*-return-value
          ; Where*'s return value should be whether the predicate matched.


### PR DESCRIPTION
Copy the idiom used in where to evaluate the children once instead of for each execution
