### PR TITLE
Two simple functions:

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -207,6 +207,12 @@ OA
   (deprecated "riemann.streams/stream is now streams/sdo."
               (apply sdo args)))
 
+(defmacro defstream
+  "Define a named stream, equivalent to calling (def stream-sym (sdo ...))"
+  [stream-sym & body]
+  `(def ~stream-sym
+     (sdo ~@body)))
+
 (defn execute-on
   "Returns a stream which accepts events and executes them using a
   java.util.concurrent.Executor. Returns immediately. May throw
@@ -1199,6 +1205,15 @@ OA
               event (assoc event field value)]
           (call-rescue event children))))
     (apply smap (first args) (rest args))))
+
+(defn scale
+  "Passes on a changed version of each event by multiplying each
+   metric with the input scale factor"
+  [factor & children]
+  (let [scale-event (fn [{:keys [metric] :as event}]
+                      (assoc event :metric
+                             (if metric (* metric factor))))]
+    (apply smap scale-event children)))
 
 (defn tag
   "Adds a new tag, or set of tags, to events which flow through.


### PR DESCRIPTION
- scale wraps a common smap idiom
- defstream is a shortcut for (def foo (sdo ..))
