### PR TITLE
Include custom attributes in emails & SNS notifications

### DIFF
--- a/src/riemann/common.clj
+++ b/src/riemann/common.clj
@@ -212,6 +212,12 @@
          (human-uniq (map :service events) "services")
          (human-uniq (map :state events) "states")])))
 
+(defn attributes
+  "Returns a Map of the custom attributes of an Event."
+  [event]
+  (let [attribute-keys (filter (complement event-keys) (keys event))]
+    (select-keys event attribute-keys)))
+
 (defn body
   "Constructs a message body for a set of events."
   [events]
@@ -225,6 +231,8 @@
               (:state event) " ("
               (:metric event) ")\n"
               "Tags: [" (join ", " (:tags event)) "]"
+              "\n"
+              "Attributes: " (attributes event)
               "\n\n"
               (:description event)))
           events)))

--- a/test/riemann/test/sns.clj
+++ b/test/riemann/test/sns.clj
@@ -19,7 +19,7 @@
 (def fake-event-subject "localhost sns test ok")
 (def fake-event-body (str "At "
                           (time-at 0)
-                          "\nlocalhost sns test ok (2.71828)\nTags: []\n\nall clear, uh, situation normal"))
+                          "\nlocalhost sns test ok (2.71828)\nTags: []\nAttributes: {}\n\nall clear, uh, situation normal"))
 
 (deftest override-formatting-test
   (let [message (#'riemann.sns/compose-message


### PR DESCRIPTION
Uses riemann.codec/event-keys for a list of default
attributes on an Event.  Other keys on an Event are
custom attributes and are presented separately.
- Add riemann.common/attributes, returns a sub-map
  of an Event including only custom attributes.
- Include custom Event attributes in riemann.common/body
  - Used for email and SNS notifications

Email format example:

```
At Wed Jun 12 00:33:40 CEST 2013
doghouse dogs exception (1)
Tags: [exception]
Attributes: {:group "ActiveDog::DogNotFound", :alert-rate "2"}

63.5 milliseconds per request
```
