### PR TITLE
Remove error in "count number of hosts" example query

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -768,14 +768,13 @@ an anonymous function to <code>(streams)</code> that will store a set of hosts.<
 tag. In riemann.config, try this stream:</p>
 
 {% highlight clj %}
-(let [hosts (atom {}) host (atom #{})]
+(let [hosts (atom {})]
   (fn [event]
     (let [tag-str (keyword (clojure.string/join "-" (:tags event)))]
     (swap! hosts assoc tag-str (conj (tag-str @hosts #{}) (:host event)))
     (index {:service (str (name tag-str) "-count")
             :time (unix-time)
-            :metric (count (tag-str @hosts))})
-    (swap! hosts (atom {})))))
+            :metric (count (tag-str @hosts))}))))
 {% endhighlight %}
 
 <p>The above code will create a unique service using all your tags with "-count"


### PR DESCRIPTION
Together with @neotyk we found the following error in this example code:

This isn't valid clojure code:

``` clojure
   (swap! hosts (atom {}))
```

The biggest problem is that this error doesn't seem to be reported somewhere and the system will just continue. In this case nothing comes after it so it might have just worked. In our case, several other queries weren't working. We'll create a separate issue for that once we know better what was going on.
