### PR TITLE
Lookup an event directly from the index

### DIFF
--- a/src/riemann/index.clj
+++ b/src/riemann/index.clj
@@ -28,7 +28,9 @@
   (search [this query-ast]
     "Returns a seq of events from the index matching this query AST")
   (update [this event]
-    "Updates index with event"))
+    "Updates index with event")
+  (lookup [this host service]
+    "Lookup an indexed event from the index"))
 
 ; The index accepts states and maintains a table of the most recent state for
 ; each unique [host, service]. It can be searched for states matching a query.
@@ -68,6 +70,9 @@
               (when-not (= "expired" (:state event))
                 (.put hm [(:host event) (:service event)] event)
                   event))
+
+      (lookup [this host service]
+        (.get hm [host service]))
 
       clojure.lang.Seqable
       (seq [this]

--- a/test/riemann/test/index.clj
+++ b/test/riemann/test/index.clj
@@ -47,6 +47,15 @@
            (is (= (map (fn [e] (:host e)) i)
                   [2]))))
 
+(deftest nbhm-read-index
+         (let [i (nbhm-index)]
+           (update i {:host 1 :service 1 :metric 5})
+           (update i {:host 1 :service 2 :metric 7})
+
+           (is (= 5 (:metric (lookup i 1 1))))
+           (is (= 7 (:metric (lookup i 1 2))))))
+
+
 (defn random-event
   [& {:as event}]
   (merge {:host    (rand-int 100)


### PR DESCRIPTION
We would like to be able to read an event direct from the index and therefore have added a simple lookup function to use instead of having to execute a search.
