### PR TITLE
add missing param stats to graphite-handler

### DIFF
--- a/src/riemann/transport/graphite.clj
+++ b/src/riemann/transport/graphite.clj
@@ -50,7 +50,7 @@
 
 (defn graphite-handler
   "Given a core and a MessageEvent, applies the message to core."
-  [core ^MessageEvent e]
+  [core stats ^MessageEvent e]
   (stream! core (.getMessage e)))
 
 (defn graphite-server


### PR DESCRIPTION
The graphite-server seems to be broken atm. But i don't know if my change really fixes it.
