### PR TITLE
Fix start-stop-daemon not working on older Debian versions

### DIFF
--- a/pkg/deb/init.sh
+++ b/pkg/deb/init.sh
@@ -44,7 +44,11 @@ do_start()
   #   0 if daemon has been started
   #   1 if daemon was already running
   #   2 if daemon could not be started
-  start-stop-daemon --status --pidfile $PIDFILE && (log_daemon_msg "Riemann is already running (PID `cat ${PIDFILE}`)"; return 1)
+  pid=$( pidofproc -p $PID_FILE "$NAME")
+  if [ -n "$pid" ] ; then
+    log_daemon_msg "Riemann is already running (PID `cat ${PIDFILE}`)"
+    return 1
+  fi
   start-stop-daemon --start --quiet --chuid $DAEMON_USER --chdir / --make-pidfile --background --pidfile $PIDFILE --exec $DAEMON -- \
     $DAEMON_ARGS \
     || return 2
@@ -112,7 +116,6 @@ case "$1" in
     log_daemon_msg "Reloading $DESC" "$NAME"
     do_reload
     log_end_msg $?
-    
     ;;
   restart)
     log_daemon_msg "Restarting $DESC" "$NAME"


### PR DESCRIPTION
Issue is the same as https://github.com/elasticsearch/elasticsearch/issues/3452.
Older versions of `start-stop-daemon` do not support the `--status` flag. This fixes the issue by relying on the provided init scripts from `lsb-base`.
