### PR TITLE
clients.html: Add a link to another C client library

### DIFF
--- a/clients.html
+++ b/clients.html
@@ -48,6 +48,11 @@ title: Riemann - Clients
       <h2 id="c">C</h2> <p>Daniel Hilst wrote a <a
         href="https://github.com/gkos/riemann-c-client">client in C</a>,
       supporting both events and queries.</p>
+
+        <p>Gergely Nagy wrote another <a
+          href="https://github.com/algernon/riemann-c-client">client in C</a>,
+        supporting both events and queries, but with a different API and
+        goals.</p>
       
       <h2 id="c-sharp">C#</h2>
       <p>Blue Mountain Capital has written a <a


### PR DESCRIPTION
The library is used by syslog-ng, which is already linked to.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
