### PR TITLE
Load defaults from /etc/default

### DIFF
--- a/pkg/deb/riemann
+++ b/pkg/deb/riemann
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ -f /etc/defaults/riemann ]; then
-    . /etc/defaults/riemann
+if [ -f /etc/default/riemann ]; then
+    . /etc/default/riemann
 fi
 
 JAR="$EXTRA_CLASSPATH:/usr/lib/riemann/riemann.jar"


### PR DESCRIPTION
On debian-based systems the location for default files is `/etc/default` (singular), not `/etc/defaults` (plural).
