### PR TITLE
Use tagged release nrepl-0.2.2 instead of 0.2.0-RC1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
     [org.clojure/clojure "1.5.0"]
     [org.clojure/math.numeric-tower "0.0.1"]
     [org.clojure/tools.logging "0.2.3"]
-    [org.clojure/tools.nrepl "0.2.0-RC1"]
+    [org.clojure/tools.nrepl "0.2.2"]
     [clojure-complete "0.2.2"]
     [log4j/log4j "1.2.16" :exclusions [javax.mail/mail
                                        javax.jms/jms


### PR DESCRIPTION
tests:

```
Compiling 2 source files to /zfs/shared/repos/riemann/core/target/classes
warning: [options] bootstrap class path not set in conjunction with -source 1.6
1 warning
export LIBRATO_METRICS_USER="..." to run these tests.
export LIBRATO_METRICS_API_KEY="..." to run these tests.

lein test riemann.test.client
line 1:8 mismatched character '<EOF>' expecting '='
line 1:0 no viable alternative at input 'invalid'
line 1:8 mismatched character '<EOF>' expecting '='
line 1:0 no viable alternative at input 'invalid'

lein test riemann.test.common

lein test riemann.test.config

lein test riemann.test.core

lein test riemann.test.deps

lein test riemann.test.email

lein test riemann.test.folds

lein test riemann.test.graphite

lein test riemann.test.index

lein test riemann.test.librato

lein test riemann.test.pool

lein test riemann.test.pubsub

lein test riemann.test.query

lein test riemann.test.service

lein test riemann.test.sns

lein test riemann.test.streams

lein test riemann.test.time

lein test riemann.test.time.controlled

lein test riemann.test.transport

Ran 147 tests containing 701 assertions.
0 failures, 0 errors.
```
