### PR TITLE
Add a name attribute to riemann.bin

### DIFF
--- a/src/riemann/bin.clj
+++ b/src/riemann/bin.clj
@@ -5,7 +5,7 @@
             riemann.time
             riemann.pubsub)
   (:use clojure.tools.logging)
-  (:gen-class))
+  (:gen-class :name com.aphyr.riemann.Main))
 
 (def config-file
   "The configuration file loaded by the bin tool" 


### PR DESCRIPTION
Adding the name attribute to bin.clj so that Java apps can invoke main directly.
