### PR TITLE
Add logstash client based on existing graphite client

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -15,6 +15,7 @@
             [riemann.folds :as folds]
             [riemann.pubsub :as pubsub]
             [riemann.graphite :as graphite-client]
+            [riemann.logstash :as logstash-client]
             [clojure.tools.nrepl.server :as repl])
   (:use clojure.tools.logging
         [clojure.java.io :only [file]]
@@ -33,6 +34,8 @@
   (atom (core/core)))
 
 (def graphite #'graphite-client/graphite)
+(def logstash #'logstash-client/logstash)
+
 
 (defn repl-server
   "Starts a new REPL server with opts."

--- a/src/riemann/logstash.clj
+++ b/src/riemann/logstash.clj
@@ -1,0 +1,117 @@
+(ns riemann.logstash
+  "Forwards events to LogStash."
+  (:refer-clojure :exclude [replace])
+  (:import
+   (java.net Socket
+             DatagramSocket
+             DatagramPacket
+             InetAddress)
+   (java.io Writer
+            OutputStreamWriter)
+   (org.jboss.netty.channel Channels)
+   (org.jboss.netty.handler.codec.frame DelimiterBasedFrameDecoder
+                                        Delimiters)
+   (org.jboss.netty.handler.codec.oneone OneToOneDecoder)
+   (org.jboss.netty.handler.codec.string StringDecoder StringEncoder)
+   (org.jboss.netty.util CharsetUtil))
+  (:use [clojure.string :only [split join replace]]
+        clojure.tools.logging
+        riemann.pool
+        riemann.common))
+
+(defprotocol LogStashClient
+  (open [client]
+        "Creates a LogStash client")
+  (send-line [client line]
+        "Sends a formatted line to LogStash")
+  (close [client]
+         "Cleans up (closes sockets etc.)"))
+
+(defrecord LogStashTCPClient [^String host ^int port]
+  LogStashClient
+  (open [this]
+    (let [sock (Socket. host port)]
+      (assoc this 
+             :socket sock
+             :out (OutputStreamWriter. (.getOutputStream sock)))))
+  (send-line [this line]
+    (let [out (:out this)]
+      (.write ^OutputStreamWriter out ^String line)
+      (.flush ^OutputStreamWriter out)))
+  (close [this]
+    (.close ^OutputStreamWriter (:out this))
+    (.close ^Socket (:socket this))))
+
+(defrecord LogStashUDPClient [^String host ^int port]
+  LogStashClient
+  (open [this]
+    (assoc this 
+           :socket (DatagramSocket.)
+           :host host
+           :port port))
+  (send-line [this line]
+    (let [bytes (.getBytes ^String line)
+          length (count line)
+          addr (InetAddress/getByName (:host this))
+          datagram (DatagramPacket. bytes length ^InetAddress addr port)]
+      (.send ^DatagramSocket (:socket this) datagram)))
+  (close [this]
+    (.close ^DatagramSocket (:socket this))))
+
+
+
+(defn logstash
+  "Returns a function which accepts an event and sends it to Graphite.
+  Silently drops events when graphite is down. Attempts to reconnect
+  automatically every five seconds. Use:
+
+  (logstash {:host \"logstash.local\" :port 2003})
+
+  Options:
+
+  :path       A function which, given an event, returns the string describing
+              the path of that event in graphite. graphite-path-percentiles by
+              default.
+
+  :pool-size  The number of connections to keep open. Default 4.
+
+  :reconnect-interval   How many seconds to wait between attempts to connect.
+                        Default 5.
+
+  :claim-timeout        How many seconds to wait for a graphite connection from
+                        the pool. Default 0.1.
+
+  :block-start          Wait for the pool's initial connections to open
+                        before returning.
+
+  :protocol             Protocol to use. Either :tcp (default) or :udp."
+  [opts]
+  (let [opts (merge {:host "127.0.0.1"
+                     :port 9999
+                     :protocol :tcp
+                     :claim-timeout 0.1
+                     :pool-size 4} opts)
+        pool (fixed-pool
+               (fn []
+                 (info "Connecting to " (select-keys opts [:host :port]))
+                 (let [host (:host opts)
+                       port (:port opts)
+                       client (open (condp = (:protocol opts)
+                                      :tcp (LogStashTCPClient. host port)
+                                      :udp (LogStashUDPClient. host port)))]
+                   (info "Connected")
+                   client))
+               (fn [client]
+                 (info "Closing connection to "
+                       (select-keys opts [:host :port]))
+                 (close client))
+               {:size                 (:pool-size opts)
+                :block-start          (:block-start opts)
+                :regenerate-interval  (:reconnect-interval opts)})
+        path (:path opts)]
+
+    (fn [event]
+      (when (:metric event)
+        (with-pool [client pool (:claim-timeout opts)]
+                   (let [string (event-to-json event)]
+                     (send-line client string)))))))


### PR DESCRIPTION
Adds a logstash compatible client to riemann

example riemann config:

```
; -*- mode: clojure; -*-
; vim: filetype=clojure

(logging/init :file "riemann.log")

; Listen on the local interface over TCP (5555), UDP (5555), and websockets
; (5556)
(let [host "127.0.0.1"]
  (tcp-server :host host)
  (udp-server :host host)
  (ws-server  :host host))

(def stash (logstash {:host "localhost" :port 9999 :protocol :udp}))

; Expire old events from the index every 5 seconds.
(periodically-expire 5)

; Keep events in the index for 5 minutes by default.
(let [index (default :ttl 300 (update-index (index)))]

  ; Inbound events will be passed to these streams:
  (streams

    ; Index all events immediately.
    index

    ; Stash all the things
    stash

    ; Calculate an overall rate of events.
    (with {:metric 1 :host nil :state "ok" :service "events/sec"}
      (rate 5 index))

    ; Log expired events.
    ;(expired
      (fn [event] (info "debug" event))
))
```

Example logstash config:

```
input {
   file{
        path => "/dev/null"
   }

   tcp {
        port => 9999
        codec => "json"
   }

   udp {
        port => 9999
        codec => "json"
   }
}

output { 
  stdout {
    # Enabling 'debug' on the stdout output will make logstash pretty-print the
    # entire event as something similar to a JSON representation.
    debug => true
  }

  # You can have multiple outputs. All events generally to all outputs.
  # Output events to elasticsearch
  elasticsearch {
    embedded => true
  }
}
```
