### PR TITLE
Don't register HUP signal handler on Windows

### DIFF
--- a/src/riemann/bin.clj
+++ b/src/riemann/bin.clj
@@ -33,7 +33,7 @@
 (defn handle-signals
   "Sets up POSIX signal handlers."
   []
-  (if (not (. contains (. System getProperty "os.name") "Windows"))
+  (if (not (.contains (. System getProperty "os.name") "Windows"))
     (sun.misc.Signal/handle
       (sun.misc.Signal. "HUP")
       (proxy [sun.misc.SignalHandler] []


### PR DESCRIPTION
Don't register HUP signal handler on Windows.

Fixes bug #244

```
$ bin/riemann etc/riemann.config
INFO [2013-06-20 09:08:13,593] main - riemann.bin - PID 277056

ERROR [2013-06-20 09:08:13,594] main - riemann.bin - Couldn't start
java.lang.IllegalArgumentException: Unknown signal: HUP
        at sun.misc.Signal.<init>(Unknown Source)
        at riemann.bin$handle_signals.invoke(bin.clj:36)
        at riemann.bin$_main.doInvoke(bin.clj:58)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at riemann.bin.main(Unknown Source)
```
