### PR TITLE
bumps to clojure 1.5.1 for memory leak patch

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :maintainer {:email "aphyr@aphyr.com"}
   :dependencies [
     [org.clojure/algo.generic "0.1.0"]
-    [org.clojure/clojure "1.5.0"]
+    [org.clojure/clojure "1.5.1"]
     [org.clojure/math.numeric-tower "0.0.1"]
     [org.clojure/tools.logging "0.2.3"]
     [org.clojure/tools.nrepl "0.2.2"]


### PR DESCRIPTION
clojure 1.5.0 had a memory leak bug. The fact that no one has reported
any issues with riemann suggests that riemann is not effected by the
bug, but I still feel better with the patched version of 1.5.1. :)
