### PR TITLE
Rename riemann.common/attributes -> custom-attributes

### DIFF
--- a/src/riemann/common.clj
+++ b/src/riemann/common.clj
@@ -213,7 +213,7 @@
          (human-uniq (map :service events) "services")
          (human-uniq (map :state events) "states")])))
 
-(defn attributes
+(defn custom-attributes
   "Returns a Map of the custom attributes of an Event."
   [event]
   (let [attribute-keys (filter (complement event-keys) (keys event))]
@@ -233,7 +233,7 @@
               (:metric event) ")\n"
               "Tags: [" (join ", " (:tags event)) "]"
               "\n"
-              "Attributes: " (attributes event)
+              "Custom Attributes: " (custom-attributes event)
               "\n\n"
               (:description event)))
           events)))

--- a/test/riemann/test/sns.clj
+++ b/test/riemann/test/sns.clj
@@ -19,7 +19,7 @@
 (def fake-event-subject "localhost sns test ok")
 (def fake-event-body (str "At "
                           (time-at 0)
-                          "\nlocalhost sns test ok (2.71828)\nTags: []\nAttributes: {}\n\nall clear, uh, situation normal"))
+                          "\nlocalhost sns test ok (2.71828)\nTags: []\nCustom Attributes: {}\n\nall clear, uh, situation normal"))
 
 (deftest override-formatting-test
   (let [message (#'riemann.sns/compose-message


### PR DESCRIPTION
per https://github.com/aphyr/riemann/pull/238

also changes email/sns notification bodies to say
'Custom Attributes' instead of 'Attributes'
before listing custom attributes from an event.
