### PR TITLE
Add java as a dependency in the .deb package

### DIFF
--- a/tasks/leiningen/fatdeb.clj
+++ b/tasks/leiningen/fatdeb.clj
@@ -50,7 +50,7 @@
               :section "base"
               :priority "optional"
               :architecture "all"
-              :depends (join ", " ["bash", "default-jre"])
+              :depends (join ", " ["bash", "java-runtime-headless"])
               :maintainer (:email (:maintainer project))
               :description (:description project)})))
 


### PR DESCRIPTION
We noticed riemann didn't mention it's dependency on java when we installed it on a completely fresh box, so this adds the default-jre package to the dependency list (I'm assuming riemann doesn't require default-jdk?).

I guess this isn't an issue for most people who probably have java installed already.
