### PR TITLE
Query: Add support for regexp queries with ~=

### DIFF
--- a/src/riemann/Query.g
+++ b/src/riemann/Query.g
@@ -10,6 +10,7 @@ tokens {
 	OR = 'or';
 	NOT = 'not';
 	APPROXIMATELY = '=~';
+	REGEX_MATCH = '~=';
 	NOT_EQUAL = '!=';
 	EQUAL = '=';
 	LESSER = '<';
@@ -40,6 +41,7 @@ fragment
 simple	:	( t | f | nil
 		| tagged
 		| approximately
+		| regex_match
 		| lesser
 		| lesser_equal
 		| greater
@@ -50,6 +52,8 @@ simple	:	( t | f | nil
 
 approximately
 	:	field WS* APPROXIMATELY^ WS* value;
+regex_match
+	:	field WS* REGEX_MATCH^ WS* value;
 lesser	:	field WS* LESSER^ WS* value;
 lesser_equal
 	:	field WS* LESSER_EQUAL^ WS* value;

--- a/src/riemann/QueryLexer.java
+++ b/src/riemann/QueryLexer.java
@@ -1,4 +1,4 @@
-// $ANTLR 3.2 Sep 23, 2009 14:05:07 src/riemann/Query.g 2012-02-24 01:08:55
+// $ANTLR 3.2 Sep 23, 2009 14:05:07 src/riemann/Query.g 2013-12-02 00:16:46
 package riemann;
 
 import org.antlr.runtime.*;
@@ -7,46 +7,47 @@ import java.util.List;
 import java.util.ArrayList;
 
 public class QueryLexer extends Lexer {
-    public static final int LESSER_EQUAL=11;
-    public static final int EXPONENT=20;
+    public static final int LESSER_EQUAL=12;
+    public static final int EXPONENT=21;
     public static final int T__29=29;
     public static final int T__28=28;
     public static final int T__27=27;
     public static final int T__26=26;
     public static final int T__25=25;
-    public static final int T__24=24;
     public static final int APPROXIMATELY=7;
-    public static final int FLOAT=18;
-    public static final int INT=17;
+    public static final int FLOAT=19;
+    public static final int INT=18;
     public static final int NOT=6;
-    public static final int ID=19;
+    public static final int ID=20;
     public static final int AND=4;
     public static final int EOF=-1;
-    public static final int HexDigit=23;
+    public static final int HexDigit=24;
     public static final int T__30=30;
     public static final int T__31=31;
     public static final int T__32=32;
     public static final int T__33=33;
-    public static final int LESSER=10;
-    public static final int GREATER=12;
-    public static final int WS=15;
+    public static final int LESSER=11;
+    public static final int GREATER=13;
+    public static final int WS=16;
     public static final int T__34=34;
     public static final int T__35=35;
     public static final int T__36=36;
     public static final int T__37=37;
-    public static final int NOT_EQUAL=8;
-    public static final int TAGGED=14;
-    public static final int UnicodeEscape=22;
-    public static final int EQUAL=9;
+    public static final int T__38=38;
+    public static final int NOT_EQUAL=9;
+    public static final int TAGGED=15;
+    public static final int UnicodeEscape=23;
+    public static final int EQUAL=10;
     public static final int OR=5;
-    public static final int String=16;
-    public static final int GREATER_EQUAL=13;
-    public static final int EscapeSequence=21;
+    public static final int String=17;
+    public static final int GREATER_EQUAL=14;
+    public static final int EscapeSequence=22;
+    public static final int REGEX_MATCH=8;
 
     // delegates
     // delegators
 
-    public QueryLexer() {;}
+    public QueryLexer() {;} 
     public QueryLexer(CharStream input) {
         this(input, new RecognizerSharedState());
     }
@@ -64,7 +65,7 @@ public class QueryLexer extends Lexer {
             // src/riemann/Query.g:5:5: ( 'and' )
             // src/riemann/Query.g:5:7: 'and'
             {
-            match("and");
+            match("and"); 
 
 
             }
@@ -85,7 +86,7 @@ public class QueryLexer extends Lexer {
             // src/riemann/Query.g:6:4: ( 'or' )
             // src/riemann/Query.g:6:6: 'or'
             {
-            match("or");
+            match("or"); 
 
 
             }
@@ -106,7 +107,7 @@ public class QueryLexer extends Lexer {
             // src/riemann/Query.g:7:5: ( 'not' )
             // src/riemann/Query.g:7:7: 'not'
             {
-            match("not");
+            match("not"); 
 
 
             }
@@ -127,7 +128,7 @@ public class QueryLexer extends Lexer {
             // src/riemann/Query.g:8:15: ( '=~' )
             // src/riemann/Query.g:8:17: '=~'
             {
-            match("=~");
+            match("=~"); 
 
 
             }
@@ -140,15 +141,36 @@ public class QueryLexer extends Lexer {
     }
     // $ANTLR end "APPROXIMATELY"
 
+    // $ANTLR start "REGEX_MATCH"
+    public final void mREGEX_MATCH() throws RecognitionException {
+        try {
+            int _type = REGEX_MATCH;
+            int _channel = DEFAULT_TOKEN_CHANNEL;
+            // src/riemann/Query.g:9:13: ( '~=' )
+            // src/riemann/Query.g:9:15: '~='
+            {
+            match("~="); 
+
+
+            }
+
+            state.type = _type;
+            state.channel = _channel;
+        }
+        finally {
+        }
+    }
+    // $ANTLR end "REGEX_MATCH"
+
     // $ANTLR start "NOT_EQUAL"
     public final void mNOT_EQUAL() throws RecognitionException {
         try {
             int _type = NOT_EQUAL;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:9:11: ( '!=' )
-            // src/riemann/Query.g:9:13: '!='
+            // src/riemann/Query.g:10:11: ( '!=' )
+            // src/riemann/Query.g:10:13: '!='
             {
-            match("!=");
+            match("!="); 
 
 
             }
@@ -166,10 +188,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = EQUAL;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:10:7: ( '=' )
-            // src/riemann/Query.g:10:9: '='
+            // src/riemann/Query.g:11:7: ( '=' )
+            // src/riemann/Query.g:11:9: '='
             {
-            match('=');
+            match('='); 
 
             }
 
@@ -186,10 +208,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = LESSER;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:11:8: ( '<' )
-            // src/riemann/Query.g:11:10: '<'
+            // src/riemann/Query.g:12:8: ( '<' )
+            // src/riemann/Query.g:12:10: '<'
             {
-            match('<');
+            match('<'); 
 
             }
 
@@ -206,10 +228,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = LESSER_EQUAL;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:12:14: ( '<=' )
-            // src/riemann/Query.g:12:16: '<='
+            // src/riemann/Query.g:13:14: ( '<=' )
+            // src/riemann/Query.g:13:16: '<='
             {
-            match("<=");
+            match("<="); 
 
 
             }
@@ -227,10 +249,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = GREATER;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:13:9: ( '>' )
-            // src/riemann/Query.g:13:11: '>'
+            // src/riemann/Query.g:14:9: ( '>' )
+            // src/riemann/Query.g:14:11: '>'
             {
-            match('>');
+            match('>'); 
 
             }
 
@@ -247,10 +269,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = GREATER_EQUAL;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:14:15: ( '>=' )
-            // src/riemann/Query.g:14:17: '>='
+            // src/riemann/Query.g:15:15: ( '>=' )
+            // src/riemann/Query.g:15:17: '>='
             {
-            match(">=");
+            match(">="); 
 
 
             }
@@ -268,10 +290,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = TAGGED;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:15:8: ( 'tagged' )
-            // src/riemann/Query.g:15:10: 'tagged'
+            // src/riemann/Query.g:16:8: ( 'tagged' )
+            // src/riemann/Query.g:16:10: 'tagged'
             {
-            match("tagged");
+            match("tagged"); 
 
 
             }
@@ -284,35 +306,15 @@ public class QueryLexer extends Lexer {
     }
     // $ANTLR end "TAGGED"
 
-    // $ANTLR start "T__24"
-    public final void mT__24() throws RecognitionException {
-        try {
-            int _type = T__24;
-            int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:16:7: ( '(' )
-            // src/riemann/Query.g:16:9: '('
-            {
-            match('(');
-
-            }
-
-            state.type = _type;
-            state.channel = _channel;
-        }
-        finally {
-        }
-    }
-    // $ANTLR end "T__24"
-
     // $ANTLR start "T__25"
     public final void mT__25() throws RecognitionException {
         try {
             int _type = T__25;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:17:7: ( ')' )
-            // src/riemann/Query.g:17:9: ')'
+            // src/riemann/Query.g:17:7: ( '(' )
+            // src/riemann/Query.g:17:9: '('
             {
-            match(')');
+            match('('); 
 
             }
 
@@ -329,11 +331,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = T__26;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:18:7: ( 'true' )
-            // src/riemann/Query.g:18:9: 'true'
+            // src/riemann/Query.g:18:7: ( ')' )
+            // src/riemann/Query.g:18:9: ')'
             {
-            match("true");
-
+            match(')'); 
 
             }
 
@@ -350,10 +351,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = T__27;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:19:7: ( 'false' )
-            // src/riemann/Query.g:19:9: 'false'
+            // src/riemann/Query.g:19:7: ( 'true' )
+            // src/riemann/Query.g:19:9: 'true'
             {
-            match("false");
+            match("true"); 
 
 
             }
@@ -371,10 +372,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = T__28;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:20:7: ( 'null' )
-            // src/riemann/Query.g:20:9: 'null'
+            // src/riemann/Query.g:20:7: ( 'false' )
+            // src/riemann/Query.g:20:9: 'false'
             {
-            match("null");
+            match("false"); 
 
 
             }
@@ -392,10 +393,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = T__29;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:21:7: ( 'nil' )
-            // src/riemann/Query.g:21:9: 'nil'
+            // src/riemann/Query.g:21:7: ( 'null' )
+            // src/riemann/Query.g:21:9: 'null'
             {
-            match("nil");
+            match("null"); 
 
 
             }
@@ -413,10 +414,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = T__30;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:22:7: ( 'host' )
-            // src/riemann/Query.g:22:9: 'host'
+            // src/riemann/Query.g:22:7: ( 'nil' )
+            // src/riemann/Query.g:22:9: 'nil'
             {
-            match("host");
+            match("nil"); 
 
 
             }
@@ -434,10 +435,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = T__31;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:23:7: ( 'service' )
-            // src/riemann/Query.g:23:9: 'service'
+            // src/riemann/Query.g:23:7: ( 'host' )
+            // src/riemann/Query.g:23:9: 'host'
             {
-            match("service");
+            match("host"); 
 
 
             }
@@ -455,10 +456,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = T__32;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:24:7: ( 'state' )
-            // src/riemann/Query.g:24:9: 'state'
+            // src/riemann/Query.g:24:7: ( 'service' )
+            // src/riemann/Query.g:24:9: 'service'
             {
-            match("state");
+            match("service"); 
 
 
             }
@@ -476,10 +477,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = T__33;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:25:7: ( 'description' )
-            // src/riemann/Query.g:25:9: 'description'
+            // src/riemann/Query.g:25:7: ( 'state' )
+            // src/riemann/Query.g:25:9: 'state'
             {
-            match("description");
+            match("state"); 
 
 
             }
@@ -497,10 +498,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = T__34;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:26:7: ( 'metric_f' )
-            // src/riemann/Query.g:26:9: 'metric_f'
+            // src/riemann/Query.g:26:7: ( 'description' )
+            // src/riemann/Query.g:26:9: 'description'
             {
-            match("metric_f");
+            match("description"); 
 
 
             }
@@ -518,10 +519,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = T__35;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:27:7: ( 'metric' )
-            // src/riemann/Query.g:27:9: 'metric'
+            // src/riemann/Query.g:27:7: ( 'metric_f' )
+            // src/riemann/Query.g:27:9: 'metric_f'
             {
-            match("metric");
+            match("metric_f"); 
 
 
             }
@@ -539,10 +540,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = T__36;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:28:7: ( 'ttl' )
-            // src/riemann/Query.g:28:9: 'ttl'
+            // src/riemann/Query.g:28:7: ( 'metric' )
+            // src/riemann/Query.g:28:9: 'metric'
             {
-            match("ttl");
+            match("metric"); 
 
 
             }
@@ -560,10 +561,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = T__37;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:29:7: ( 'time' )
-            // src/riemann/Query.g:29:9: 'time'
+            // src/riemann/Query.g:29:7: ( 'ttl' )
+            // src/riemann/Query.g:29:9: 'ttl'
             {
-            match("time");
+            match("ttl"); 
 
 
             }
@@ -576,13 +577,34 @@ public class QueryLexer extends Lexer {
     }
     // $ANTLR end "T__37"
 
+    // $ANTLR start "T__38"
+    public final void mT__38() throws RecognitionException {
+        try {
+            int _type = T__38;
+            int _channel = DEFAULT_TOKEN_CHANNEL;
+            // src/riemann/Query.g:30:7: ( 'time' )
+            // src/riemann/Query.g:30:9: 'time'
+            {
+            match("time"); 
+
+
+            }
+
+            state.type = _type;
+            state.channel = _channel;
+        }
+        finally {
+        }
+    }
+    // $ANTLR end "T__38"
+
     // $ANTLR start "ID"
     public final void mID() throws RecognitionException {
         try {
             int _type = ID;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:81:5: ( ( 'a' .. 'z' | 'A' .. 'Z' | '_' ) ( 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' )* )
-            // src/riemann/Query.g:81:7: ( 'a' .. 'z' | 'A' .. 'Z' | '_' ) ( 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' )*
+            // src/riemann/Query.g:85:5: ( ( 'a' .. 'z' | 'A' .. 'Z' | '_' ) ( 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' )* )
+            // src/riemann/Query.g:85:7: ( 'a' .. 'z' | 'A' .. 'Z' | '_' ) ( 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' )*
             {
             if ( (input.LA(1)>='A' && input.LA(1)<='Z')||input.LA(1)=='_'||(input.LA(1)>='a' && input.LA(1)<='z') ) {
                 input.consume();
@@ -593,7 +615,7 @@ public class QueryLexer extends Lexer {
                 recover(mse);
                 throw mse;}
 
-            // src/riemann/Query.g:81:31: ( 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' )*
+            // src/riemann/Query.g:85:31: ( 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' )*
             loop1:
             do {
                 int alt1=2;
@@ -642,10 +664,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = INT;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:84:5: ( ( '-' )? ( '0' .. '9' )+ )
-            // src/riemann/Query.g:84:7: ( '-' )? ( '0' .. '9' )+
+            // src/riemann/Query.g:88:5: ( ( '-' )? ( '0' .. '9' )+ )
+            // src/riemann/Query.g:88:7: ( '-' )? ( '0' .. '9' )+
             {
-            // src/riemann/Query.g:84:7: ( '-' )?
+            // src/riemann/Query.g:88:7: ( '-' )?
             int alt2=2;
             int LA2_0 = input.LA(1);
 
@@ -654,16 +676,16 @@ public class QueryLexer extends Lexer {
             }
             switch (alt2) {
                 case 1 :
-                    // src/riemann/Query.g:84:7: '-'
+                    // src/riemann/Query.g:88:7: '-'
                     {
-                    match('-');
+                    match('-'); 
 
                     }
                     break;
 
             }
 
-            // src/riemann/Query.g:84:12: ( '0' .. '9' )+
+            // src/riemann/Query.g:88:12: ( '0' .. '9' )+
             int cnt3=0;
             loop3:
             do {
@@ -677,9 +699,9 @@ public class QueryLexer extends Lexer {
 
                 switch (alt3) {
             	case 1 :
-            	    // src/riemann/Query.g:84:12: '0' .. '9'
+            	    // src/riemann/Query.g:88:12: '0' .. '9'
             	    {
-            	    matchRange('0','9');
+            	    matchRange('0','9'); 
 
             	    }
             	    break;
@@ -709,10 +731,10 @@ public class QueryLexer extends Lexer {
         try {
             int _type = FLOAT;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:88:5: ( ( '-' )? ( '0' .. '9' )+ ( '.' ( '0' .. '9' )* )? ( EXPONENT )? )
-            // src/riemann/Query.g:88:9: ( '-' )? ( '0' .. '9' )+ ( '.' ( '0' .. '9' )* )? ( EXPONENT )?
+            // src/riemann/Query.g:92:5: ( ( '-' )? ( '0' .. '9' )+ ( '.' ( '0' .. '9' )* )? ( EXPONENT )? )
+            // src/riemann/Query.g:92:9: ( '-' )? ( '0' .. '9' )+ ( '.' ( '0' .. '9' )* )? ( EXPONENT )?
             {
-            // src/riemann/Query.g:88:9: ( '-' )?
+            // src/riemann/Query.g:92:9: ( '-' )?
             int alt4=2;
             int LA4_0 = input.LA(1);
 
@@ -721,16 +743,16 @@ public class QueryLexer extends Lexer {
             }
             switch (alt4) {
                 case 1 :
-                    // src/riemann/Query.g:88:9: '-'
+                    // src/riemann/Query.g:92:9: '-'
                     {
-                    match('-');
+                    match('-'); 
 
                     }
                     break;
 
             }
 
-            // src/riemann/Query.g:88:14: ( '0' .. '9' )+
+            // src/riemann/Query.g:92:14: ( '0' .. '9' )+
             int cnt5=0;
             loop5:
             do {
@@ -744,9 +766,9 @@ public class QueryLexer extends Lexer {
 
                 switch (alt5) {
             	case 1 :
-            	    // src/riemann/Query.g:88:15: '0' .. '9'
+            	    // src/riemann/Query.g:92:15: '0' .. '9'
             	    {
-            	    matchRange('0','9');
+            	    matchRange('0','9'); 
 
             	    }
             	    break;
@@ -760,7 +782,7 @@ public class QueryLexer extends Lexer {
                 cnt5++;
             } while (true);
 
-            // src/riemann/Query.g:88:26: ( '.' ( '0' .. '9' )* )?
+            // src/riemann/Query.g:92:26: ( '.' ( '0' .. '9' )* )?
             int alt7=2;
             int LA7_0 = input.LA(1);
 
@@ -769,10 +791,10 @@ public class QueryLexer extends Lexer {
             }
             switch (alt7) {
                 case 1 :
-                    // src/riemann/Query.g:88:27: '.' ( '0' .. '9' )*
+                    // src/riemann/Query.g:92:27: '.' ( '0' .. '9' )*
                     {
-                    match('.');
-                    // src/riemann/Query.g:88:31: ( '0' .. '9' )*
+                    match('.'); 
+                    // src/riemann/Query.g:92:31: ( '0' .. '9' )*
                     loop6:
                     do {
                         int alt6=2;
@@ -785,9 +807,9 @@ public class QueryLexer extends Lexer {
 
                         switch (alt6) {
                     	case 1 :
-                    	    // src/riemann/Query.g:88:32: '0' .. '9'
+                    	    // src/riemann/Query.g:92:32: '0' .. '9'
                     	    {
-                    	    matchRange('0','9');
+                    	    matchRange('0','9'); 
 
                     	    }
                     	    break;
@@ -803,7 +825,7 @@ public class QueryLexer extends Lexer {
 
             }
 
-            // src/riemann/Query.g:88:45: ( EXPONENT )?
+            // src/riemann/Query.g:92:45: ( EXPONENT )?
             int alt8=2;
             int LA8_0 = input.LA(1);
 
@@ -812,9 +834,9 @@ public class QueryLexer extends Lexer {
             }
             switch (alt8) {
                 case 1 :
-                    // src/riemann/Query.g:88:45: EXPONENT
+                    // src/riemann/Query.g:92:45: EXPONENT
                     {
-                    mEXPONENT();
+                    mEXPONENT(); 
 
                     }
                     break;
@@ -837,8 +859,8 @@ public class QueryLexer extends Lexer {
         try {
             int _type = WS;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:91:5: ( ( ' ' | '\\t' | '\\r' | '\\n' ) )
-            // src/riemann/Query.g:91:9: ( ' ' | '\\t' | '\\r' | '\\n' )
+            // src/riemann/Query.g:95:5: ( ( ' ' | '\\t' | '\\r' | '\\n' ) )
+            // src/riemann/Query.g:95:9: ( ' ' | '\\t' | '\\r' | '\\n' )
             {
             if ( (input.LA(1)>='\t' && input.LA(1)<='\n')||input.LA(1)=='\r'||input.LA(1)==' ' ) {
                 input.consume();
@@ -864,8 +886,8 @@ public class QueryLexer extends Lexer {
     // $ANTLR start "EXPONENT"
     public final void mEXPONENT() throws RecognitionException {
         try {
-            // src/riemann/Query.g:99:10: ( ( 'e' | 'E' ) ( '+' | '-' )? ( '0' .. '9' )+ )
-            // src/riemann/Query.g:99:12: ( 'e' | 'E' ) ( '+' | '-' )? ( '0' .. '9' )+
+            // src/riemann/Query.g:103:10: ( ( 'e' | 'E' ) ( '+' | '-' )? ( '0' .. '9' )+ )
+            // src/riemann/Query.g:103:12: ( 'e' | 'E' ) ( '+' | '-' )? ( '0' .. '9' )+
             {
             if ( input.LA(1)=='E'||input.LA(1)=='e' ) {
                 input.consume();
@@ -876,7 +898,7 @@ public class QueryLexer extends Lexer {
                 recover(mse);
                 throw mse;}
 
-            // src/riemann/Query.g:99:22: ( '+' | '-' )?
+            // src/riemann/Query.g:103:22: ( '+' | '-' )?
             int alt9=2;
             int LA9_0 = input.LA(1);
 
@@ -902,7 +924,7 @@ public class QueryLexer extends Lexer {
 
             }
 
-            // src/riemann/Query.g:99:33: ( '0' .. '9' )+
+            // src/riemann/Query.g:103:33: ( '0' .. '9' )+
             int cnt10=0;
             loop10:
             do {
@@ -916,9 +938,9 @@ public class QueryLexer extends Lexer {
 
                 switch (alt10) {
             	case 1 :
-            	    // src/riemann/Query.g:99:34: '0' .. '9'
+            	    // src/riemann/Query.g:103:34: '0' .. '9'
             	    {
-            	    matchRange('0','9');
+            	    matchRange('0','9'); 
 
             	    }
             	    break;
@@ -946,11 +968,11 @@ public class QueryLexer extends Lexer {
         try {
             int _type = String;
             int _channel = DEFAULT_TOKEN_CHANNEL;
-            // src/riemann/Query.g:101:9: ( '\"' ( EscapeSequence | ~ ( '\\u0000' .. '\\u001f' | '\\\\' | '\\\"' ) )* '\"' )
-            // src/riemann/Query.g:104:5: '\"' ( EscapeSequence | ~ ( '\\u0000' .. '\\u001f' | '\\\\' | '\\\"' ) )* '\"'
+            // src/riemann/Query.g:105:9: ( '\"' ( EscapeSequence | ~ ( '\\u0000' .. '\\u001f' | '\\\\' | '\\\"' ) )* '\"' )
+            // src/riemann/Query.g:108:5: '\"' ( EscapeSequence | ~ ( '\\u0000' .. '\\u001f' | '\\\\' | '\\\"' ) )* '\"'
             {
-            match('\"');
-            // src/riemann/Query.g:104:9: ( EscapeSequence | ~ ( '\\u0000' .. '\\u001f' | '\\\\' | '\\\"' ) )*
+            match('\"'); 
+            // src/riemann/Query.g:108:9: ( EscapeSequence | ~ ( '\\u0000' .. '\\u001f' | '\\\\' | '\\\"' ) )*
             loop11:
             do {
                 int alt11=3;
@@ -966,14 +988,14 @@ public class QueryLexer extends Lexer {
 
                 switch (alt11) {
             	case 1 :
-            	    // src/riemann/Query.g:104:11: EscapeSequence
+            	    // src/riemann/Query.g:108:11: EscapeSequence
             	    {
-            	    mEscapeSequence();
+            	    mEscapeSequence(); 
 
             	    }
             	    break;
             	case 2 :
-            	    // src/riemann/Query.g:104:28: ~ ( '\\u0000' .. '\\u001f' | '\\\\' | '\\\"' )
+            	    // src/riemann/Query.g:108:28: ~ ( '\\u0000' .. '\\u001f' | '\\\\' | '\\\"' )
             	    {
             	    if ( (input.LA(1)>=' ' && input.LA(1)<='!')||(input.LA(1)>='#' && input.LA(1)<='[')||(input.LA(1)>=']' && input.LA(1)<='\uFFFF') ) {
             	        input.consume();
@@ -993,7 +1015,7 @@ public class QueryLexer extends Lexer {
                 }
             } while (true);
 
-            match('\"');
+            match('\"'); 
 
             }
 
@@ -1008,11 +1030,11 @@ public class QueryLexer extends Lexer {
     // $ANTLR start "EscapeSequence"
     public final void mEscapeSequence() throws RecognitionException {
         try {
-            // src/riemann/Query.g:108:9: ( '\\\\' ( UnicodeEscape | 'b' | 't' | 'n' | 'f' | 'r' | '\\\"' | '\\\\' ) )
-            // src/riemann/Query.g:108:13: '\\\\' ( UnicodeEscape | 'b' | 't' | 'n' | 'f' | 'r' | '\\\"' | '\\\\' )
+            // src/riemann/Query.g:112:9: ( '\\\\' ( UnicodeEscape | 'b' | 't' | 'n' | 'f' | 'r' | '\\\"' | '\\\\' ) )
+            // src/riemann/Query.g:112:13: '\\\\' ( UnicodeEscape | 'b' | 't' | 'n' | 'f' | 'r' | '\\\"' | '\\\\' )
             {
-            match('\\');
-            // src/riemann/Query.g:108:18: ( UnicodeEscape | 'b' | 't' | 'n' | 'f' | 'r' | '\\\"' | '\\\\' )
+            match('\\'); 
+            // src/riemann/Query.g:112:18: ( UnicodeEscape | 'b' | 't' | 'n' | 'f' | 'r' | '\\\"' | '\\\\' )
             int alt12=8;
             switch ( input.LA(1) ) {
             case 'u':
@@ -1064,58 +1086,58 @@ public class QueryLexer extends Lexer {
 
             switch (alt12) {
                 case 1 :
-                    // src/riemann/Query.g:108:19: UnicodeEscape
+                    // src/riemann/Query.g:112:19: UnicodeEscape
                     {
-                    mUnicodeEscape();
+                    mUnicodeEscape(); 
 
                     }
                     break;
                 case 2 :
-                    // src/riemann/Query.g:108:34: 'b'
+                    // src/riemann/Query.g:112:34: 'b'
                     {
-                    match('b');
+                    match('b'); 
 
                     }
                     break;
                 case 3 :
-                    // src/riemann/Query.g:108:38: 't'
+                    // src/riemann/Query.g:112:38: 't'
                     {
-                    match('t');
+                    match('t'); 
 
                     }
                     break;
                 case 4 :
-                    // src/riemann/Query.g:108:42: 'n'
+                    // src/riemann/Query.g:112:42: 'n'
                     {
-                    match('n');
+                    match('n'); 
 
                     }
                     break;
                 case 5 :
-                    // src/riemann/Query.g:108:46: 'f'
+                    // src/riemann/Query.g:112:46: 'f'
                     {
-                    match('f');
+                    match('f'); 
 
                     }
                     break;
                 case 6 :
-                    // src/riemann/Query.g:108:50: 'r'
+                    // src/riemann/Query.g:112:50: 'r'
                     {
-                    match('r');
+                    match('r'); 
 
                     }
                     break;
                 case 7 :
-                    // src/riemann/Query.g:108:54: '\\\"'
+                    // src/riemann/Query.g:112:54: '\\\"'
                     {
-                    match('\"');
+                    match('\"'); 
 
                     }
                     break;
                 case 8 :
-                    // src/riemann/Query.g:108:59: '\\\\'
+                    // src/riemann/Query.g:112:59: '\\\\'
                     {
-                    match('\\');
+                    match('\\'); 
 
                     }
                     break;
@@ -1134,14 +1156,14 @@ public class QueryLexer extends Lexer {
     // $ANTLR start "UnicodeEscape"
     public final void mUnicodeEscape() throws RecognitionException {
         try {
-            // src/riemann/Query.g:112:5: ( 'u' HexDigit HexDigit HexDigit HexDigit )
-            // src/riemann/Query.g:112:7: 'u' HexDigit HexDigit HexDigit HexDigit
+            // src/riemann/Query.g:116:5: ( 'u' HexDigit HexDigit HexDigit HexDigit )
+            // src/riemann/Query.g:116:7: 'u' HexDigit HexDigit HexDigit HexDigit
             {
-            match('u');
-            mHexDigit();
-            mHexDigit();
-            mHexDigit();
-            mHexDigit();
+            match('u'); 
+            mHexDigit(); 
+            mHexDigit(); 
+            mHexDigit(); 
+            mHexDigit(); 
 
             }
 
@@ -1154,7 +1176,7 @@ public class QueryLexer extends Lexer {
     // $ANTLR start "HexDigit"
     public final void mHexDigit() throws RecognitionException {
         try {
-            // src/riemann/Query.g:116:5: ( '0' .. '9' | 'A' .. 'F' | 'a' .. 'f' )
+            // src/riemann/Query.g:120:5: ( '0' .. '9' | 'A' .. 'F' | 'a' .. 'f' )
             // src/riemann/Query.g:
             {
             if ( (input.LA(1)>='0' && input.LA(1)<='9')||(input.LA(1)>='A' && input.LA(1)<='F')||(input.LA(1)>='a' && input.LA(1)<='f') ) {
@@ -1176,217 +1198,224 @@ public class QueryLexer extends Lexer {
     // $ANTLR end "HexDigit"
 
     public void mTokens() throws RecognitionException {
-        // src/riemann/Query.g:1:8: ( AND | OR | NOT | APPROXIMATELY | NOT_EQUAL | EQUAL | LESSER | LESSER_EQUAL | GREATER | GREATER_EQUAL | TAGGED | T__24 | T__25 | T__26 | T__27 | T__28 | T__29 | T__30 | T__31 | T__32 | T__33 | T__34 | T__35 | T__36 | T__37 | ID | INT | FLOAT | WS | String )
-        int alt13=30;
+        // src/riemann/Query.g:1:8: ( AND | OR | NOT | APPROXIMATELY | REGEX_MATCH | NOT_EQUAL | EQUAL | LESSER | LESSER_EQUAL | GREATER | GREATER_EQUAL | TAGGED | T__25 | T__26 | T__27 | T__28 | T__29 | T__30 | T__31 | T__32 | T__33 | T__34 | T__35 | T__36 | T__37 | T__38 | ID | INT | FLOAT | WS | String )
+        int alt13=31;
         alt13 = dfa13.predict(input);
         switch (alt13) {
             case 1 :
                 // src/riemann/Query.g:1:10: AND
                 {
-                mAND();
+                mAND(); 
 
                 }
                 break;
             case 2 :
                 // src/riemann/Query.g:1:14: OR
                 {
-                mOR();
+                mOR(); 
 
                 }
                 break;
             case 3 :
                 // src/riemann/Query.g:1:17: NOT
                 {
-                mNOT();
+                mNOT(); 
 
                 }
                 break;
             case 4 :
                 // src/riemann/Query.g:1:21: APPROXIMATELY
                 {
-                mAPPROXIMATELY();
+                mAPPROXIMATELY(); 
 
                 }
                 break;
             case 5 :
-                // src/riemann/Query.g:1:35: NOT_EQUAL
+                // src/riemann/Query.g:1:35: REGEX_MATCH
                 {
-                mNOT_EQUAL();
+                mREGEX_MATCH(); 
 
                 }
                 break;
             case 6 :
-                // src/riemann/Query.g:1:45: EQUAL
+                // src/riemann/Query.g:1:47: NOT_EQUAL
                 {
-                mEQUAL();
+                mNOT_EQUAL(); 
 
                 }
                 break;
             case 7 :
-                // src/riemann/Query.g:1:51: LESSER
+                // src/riemann/Query.g:1:57: EQUAL
                 {
-                mLESSER();
+                mEQUAL(); 
 
                 }
                 break;
             case 8 :
-                // src/riemann/Query.g:1:58: LESSER_EQUAL
+                // src/riemann/Query.g:1:63: LESSER
                 {
-                mLESSER_EQUAL();
+                mLESSER(); 
 
                 }
                 break;
             case 9 :
-                // src/riemann/Query.g:1:71: GREATER
+                // src/riemann/Query.g:1:70: LESSER_EQUAL
                 {
-                mGREATER();
+                mLESSER_EQUAL(); 
 
                 }
                 break;
             case 10 :
-                // src/riemann/Query.g:1:79: GREATER_EQUAL
+                // src/riemann/Query.g:1:83: GREATER
                 {
-                mGREATER_EQUAL();
+                mGREATER(); 
 
                 }
                 break;
             case 11 :
-                // src/riemann/Query.g:1:93: TAGGED
+                // src/riemann/Query.g:1:91: GREATER_EQUAL
                 {
-                mTAGGED();
+                mGREATER_EQUAL(); 
 
                 }
                 break;
             case 12 :
-                // src/riemann/Query.g:1:100: T__24
+                // src/riemann/Query.g:1:105: TAGGED
                 {
-                mT__24();
+                mTAGGED(); 
 
                 }
                 break;
             case 13 :
-                // src/riemann/Query.g:1:106: T__25
+                // src/riemann/Query.g:1:112: T__25
                 {
-                mT__25();
+                mT__25(); 
 
                 }
                 break;
             case 14 :
-                // src/riemann/Query.g:1:112: T__26
+                // src/riemann/Query.g:1:118: T__26
                 {
-                mT__26();
+                mT__26(); 
 
                 }
                 break;
             case 15 :
-                // src/riemann/Query.g:1:118: T__27
+                // src/riemann/Query.g:1:124: T__27
                 {
-                mT__27();
+                mT__27(); 
 
                 }
                 break;
             case 16 :
-                // src/riemann/Query.g:1:124: T__28
+                // src/riemann/Query.g:1:130: T__28
                 {
-                mT__28();
+                mT__28(); 
 
                 }
                 break;
             case 17 :
-                // src/riemann/Query.g:1:130: T__29
+                // src/riemann/Query.g:1:136: T__29
                 {
-                mT__29();
+                mT__29(); 
 
                 }
                 break;
             case 18 :
-                // src/riemann/Query.g:1:136: T__30
+                // src/riemann/Query.g:1:142: T__30
                 {
-                mT__30();
+                mT__30(); 
 
                 }
                 break;
             case 19 :
-                // src/riemann/Query.g:1:142: T__31
+                // src/riemann/Query.g:1:148: T__31
                 {
-                mT__31();
+                mT__31(); 
 
                 }
                 break;
             case 20 :
-                // src/riemann/Query.g:1:148: T__32
+                // src/riemann/Query.g:1:154: T__32
                 {
-                mT__32();
+                mT__32(); 
 
                 }
                 break;
             case 21 :
-                // src/riemann/Query.g:1:154: T__33
+                // src/riemann/Query.g:1:160: T__33
                 {
-                mT__33();
+                mT__33(); 
 
                 }
                 break;
             case 22 :
-                // src/riemann/Query.g:1:160: T__34
+                // src/riemann/Query.g:1:166: T__34
                 {
-                mT__34();
+                mT__34(); 
 
                 }
                 break;
             case 23 :
-                // src/riemann/Query.g:1:166: T__35
+                // src/riemann/Query.g:1:172: T__35
                 {
-                mT__35();
+                mT__35(); 
 
                 }
                 break;
             case 24 :
-                // src/riemann/Query.g:1:172: T__36
+                // src/riemann/Query.g:1:178: T__36
                 {
-                mT__36();
+                mT__36(); 
 
                 }
                 break;
             case 25 :
-                // src/riemann/Query.g:1:178: T__37
+                // src/riemann/Query.g:1:184: T__37
                 {
-                mT__37();
+                mT__37(); 
 
                 }
                 break;
             case 26 :
-                // src/riemann/Query.g:1:184: ID
+                // src/riemann/Query.g:1:190: T__38
                 {
-                mID();
+                mT__38(); 
 
                 }
                 break;
             case 27 :
-                // src/riemann/Query.g:1:187: INT
+                // src/riemann/Query.g:1:196: ID
                 {
-                mINT();
+                mID(); 
 
                 }
                 break;
             case 28 :
-                // src/riemann/Query.g:1:191: FLOAT
+                // src/riemann/Query.g:1:199: INT
                 {
-                mFLOAT();
+                mINT(); 
 
                 }
                 break;
             case 29 :
-                // src/riemann/Query.g:1:197: WS
+                // src/riemann/Query.g:1:203: FLOAT
                 {
-                mWS();
+                mFLOAT(); 
 
                 }
                 break;
             case 30 :
-                // src/riemann/Query.g:1:200: String
+                // src/riemann/Query.g:1:209: WS
                 {
-                mString();
+                mWS(); 
+
+                }
+                break;
+            case 31 :
+                // src/riemann/Query.g:1:212: String
+                {
+                mString(); 
 
                 }
                 break;
@@ -1398,16 +1427,16 @@ public class QueryLexer extends Lexer {
 
     protected DFA13 dfa13 = new DFA13(this);
     static final String DFA13_eotS =
-        "\1\uffff\3\20\1\33\1\uffff\1\35\1\37\1\20\2\uffff\5\20\2\uffff\1"+
-        "\53\2\uffff\1\20\1\55\3\20\6\uffff\12\20\2\uffff\1\73\1\uffff\1"+
-        "\74\1\20\1\76\2\20\1\101\7\20\2\uffff\1\111\1\uffff\1\20\1\113\1"+
-        "\uffff\1\114\1\20\1\116\4\20\1\uffff\1\20\2\uffff\1\124\1\uffff"+
-        "\1\20\1\126\2\20\1\131\1\uffff\1\20\1\uffff\1\20\1\135\1\uffff\1"+
-        "\136\2\20\2\uffff\1\20\1\142\1\20\1\uffff\1\20\1\145\1\uffff";
+        "\1\uffff\3\21\1\34\2\uffff\1\36\1\40\1\21\2\uffff\5\21\2\uffff\1"+
+        "\54\2\uffff\1\21\1\56\3\21\6\uffff\12\21\2\uffff\1\74\1\uffff\1"+
+        "\75\1\21\1\77\2\21\1\102\7\21\2\uffff\1\112\1\uffff\1\21\1\114\1"+
+        "\uffff\1\115\1\21\1\117\4\21\1\uffff\1\21\2\uffff\1\125\1\uffff"+
+        "\1\21\1\127\2\21\1\132\1\uffff\1\21\1\uffff\1\21\1\136\1\uffff\1"+
+        "\137\2\21\2\uffff\1\21\1\143\1\21\1\uffff\1\21\1\146\1\uffff";
     static final String DFA13_eofS =
-        "\146\uffff";
+        "\147\uffff";
     static final String DFA13_minS =
-        "\1\11\1\156\1\162\1\151\1\176\1\uffff\2\75\1\141\2\uffff\1\141\1"+
+        "\1\11\1\156\1\162\1\151\1\176\2\uffff\2\75\1\141\2\uffff\1\141\1"+
         "\157\3\145\1\uffff\1\60\1\56\2\uffff\1\144\1\60\1\164\2\154\6\uffff"+
         "\1\147\1\165\1\154\1\155\1\154\1\163\1\162\1\141\1\163\1\164\2\uffff"+
         "\1\60\1\uffff\1\60\1\154\1\60\1\147\1\145\1\60\1\145\1\163\1\164"+
@@ -1417,7 +1446,7 @@ public class QueryLexer extends Lexer {
         "\160\1\60\1\uffff\1\60\1\164\1\146\2\uffff\1\151\1\60\1\157\1\uffff"+
         "\1\156\1\60\1\uffff";
     static final String DFA13_maxS =
-        "\1\172\1\156\1\162\1\165\1\176\1\uffff\2\75\1\164\2\uffff\1\141"+
+        "\1\176\1\156\1\162\1\165\1\176\2\uffff\2\75\1\164\2\uffff\1\141"+
         "\1\157\1\164\2\145\1\uffff\1\71\1\145\2\uffff\1\144\1\172\1\164"+
         "\2\154\6\uffff\1\147\1\165\1\154\1\155\1\154\1\163\1\162\1\141\1"+
         "\163\1\164\2\uffff\1\172\1\uffff\1\172\1\154\1\172\1\147\1\145\1"+
@@ -1427,50 +1456,50 @@ public class QueryLexer extends Lexer {
         "\1\uffff\1\145\1\uffff\1\160\1\172\1\uffff\1\172\1\164\1\146\2\uffff"+
         "\1\151\1\172\1\157\1\uffff\1\156\1\172\1\uffff";
     static final String DFA13_acceptS =
-        "\5\uffff\1\5\3\uffff\1\14\1\15\5\uffff\1\32\2\uffff\1\35\1\36\5"+
-        "\uffff\1\4\1\6\1\10\1\7\1\12\1\11\12\uffff\1\34\1\33\1\uffff\1\2"+
-        "\15\uffff\1\1\1\3\1\uffff\1\21\2\uffff\1\30\7\uffff\1\20\1\uffff"+
-        "\1\16\1\31\1\uffff\1\22\5\uffff\1\17\1\uffff\1\24\2\uffff\1\13\3"+
-        "\uffff\1\27\1\23\3\uffff\1\26\2\uffff\1\25";
+        "\5\uffff\1\5\1\6\3\uffff\1\15\1\16\5\uffff\1\33\2\uffff\1\36\1\37"+
+        "\5\uffff\1\4\1\7\1\11\1\10\1\13\1\12\12\uffff\1\35\1\34\1\uffff"+
+        "\1\2\15\uffff\1\1\1\3\1\uffff\1\22\2\uffff\1\31\7\uffff\1\21\1\uffff"+
+        "\1\17\1\32\1\uffff\1\23\5\uffff\1\20\1\uffff\1\25\2\uffff\1\14\3"+
+        "\uffff\1\30\1\24\3\uffff\1\27\2\uffff\1\26";
     static final String DFA13_specialS =
-        "\146\uffff}>";
+        "\147\uffff}>";
     static final String[] DFA13_transitionS = {
-            "\2\23\2\uffff\1\23\22\uffff\1\23\1\5\1\24\5\uffff\1\11\1\12"+
-            "\3\uffff\1\21\2\uffff\12\22\2\uffff\1\6\1\4\1\7\2\uffff\32\20"+
-            "\4\uffff\1\20\1\uffff\1\1\2\20\1\16\1\20\1\13\1\20\1\14\4\20"+
-            "\1\17\1\3\1\2\3\20\1\15\1\10\6\20",
-            "\1\25",
+            "\2\24\2\uffff\1\24\22\uffff\1\24\1\6\1\25\5\uffff\1\12\1\13"+
+            "\3\uffff\1\22\2\uffff\12\23\2\uffff\1\7\1\4\1\10\2\uffff\32"+
+            "\21\4\uffff\1\21\1\uffff\1\1\2\21\1\17\1\21\1\14\1\21\1\15\4"+
+            "\21\1\20\1\3\1\2\3\21\1\16\1\11\6\21\3\uffff\1\5",
             "\1\26",
-            "\1\31\5\uffff\1\27\5\uffff\1\30",
-            "\1\32",
-            "",
-            "\1\34",
-            "\1\36",
-            "\1\40\7\uffff\1\43\10\uffff\1\41\1\uffff\1\42",
+            "\1\27",
+            "\1\32\5\uffff\1\30\5\uffff\1\31",
+            "\1\33",
             "",
             "",
-            "\1\44",
+            "\1\35",
+            "\1\37",
+            "\1\41\7\uffff\1\44\10\uffff\1\42\1\uffff\1\43",
+            "",
+            "",
             "\1\45",
-            "\1\46\16\uffff\1\47",
-            "\1\50",
+            "\1\46",
+            "\1\47\16\uffff\1\50",
             "\1\51",
+            "\1\52",
             "",
-            "\12\22",
-            "\1\52\1\uffff\12\22\13\uffff\1\52\37\uffff\1\52",
+            "\12\23",
+            "\1\53\1\uffff\12\23\13\uffff\1\53\37\uffff\1\53",
             "",
             "",
-            "\1\54",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
-            "\1\56",
+            "\1\55",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
             "\1\57",
             "\1\60",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
             "\1\61",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
             "\1\62",
             "\1\63",
             "\1\64",
@@ -1480,65 +1509,66 @@ public class QueryLexer extends Lexer {
             "\1\70",
             "\1\71",
             "\1\72",
+            "\1\73",
             "",
             "",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
             "",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
-            "\1\75",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
-            "\1\77",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
+            "\1\76",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
             "\1\100",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
-            "\1\102",
+            "\1\101",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
             "\1\103",
             "\1\104",
             "\1\105",
             "\1\106",
             "\1\107",
             "\1\110",
+            "\1\111",
             "",
             "",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
             "",
-            "\1\112",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
+            "\1\113",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
             "",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
-            "\1\115",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
-            "\1\117",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
+            "\1\116",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
             "\1\120",
             "\1\121",
             "\1\122",
-            "",
             "\1\123",
             "",
+            "\1\124",
             "",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
             "",
-            "\1\125",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
-            "\1\127",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
+            "",
+            "\1\126",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
             "\1\130",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
-            "",
-            "\1\132",
+            "\1\131",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
             "",
             "\1\133",
-            "\12\20\7\uffff\32\20\4\uffff\1\134\1\uffff\32\20",
             "",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
-            "\1\137",
+            "\1\134",
+            "\12\21\7\uffff\32\21\4\uffff\1\135\1\uffff\32\21",
+            "",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
             "\1\140",
-            "",
-            "",
             "\1\141",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
-            "\1\143",
             "",
+            "",
+            "\1\142",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
             "\1\144",
-            "\12\20\7\uffff\32\20\4\uffff\1\20\1\uffff\32\20",
+            "",
+            "\1\145",
+            "\12\21\7\uffff\32\21\4\uffff\1\21\1\uffff\32\21",
             ""
     };
 
@@ -1572,9 +1602,9 @@ public class QueryLexer extends Lexer {
             this.transition = DFA13_transition;
         }
         public String getDescription() {
-            return "1:1: Tokens : ( AND | OR | NOT | APPROXIMATELY | NOT_EQUAL | EQUAL | LESSER | LESSER_EQUAL | GREATER | GREATER_EQUAL | TAGGED | T__24 | T__25 | T__26 | T__27 | T__28 | T__29 | T__30 | T__31 | T__32 | T__33 | T__34 | T__35 | T__36 | T__37 | ID | INT | FLOAT | WS | String );";
+            return "1:1: Tokens : ( AND | OR | NOT | APPROXIMATELY | REGEX_MATCH | NOT_EQUAL | EQUAL | LESSER | LESSER_EQUAL | GREATER | GREATER_EQUAL | TAGGED | T__25 | T__26 | T__27 | T__28 | T__29 | T__30 | T__31 | T__32 | T__33 | T__34 | T__35 | T__36 | T__37 | T__38 | ID | INT | FLOAT | WS | String );";
         }
     }
-
+ 
 
 }

--- a/src/riemann/QueryParser.java
+++ b/src/riemann/QueryParser.java
@@ -1,4 +1,4 @@
-// $ANTLR 3.2 Sep 23, 2009 14:05:07 src/riemann/Query.g 2012-02-24 01:08:54
+// $ANTLR 3.2 Sep 23, 2009 14:05:07 src/riemann/Query.g 2013-12-02 00:16:45
 package riemann;
 
 import org.antlr.runtime.*;
@@ -11,43 +11,44 @@ import org.antlr.runtime.tree.*;
 
 public class QueryParser extends Parser {
     public static final String[] tokenNames = new String[] {
-        "<invalid>", "<EOR>", "<DOWN>", "<UP>", "AND", "OR", "NOT", "APPROXIMATELY", "NOT_EQUAL", "EQUAL", "LESSER", "LESSER_EQUAL", "GREATER", "GREATER_EQUAL", "TAGGED", "WS", "String", "INT", "FLOAT", "ID", "EXPONENT", "EscapeSequence", "UnicodeEscape", "HexDigit", "'('", "')'", "'true'", "'false'", "'null'", "'nil'", "'host'", "'service'", "'state'", "'description'", "'metric_f'", "'metric'", "'ttl'", "'time'"
+        "<invalid>", "<EOR>", "<DOWN>", "<UP>", "AND", "OR", "NOT", "APPROXIMATELY", "REGEX_MATCH", "NOT_EQUAL", "EQUAL", "LESSER", "LESSER_EQUAL", "GREATER", "GREATER_EQUAL", "TAGGED", "WS", "String", "INT", "FLOAT", "ID", "EXPONENT", "EscapeSequence", "UnicodeEscape", "HexDigit", "'('", "')'", "'true'", "'false'", "'null'", "'nil'", "'host'", "'service'", "'state'", "'description'", "'metric_f'", "'metric'", "'ttl'", "'time'"
     };
-    public static final int LESSER_EQUAL=11;
-    public static final int EXPONENT=20;
+    public static final int LESSER_EQUAL=12;
+    public static final int EXPONENT=21;
     public static final int T__29=29;
     public static final int T__28=28;
     public static final int T__27=27;
     public static final int T__26=26;
     public static final int T__25=25;
-    public static final int T__24=24;
     public static final int APPROXIMATELY=7;
-    public static final int FLOAT=18;
-    public static final int INT=17;
+    public static final int FLOAT=19;
+    public static final int INT=18;
     public static final int NOT=6;
-    public static final int ID=19;
+    public static final int ID=20;
     public static final int AND=4;
     public static final int EOF=-1;
-    public static final int HexDigit=23;
+    public static final int HexDigit=24;
     public static final int T__30=30;
     public static final int T__31=31;
     public static final int T__32=32;
-    public static final int WS=15;
-    public static final int GREATER=12;
-    public static final int LESSER=10;
+    public static final int WS=16;
+    public static final int GREATER=13;
+    public static final int LESSER=11;
     public static final int T__33=33;
     public static final int T__34=34;
     public static final int T__35=35;
     public static final int T__36=36;
     public static final int T__37=37;
-    public static final int NOT_EQUAL=8;
-    public static final int TAGGED=14;
-    public static final int UnicodeEscape=22;
-    public static final int EQUAL=9;
+    public static final int NOT_EQUAL=9;
+    public static final int T__38=38;
+    public static final int TAGGED=15;
+    public static final int UnicodeEscape=23;
+    public static final int EQUAL=10;
     public static final int OR=5;
-    public static final int String=16;
-    public static final int EscapeSequence=21;
-    public static final int GREATER_EQUAL=13;
+    public static final int String=17;
+    public static final int EscapeSequence=22;
+    public static final int GREATER_EQUAL=14;
+    public static final int REGEX_MATCH=8;
 
     // delegates
     // delegators
@@ -58,9 +59,9 @@ public class QueryParser extends Parser {
         }
         public QueryParser(TokenStream input, RecognizerSharedState state) {
             super(input, state);
-
+             
         }
-
+        
     protected TreeAdaptor adaptor = new CommonTreeAdaptor();
 
     public void setTreeAdaptor(TreeAdaptor adaptor) {
@@ -80,7 +81,7 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "expr"
-    // src/riemann/Query.g:25:1: expr : ( or EOF ) -> or ;
+    // src/riemann/Query.g:26:1: expr : ( or EOF ) -> or ;
     public final QueryParser.expr_return expr() throws RecognitionException {
         QueryParser.expr_return retval = new QueryParser.expr_return();
         retval.start = input.LT(1);
@@ -95,19 +96,19 @@ public class QueryParser extends Parser {
         RewriteRuleTokenStream stream_EOF=new RewriteRuleTokenStream(adaptor,"token EOF");
         RewriteRuleSubtreeStream stream_or=new RewriteRuleSubtreeStream(adaptor,"rule or");
         try {
-            // src/riemann/Query.g:25:6: ( ( or EOF ) -> or )
-            // src/riemann/Query.g:25:8: ( or EOF )
+            // src/riemann/Query.g:26:6: ( ( or EOF ) -> or )
+            // src/riemann/Query.g:26:8: ( or EOF )
             {
-            // src/riemann/Query.g:25:8: ( or EOF )
-            // src/riemann/Query.g:25:9: or EOF
+            // src/riemann/Query.g:26:8: ( or EOF )
+            // src/riemann/Query.g:26:9: or EOF
             {
-            pushFollow(FOLLOW_or_in_expr137);
+            pushFollow(FOLLOW_or_in_expr145);
             or1=or();
 
             state._fsp--;
 
             stream_or.add(or1.getTree());
-            EOF2=(Token)match(input,EOF,FOLLOW_EOF_in_expr139);
+            EOF2=(Token)match(input,EOF,FOLLOW_EOF_in_expr147);  
             stream_EOF.add(EOF2);
 
 
@@ -117,16 +118,16 @@ public class QueryParser extends Parser {
 
             // AST REWRITE
             // elements: or
-            // token labels:
+            // token labels: 
             // rule labels: retval
-            // token list labels:
-            // rule list labels:
-            // wildcard labels:
+            // token list labels: 
+            // rule list labels: 
+            // wildcard labels: 
             retval.tree = root_0;
             RewriteRuleSubtreeStream stream_retval=new RewriteRuleSubtreeStream(adaptor,"rule retval",retval!=null?retval.tree:null);
 
             root_0 = (CommonTree)adaptor.nil();
-            // 25:17: -> or
+            // 26:17: -> or
             {
                 adaptor.addChild(root_0, stream_or.nextTree());
 
@@ -159,7 +160,7 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "or"
-    // src/riemann/Query.g:27:1: or : and ( ( WS )* OR ( WS )* and )* ;
+    // src/riemann/Query.g:28:1: or : and ( ( WS )* OR ( WS )* and )* ;
     public final QueryParser.or_return or() throws RecognitionException {
         QueryParser.or_return retval = new QueryParser.or_return();
         retval.start = input.LT(1);
@@ -179,18 +180,18 @@ public class QueryParser extends Parser {
         CommonTree WS6_tree=null;
 
         try {
-            // src/riemann/Query.g:27:4: ( and ( ( WS )* OR ( WS )* and )* )
-            // src/riemann/Query.g:27:6: and ( ( WS )* OR ( WS )* and )*
+            // src/riemann/Query.g:28:4: ( and ( ( WS )* OR ( WS )* and )* )
+            // src/riemann/Query.g:28:6: and ( ( WS )* OR ( WS )* and )*
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            pushFollow(FOLLOW_and_in_or152);
+            pushFollow(FOLLOW_and_in_or160);
             and3=and();
 
             state._fsp--;
 
             adaptor.addChild(root_0, and3.getTree());
-            // src/riemann/Query.g:27:10: ( ( WS )* OR ( WS )* and )*
+            // src/riemann/Query.g:28:10: ( ( WS )* OR ( WS )* and )*
             loop3:
             do {
                 int alt3=2;
@@ -203,9 +204,9 @@ public class QueryParser extends Parser {
 
                 switch (alt3) {
             	case 1 :
-            	    // src/riemann/Query.g:27:11: ( WS )* OR ( WS )* and
+            	    // src/riemann/Query.g:28:11: ( WS )* OR ( WS )* and
             	    {
-            	    // src/riemann/Query.g:27:11: ( WS )*
+            	    // src/riemann/Query.g:28:11: ( WS )*
             	    loop1:
             	    do {
             	        int alt1=2;
@@ -218,9 +219,9 @@ public class QueryParser extends Parser {
 
             	        switch (alt1) {
             	    	case 1 :
-            	    	    // src/riemann/Query.g:27:11: WS
+            	    	    // src/riemann/Query.g:28:11: WS
             	    	    {
-            	    	    WS4=(Token)match(input,WS,FOLLOW_WS_in_or155);
+            	    	    WS4=(Token)match(input,WS,FOLLOW_WS_in_or163); 
             	    	    WS4_tree = (CommonTree)adaptor.create(WS4);
             	    	    adaptor.addChild(root_0, WS4_tree);
 
@@ -233,11 +234,11 @@ public class QueryParser extends Parser {
             	        }
             	    } while (true);
 
-            	    OR5=(Token)match(input,OR,FOLLOW_OR_in_or158);
+            	    OR5=(Token)match(input,OR,FOLLOW_OR_in_or166); 
             	    OR5_tree = (CommonTree)adaptor.create(OR5);
             	    root_0 = (CommonTree)adaptor.becomeRoot(OR5_tree, root_0);
 
-            	    // src/riemann/Query.g:27:19: ( WS )*
+            	    // src/riemann/Query.g:28:19: ( WS )*
             	    loop2:
             	    do {
             	        int alt2=2;
@@ -250,9 +251,9 @@ public class QueryParser extends Parser {
 
             	        switch (alt2) {
             	    	case 1 :
-            	    	    // src/riemann/Query.g:27:19: WS
+            	    	    // src/riemann/Query.g:28:19: WS
             	    	    {
-            	    	    WS6=(Token)match(input,WS,FOLLOW_WS_in_or161);
+            	    	    WS6=(Token)match(input,WS,FOLLOW_WS_in_or169); 
             	    	    WS6_tree = (CommonTree)adaptor.create(WS6);
             	    	    adaptor.addChild(root_0, WS6_tree);
 
@@ -265,7 +266,7 @@ public class QueryParser extends Parser {
             	        }
             	    } while (true);
 
-            	    pushFollow(FOLLOW_and_in_or164);
+            	    pushFollow(FOLLOW_and_in_or172);
             	    and7=and();
 
             	    state._fsp--;
@@ -307,7 +308,7 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "and"
-    // src/riemann/Query.g:29:1: and : ( not | primary ) ( ( WS )* AND ( WS )* ( not | primary ) )* ;
+    // src/riemann/Query.g:30:1: and : ( not | primary ) ( ( WS )* AND ( WS )* ( not | primary ) )* ;
     public final QueryParser.and_return and() throws RecognitionException {
         QueryParser.and_return retval = new QueryParser.and_return();
         retval.start = input.LT(1);
@@ -331,19 +332,19 @@ public class QueryParser extends Parser {
         CommonTree WS12_tree=null;
 
         try {
-            // src/riemann/Query.g:29:5: ( ( not | primary ) ( ( WS )* AND ( WS )* ( not | primary ) )* )
-            // src/riemann/Query.g:29:7: ( not | primary ) ( ( WS )* AND ( WS )* ( not | primary ) )*
+            // src/riemann/Query.g:30:5: ( ( not | primary ) ( ( WS )* AND ( WS )* ( not | primary ) )* )
+            // src/riemann/Query.g:30:7: ( not | primary ) ( ( WS )* AND ( WS )* ( not | primary ) )*
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            // src/riemann/Query.g:29:7: ( not | primary )
+            // src/riemann/Query.g:30:7: ( not | primary )
             int alt4=2;
             int LA4_0 = input.LA(1);
 
             if ( (LA4_0==NOT) ) {
                 alt4=1;
             }
-            else if ( (LA4_0==TAGGED||LA4_0==24||(LA4_0>=26 && LA4_0<=37)) ) {
+            else if ( (LA4_0==TAGGED||LA4_0==25||(LA4_0>=27 && LA4_0<=38)) ) {
                 alt4=2;
             }
             else {
@@ -354,9 +355,9 @@ public class QueryParser extends Parser {
             }
             switch (alt4) {
                 case 1 :
-                    // src/riemann/Query.g:29:8: not
+                    // src/riemann/Query.g:30:8: not
                     {
-                    pushFollow(FOLLOW_not_in_and175);
+                    pushFollow(FOLLOW_not_in_and183);
                     not8=not();
 
                     state._fsp--;
@@ -366,9 +367,9 @@ public class QueryParser extends Parser {
                     }
                     break;
                 case 2 :
-                    // src/riemann/Query.g:29:14: primary
+                    // src/riemann/Query.g:30:14: primary
                     {
-                    pushFollow(FOLLOW_primary_in_and179);
+                    pushFollow(FOLLOW_primary_in_and187);
                     primary9=primary();
 
                     state._fsp--;
@@ -380,16 +381,16 @@ public class QueryParser extends Parser {
 
             }
 
-            // src/riemann/Query.g:29:23: ( ( WS )* AND ( WS )* ( not | primary ) )*
+            // src/riemann/Query.g:30:23: ( ( WS )* AND ( WS )* ( not | primary ) )*
             loop8:
             do {
                 int alt8=2;
                 alt8 = dfa8.predict(input);
                 switch (alt8) {
             	case 1 :
-            	    // src/riemann/Query.g:29:24: ( WS )* AND ( WS )* ( not | primary )
+            	    // src/riemann/Query.g:30:24: ( WS )* AND ( WS )* ( not | primary )
             	    {
-            	    // src/riemann/Query.g:29:24: ( WS )*
+            	    // src/riemann/Query.g:30:24: ( WS )*
             	    loop5:
             	    do {
             	        int alt5=2;
@@ -402,9 +403,9 @@ public class QueryParser extends Parser {
 
             	        switch (alt5) {
             	    	case 1 :
-            	    	    // src/riemann/Query.g:29:24: WS
+            	    	    // src/riemann/Query.g:30:24: WS
             	    	    {
-            	    	    WS10=(Token)match(input,WS,FOLLOW_WS_in_and183);
+            	    	    WS10=(Token)match(input,WS,FOLLOW_WS_in_and191); 
             	    	    WS10_tree = (CommonTree)adaptor.create(WS10);
             	    	    adaptor.addChild(root_0, WS10_tree);
 
@@ -417,11 +418,11 @@ public class QueryParser extends Parser {
             	        }
             	    } while (true);
 
-            	    AND11=(Token)match(input,AND,FOLLOW_AND_in_and186);
+            	    AND11=(Token)match(input,AND,FOLLOW_AND_in_and194); 
             	    AND11_tree = (CommonTree)adaptor.create(AND11);
             	    root_0 = (CommonTree)adaptor.becomeRoot(AND11_tree, root_0);
 
-            	    // src/riemann/Query.g:29:33: ( WS )*
+            	    // src/riemann/Query.g:30:33: ( WS )*
             	    loop6:
             	    do {
             	        int alt6=2;
@@ -434,9 +435,9 @@ public class QueryParser extends Parser {
 
             	        switch (alt6) {
             	    	case 1 :
-            	    	    // src/riemann/Query.g:29:33: WS
+            	    	    // src/riemann/Query.g:30:33: WS
             	    	    {
-            	    	    WS12=(Token)match(input,WS,FOLLOW_WS_in_and189);
+            	    	    WS12=(Token)match(input,WS,FOLLOW_WS_in_and197); 
             	    	    WS12_tree = (CommonTree)adaptor.create(WS12);
             	    	    adaptor.addChild(root_0, WS12_tree);
 
@@ -449,14 +450,14 @@ public class QueryParser extends Parser {
             	        }
             	    } while (true);
 
-            	    // src/riemann/Query.g:29:37: ( not | primary )
+            	    // src/riemann/Query.g:30:37: ( not | primary )
             	    int alt7=2;
             	    int LA7_0 = input.LA(1);
 
             	    if ( (LA7_0==NOT) ) {
             	        alt7=1;
             	    }
-            	    else if ( (LA7_0==TAGGED||LA7_0==24||(LA7_0>=26 && LA7_0<=37)) ) {
+            	    else if ( (LA7_0==TAGGED||LA7_0==25||(LA7_0>=27 && LA7_0<=38)) ) {
             	        alt7=2;
             	    }
             	    else {
@@ -467,9 +468,9 @@ public class QueryParser extends Parser {
             	    }
             	    switch (alt7) {
             	        case 1 :
-            	            // src/riemann/Query.g:29:38: not
+            	            // src/riemann/Query.g:30:38: not
             	            {
-            	            pushFollow(FOLLOW_not_in_and193);
+            	            pushFollow(FOLLOW_not_in_and201);
             	            not13=not();
 
             	            state._fsp--;
@@ -479,9 +480,9 @@ public class QueryParser extends Parser {
             	            }
             	            break;
             	        case 2 :
-            	            // src/riemann/Query.g:29:44: primary
+            	            // src/riemann/Query.g:30:44: primary
             	            {
-            	            pushFollow(FOLLOW_primary_in_and197);
+            	            pushFollow(FOLLOW_primary_in_and205);
             	            primary14=primary();
 
             	            state._fsp--;
@@ -529,7 +530,7 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "not"
-    // src/riemann/Query.g:31:1: not : NOT ( WS )* ( not | primary ) ;
+    // src/riemann/Query.g:32:1: not : NOT ( WS )* ( not | primary ) ;
     public final QueryParser.not_return not() throws RecognitionException {
         QueryParser.not_return retval = new QueryParser.not_return();
         retval.start = input.LT(1);
@@ -547,16 +548,16 @@ public class QueryParser extends Parser {
         CommonTree WS16_tree=null;
 
         try {
-            // src/riemann/Query.g:31:5: ( NOT ( WS )* ( not | primary ) )
-            // src/riemann/Query.g:31:7: NOT ( WS )* ( not | primary )
+            // src/riemann/Query.g:32:5: ( NOT ( WS )* ( not | primary ) )
+            // src/riemann/Query.g:32:7: NOT ( WS )* ( not | primary )
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            NOT15=(Token)match(input,NOT,FOLLOW_NOT_in_not208);
+            NOT15=(Token)match(input,NOT,FOLLOW_NOT_in_not216); 
             NOT15_tree = (CommonTree)adaptor.create(NOT15);
             root_0 = (CommonTree)adaptor.becomeRoot(NOT15_tree, root_0);
 
-            // src/riemann/Query.g:31:12: ( WS )*
+            // src/riemann/Query.g:32:12: ( WS )*
             loop9:
             do {
                 int alt9=2;
@@ -569,9 +570,9 @@ public class QueryParser extends Parser {
 
                 switch (alt9) {
             	case 1 :
-            	    // src/riemann/Query.g:31:12: WS
+            	    // src/riemann/Query.g:32:12: WS
             	    {
-            	    WS16=(Token)match(input,WS,FOLLOW_WS_in_not211);
+            	    WS16=(Token)match(input,WS,FOLLOW_WS_in_not219); 
             	    WS16_tree = (CommonTree)adaptor.create(WS16);
             	    adaptor.addChild(root_0, WS16_tree);
 
@@ -584,14 +585,14 @@ public class QueryParser extends Parser {
                 }
             } while (true);
 
-            // src/riemann/Query.g:31:16: ( not | primary )
+            // src/riemann/Query.g:32:16: ( not | primary )
             int alt10=2;
             int LA10_0 = input.LA(1);
 
             if ( (LA10_0==NOT) ) {
                 alt10=1;
             }
-            else if ( (LA10_0==TAGGED||LA10_0==24||(LA10_0>=26 && LA10_0<=37)) ) {
+            else if ( (LA10_0==TAGGED||LA10_0==25||(LA10_0>=27 && LA10_0<=38)) ) {
                 alt10=2;
             }
             else {
@@ -602,9 +603,9 @@ public class QueryParser extends Parser {
             }
             switch (alt10) {
                 case 1 :
-                    // src/riemann/Query.g:31:17: not
+                    // src/riemann/Query.g:32:17: not
                     {
-                    pushFollow(FOLLOW_not_in_not215);
+                    pushFollow(FOLLOW_not_in_not223);
                     not17=not();
 
                     state._fsp--;
@@ -614,9 +615,9 @@ public class QueryParser extends Parser {
                     }
                     break;
                 case 2 :
-                    // src/riemann/Query.g:31:23: primary
+                    // src/riemann/Query.g:32:23: primary
                     {
-                    pushFollow(FOLLOW_primary_in_not219);
+                    pushFollow(FOLLOW_primary_in_not227);
                     primary18=primary();
 
                     state._fsp--;
@@ -655,7 +656,7 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "primary"
-    // src/riemann/Query.g:34:1: primary : ( ( '(' or ')' ) -> ^( or ) | simple -> simple ) ;
+    // src/riemann/Query.g:35:1: primary : ( ( '(' or ')' ) -> ^( or ) | simple -> simple ) ;
     public final QueryParser.primary_return primary() throws RecognitionException {
         QueryParser.primary_return retval = new QueryParser.primary_return();
         retval.start = input.LT(1);
@@ -671,22 +672,22 @@ public class QueryParser extends Parser {
 
         CommonTree char_literal19_tree=null;
         CommonTree char_literal21_tree=null;
-        RewriteRuleTokenStream stream_24=new RewriteRuleTokenStream(adaptor,"token 24");
         RewriteRuleTokenStream stream_25=new RewriteRuleTokenStream(adaptor,"token 25");
+        RewriteRuleTokenStream stream_26=new RewriteRuleTokenStream(adaptor,"token 26");
         RewriteRuleSubtreeStream stream_or=new RewriteRuleSubtreeStream(adaptor,"rule or");
         RewriteRuleSubtreeStream stream_simple=new RewriteRuleSubtreeStream(adaptor,"rule simple");
         try {
-            // src/riemann/Query.g:34:9: ( ( ( '(' or ')' ) -> ^( or ) | simple -> simple ) )
-            // src/riemann/Query.g:34:12: ( ( '(' or ')' ) -> ^( or ) | simple -> simple )
+            // src/riemann/Query.g:35:9: ( ( ( '(' or ')' ) -> ^( or ) | simple -> simple ) )
+            // src/riemann/Query.g:35:12: ( ( '(' or ')' ) -> ^( or ) | simple -> simple )
             {
-            // src/riemann/Query.g:34:12: ( ( '(' or ')' ) -> ^( or ) | simple -> simple )
+            // src/riemann/Query.g:35:12: ( ( '(' or ')' ) -> ^( or ) | simple -> simple )
             int alt11=2;
             int LA11_0 = input.LA(1);
 
-            if ( (LA11_0==24) ) {
+            if ( (LA11_0==25) ) {
                 alt11=1;
             }
-            else if ( (LA11_0==TAGGED||(LA11_0>=26 && LA11_0<=37)) ) {
+            else if ( (LA11_0==TAGGED||(LA11_0>=27 && LA11_0<=38)) ) {
                 alt11=2;
             }
             else {
@@ -697,22 +698,22 @@ public class QueryParser extends Parser {
             }
             switch (alt11) {
                 case 1 :
-                    // src/riemann/Query.g:35:4: ( '(' or ')' )
+                    // src/riemann/Query.g:36:4: ( '(' or ')' )
                     {
-                    // src/riemann/Query.g:35:4: ( '(' or ')' )
-                    // src/riemann/Query.g:35:5: '(' or ')'
+                    // src/riemann/Query.g:36:4: ( '(' or ')' )
+                    // src/riemann/Query.g:36:5: '(' or ')'
                     {
-                    char_literal19=(Token)match(input,24,FOLLOW_24_in_primary236);
-                    stream_24.add(char_literal19);
+                    char_literal19=(Token)match(input,25,FOLLOW_25_in_primary244);  
+                    stream_25.add(char_literal19);
 
-                    pushFollow(FOLLOW_or_in_primary238);
+                    pushFollow(FOLLOW_or_in_primary246);
                     or20=or();
 
                     state._fsp--;
 
                     stream_or.add(or20.getTree());
-                    char_literal21=(Token)match(input,25,FOLLOW_25_in_primary240);
-                    stream_25.add(char_literal21);
+                    char_literal21=(Token)match(input,26,FOLLOW_26_in_primary248);  
+                    stream_26.add(char_literal21);
 
 
                     }
@@ -721,18 +722,18 @@ public class QueryParser extends Parser {
 
                     // AST REWRITE
                     // elements: or
-                    // token labels:
+                    // token labels: 
                     // rule labels: retval
-                    // token list labels:
-                    // rule list labels:
-                    // wildcard labels:
+                    // token list labels: 
+                    // rule list labels: 
+                    // wildcard labels: 
                     retval.tree = root_0;
                     RewriteRuleSubtreeStream stream_retval=new RewriteRuleSubtreeStream(adaptor,"rule retval",retval!=null?retval.tree:null);
 
                     root_0 = (CommonTree)adaptor.nil();
-                    // 35:17: -> ^( or )
+                    // 36:17: -> ^( or )
                     {
-                        // src/riemann/Query.g:35:20: ^( or )
+                        // src/riemann/Query.g:36:20: ^( or )
                         {
                         CommonTree root_1 = (CommonTree)adaptor.nil();
                         root_1 = (CommonTree)adaptor.becomeRoot(stream_or.nextNode(), root_1);
@@ -746,9 +747,9 @@ public class QueryParser extends Parser {
                     }
                     break;
                 case 2 :
-                    // src/riemann/Query.g:36:6: simple
+                    // src/riemann/Query.g:37:6: simple
                     {
-                    pushFollow(FOLLOW_simple_in_primary254);
+                    pushFollow(FOLLOW_simple_in_primary262);
                     simple22=simple();
 
                     state._fsp--;
@@ -758,16 +759,16 @@ public class QueryParser extends Parser {
 
                     // AST REWRITE
                     // elements: simple
-                    // token labels:
+                    // token labels: 
                     // rule labels: retval
-                    // token list labels:
-                    // rule list labels:
-                    // wildcard labels:
+                    // token list labels: 
+                    // rule list labels: 
+                    // wildcard labels: 
                     retval.tree = root_0;
                     RewriteRuleSubtreeStream stream_retval=new RewriteRuleSubtreeStream(adaptor,"rule retval",retval!=null?retval.tree:null);
 
                     root_0 = (CommonTree)adaptor.nil();
-                    // 36:13: -> simple
+                    // 37:13: -> simple
                     {
                         adaptor.addChild(root_0, stream_simple.nextTree());
 
@@ -806,7 +807,7 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "simple"
-    // src/riemann/Query.g:39:1: fragment simple : ( t | f | nil | tagged | approximately | lesser | lesser_equal | greater | greater_equal | not_equal | equal ) ;
+    // src/riemann/Query.g:40:1: fragment simple : ( t | f | nil | tagged | approximately | regex_match | lesser | lesser_equal | greater | greater_equal | not_equal | equal ) ;
     public final QueryParser.simple_return simple() throws RecognitionException {
         QueryParser.simple_return retval = new QueryParser.simple_return();
         retval.start = input.LT(1);
@@ -823,34 +824,36 @@ public class QueryParser extends Parser {
 
         QueryParser.approximately_return approximately27 = null;
 
-        QueryParser.lesser_return lesser28 = null;
+        QueryParser.regex_match_return regex_match28 = null;
 
-        QueryParser.lesser_equal_return lesser_equal29 = null;
+        QueryParser.lesser_return lesser29 = null;
 
-        QueryParser.greater_return greater30 = null;
+        QueryParser.lesser_equal_return lesser_equal30 = null;
 
-        QueryParser.greater_equal_return greater_equal31 = null;
+        QueryParser.greater_return greater31 = null;
 
-        QueryParser.not_equal_return not_equal32 = null;
+        QueryParser.greater_equal_return greater_equal32 = null;
 
-        QueryParser.equal_return equal33 = null;
+        QueryParser.not_equal_return not_equal33 = null;
+
+        QueryParser.equal_return equal34 = null;
 
 
 
         try {
-            // src/riemann/Query.g:40:8: ( ( t | f | nil | tagged | approximately | lesser | lesser_equal | greater | greater_equal | not_equal | equal ) )
-            // src/riemann/Query.g:40:10: ( t | f | nil | tagged | approximately | lesser | lesser_equal | greater | greater_equal | not_equal | equal )
+            // src/riemann/Query.g:41:8: ( ( t | f | nil | tagged | approximately | regex_match | lesser | lesser_equal | greater | greater_equal | not_equal | equal ) )
+            // src/riemann/Query.g:41:10: ( t | f | nil | tagged | approximately | regex_match | lesser | lesser_equal | greater | greater_equal | not_equal | equal )
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            // src/riemann/Query.g:40:10: ( t | f | nil | tagged | approximately | lesser | lesser_equal | greater | greater_equal | not_equal | equal )
-            int alt12=11;
+            // src/riemann/Query.g:41:10: ( t | f | nil | tagged | approximately | regex_match | lesser | lesser_equal | greater | greater_equal | not_equal | equal )
+            int alt12=12;
             alt12 = dfa12.predict(input);
             switch (alt12) {
                 case 1 :
-                    // src/riemann/Query.g:40:12: t
+                    // src/riemann/Query.g:41:12: t
                     {
-                    pushFollow(FOLLOW_t_in_simple274);
+                    pushFollow(FOLLOW_t_in_simple282);
                     t23=t();
 
                     state._fsp--;
@@ -860,9 +863,9 @@ public class QueryParser extends Parser {
                     }
                     break;
                 case 2 :
-                    // src/riemann/Query.g:40:16: f
+                    // src/riemann/Query.g:41:16: f
                     {
-                    pushFollow(FOLLOW_f_in_simple278);
+                    pushFollow(FOLLOW_f_in_simple286);
                     f24=f();
 
                     state._fsp--;
@@ -872,9 +875,9 @@ public class QueryParser extends Parser {
                     }
                     break;
                 case 3 :
-                    // src/riemann/Query.g:40:20: nil
+                    // src/riemann/Query.g:41:20: nil
                     {
-                    pushFollow(FOLLOW_nil_in_simple282);
+                    pushFollow(FOLLOW_nil_in_simple290);
                     nil25=nil();
 
                     state._fsp--;
@@ -884,9 +887,9 @@ public class QueryParser extends Parser {
                     }
                     break;
                 case 4 :
-                    // src/riemann/Query.g:41:5: tagged
+                    // src/riemann/Query.g:42:5: tagged
                     {
-                    pushFollow(FOLLOW_tagged_in_simple288);
+                    pushFollow(FOLLOW_tagged_in_simple296);
                     tagged26=tagged();
 
                     state._fsp--;
@@ -896,9 +899,9 @@ public class QueryParser extends Parser {
                     }
                     break;
                 case 5 :
-                    // src/riemann/Query.g:42:5: approximately
+                    // src/riemann/Query.g:43:5: approximately
                     {
-                    pushFollow(FOLLOW_approximately_in_simple294);
+                    pushFollow(FOLLOW_approximately_in_simple302);
                     approximately27=approximately();
 
                     state._fsp--;
@@ -908,74 +911,86 @@ public class QueryParser extends Parser {
                     }
                     break;
                 case 6 :
-                    // src/riemann/Query.g:43:5: lesser
+                    // src/riemann/Query.g:44:5: regex_match
                     {
-                    pushFollow(FOLLOW_lesser_in_simple300);
-                    lesser28=lesser();
+                    pushFollow(FOLLOW_regex_match_in_simple308);
+                    regex_match28=regex_match();
 
                     state._fsp--;
 
-                    adaptor.addChild(root_0, lesser28.getTree());
+                    adaptor.addChild(root_0, regex_match28.getTree());
 
                     }
                     break;
                 case 7 :
-                    // src/riemann/Query.g:44:5: lesser_equal
+                    // src/riemann/Query.g:45:5: lesser
                     {
-                    pushFollow(FOLLOW_lesser_equal_in_simple306);
-                    lesser_equal29=lesser_equal();
+                    pushFollow(FOLLOW_lesser_in_simple314);
+                    lesser29=lesser();
 
                     state._fsp--;
 
-                    adaptor.addChild(root_0, lesser_equal29.getTree());
+                    adaptor.addChild(root_0, lesser29.getTree());
 
                     }
                     break;
                 case 8 :
-                    // src/riemann/Query.g:45:5: greater
+                    // src/riemann/Query.g:46:5: lesser_equal
                     {
-                    pushFollow(FOLLOW_greater_in_simple312);
-                    greater30=greater();
+                    pushFollow(FOLLOW_lesser_equal_in_simple320);
+                    lesser_equal30=lesser_equal();
 
                     state._fsp--;
 
-                    adaptor.addChild(root_0, greater30.getTree());
+                    adaptor.addChild(root_0, lesser_equal30.getTree());
 
                     }
                     break;
                 case 9 :
-                    // src/riemann/Query.g:46:5: greater_equal
+                    // src/riemann/Query.g:47:5: greater
                     {
-                    pushFollow(FOLLOW_greater_equal_in_simple318);
-                    greater_equal31=greater_equal();
+                    pushFollow(FOLLOW_greater_in_simple326);
+                    greater31=greater();
 
                     state._fsp--;
 
-                    adaptor.addChild(root_0, greater_equal31.getTree());
+                    adaptor.addChild(root_0, greater31.getTree());
 
                     }
                     break;
                 case 10 :
-                    // src/riemann/Query.g:47:5: not_equal
+                    // src/riemann/Query.g:48:5: greater_equal
                     {
-                    pushFollow(FOLLOW_not_equal_in_simple324);
-                    not_equal32=not_equal();
+                    pushFollow(FOLLOW_greater_equal_in_simple332);
+                    greater_equal32=greater_equal();
 
                     state._fsp--;
 
-                    adaptor.addChild(root_0, not_equal32.getTree());
+                    adaptor.addChild(root_0, greater_equal32.getTree());
 
                     }
                     break;
                 case 11 :
-                    // src/riemann/Query.g:48:5: equal
+                    // src/riemann/Query.g:49:5: not_equal
                     {
-                    pushFollow(FOLLOW_equal_in_simple330);
-                    equal33=equal();
+                    pushFollow(FOLLOW_not_equal_in_simple338);
+                    not_equal33=not_equal();
 
                     state._fsp--;
 
-                    adaptor.addChild(root_0, equal33.getTree());
+                    adaptor.addChild(root_0, not_equal33.getTree());
+
+                    }
+                    break;
+                case 12 :
+                    // src/riemann/Query.g:50:5: equal
+                    {
+                    pushFollow(FOLLOW_equal_in_simple344);
+                    equal34=equal();
+
+                    state._fsp--;
+
+                    adaptor.addChild(root_0, equal34.getTree());
 
                     }
                     break;
@@ -1009,38 +1024,38 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "approximately"
-    // src/riemann/Query.g:51:1: approximately : field ( WS )* APPROXIMATELY ( WS )* value ;
+    // src/riemann/Query.g:53:1: approximately : field ( WS )* APPROXIMATELY ( WS )* value ;
     public final QueryParser.approximately_return approximately() throws RecognitionException {
         QueryParser.approximately_return retval = new QueryParser.approximately_return();
         retval.start = input.LT(1);
 
         CommonTree root_0 = null;
 
-        Token WS35=null;
-        Token APPROXIMATELY36=null;
-        Token WS37=null;
-        QueryParser.field_return field34 = null;
+        Token WS36=null;
+        Token APPROXIMATELY37=null;
+        Token WS38=null;
+        QueryParser.field_return field35 = null;
 
-        QueryParser.value_return value38 = null;
+        QueryParser.value_return value39 = null;
 
 
-        CommonTree WS35_tree=null;
-        CommonTree APPROXIMATELY36_tree=null;
-        CommonTree WS37_tree=null;
+        CommonTree WS36_tree=null;
+        CommonTree APPROXIMATELY37_tree=null;
+        CommonTree WS38_tree=null;
 
         try {
-            // src/riemann/Query.g:52:2: ( field ( WS )* APPROXIMATELY ( WS )* value )
-            // src/riemann/Query.g:52:4: field ( WS )* APPROXIMATELY ( WS )* value
+            // src/riemann/Query.g:54:2: ( field ( WS )* APPROXIMATELY ( WS )* value )
+            // src/riemann/Query.g:54:4: field ( WS )* APPROXIMATELY ( WS )* value
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            pushFollow(FOLLOW_field_in_approximately343);
-            field34=field();
+            pushFollow(FOLLOW_field_in_approximately357);
+            field35=field();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, field34.getTree());
-            // src/riemann/Query.g:52:10: ( WS )*
+            adaptor.addChild(root_0, field35.getTree());
+            // src/riemann/Query.g:54:10: ( WS )*
             loop13:
             do {
                 int alt13=2;
@@ -1053,11 +1068,11 @@ public class QueryParser extends Parser {
 
                 switch (alt13) {
             	case 1 :
-            	    // src/riemann/Query.g:52:10: WS
+            	    // src/riemann/Query.g:54:10: WS
             	    {
-            	    WS35=(Token)match(input,WS,FOLLOW_WS_in_approximately345);
-            	    WS35_tree = (CommonTree)adaptor.create(WS35);
-            	    adaptor.addChild(root_0, WS35_tree);
+            	    WS36=(Token)match(input,WS,FOLLOW_WS_in_approximately359); 
+            	    WS36_tree = (CommonTree)adaptor.create(WS36);
+            	    adaptor.addChild(root_0, WS36_tree);
 
 
             	    }
@@ -1068,11 +1083,11 @@ public class QueryParser extends Parser {
                 }
             } while (true);
 
-            APPROXIMATELY36=(Token)match(input,APPROXIMATELY,FOLLOW_APPROXIMATELY_in_approximately348);
-            APPROXIMATELY36_tree = (CommonTree)adaptor.create(APPROXIMATELY36);
-            root_0 = (CommonTree)adaptor.becomeRoot(APPROXIMATELY36_tree, root_0);
+            APPROXIMATELY37=(Token)match(input,APPROXIMATELY,FOLLOW_APPROXIMATELY_in_approximately362); 
+            APPROXIMATELY37_tree = (CommonTree)adaptor.create(APPROXIMATELY37);
+            root_0 = (CommonTree)adaptor.becomeRoot(APPROXIMATELY37_tree, root_0);
 
-            // src/riemann/Query.g:52:29: ( WS )*
+            // src/riemann/Query.g:54:29: ( WS )*
             loop14:
             do {
                 int alt14=2;
@@ -1085,11 +1100,11 @@ public class QueryParser extends Parser {
 
                 switch (alt14) {
             	case 1 :
-            	    // src/riemann/Query.g:52:29: WS
+            	    // src/riemann/Query.g:54:29: WS
             	    {
-            	    WS37=(Token)match(input,WS,FOLLOW_WS_in_approximately351);
-            	    WS37_tree = (CommonTree)adaptor.create(WS37);
-            	    adaptor.addChild(root_0, WS37_tree);
+            	    WS38=(Token)match(input,WS,FOLLOW_WS_in_approximately365); 
+            	    WS38_tree = (CommonTree)adaptor.create(WS38);
+            	    adaptor.addChild(root_0, WS38_tree);
 
 
             	    }
@@ -1100,12 +1115,12 @@ public class QueryParser extends Parser {
                 }
             } while (true);
 
-            pushFollow(FOLLOW_value_in_approximately354);
-            value38=value();
+            pushFollow(FOLLOW_value_in_approximately368);
+            value39=value();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, value38.getTree());
+            adaptor.addChild(root_0, value39.getTree());
 
             }
 
@@ -1127,44 +1142,44 @@ public class QueryParser extends Parser {
     }
     // $ANTLR end "approximately"
 
-    public static class lesser_return extends ParserRuleReturnScope {
+    public static class regex_match_return extends ParserRuleReturnScope {
         CommonTree tree;
         public Object getTree() { return tree; }
     };
 
-    // $ANTLR start "lesser"
-    // src/riemann/Query.g:53:1: lesser : field ( WS )* LESSER ( WS )* value ;
-    public final QueryParser.lesser_return lesser() throws RecognitionException {
-        QueryParser.lesser_return retval = new QueryParser.lesser_return();
+    // $ANTLR start "regex_match"
+    // src/riemann/Query.g:55:1: regex_match : field ( WS )* REGEX_MATCH ( WS )* value ;
+    public final QueryParser.regex_match_return regex_match() throws RecognitionException {
+        QueryParser.regex_match_return retval = new QueryParser.regex_match_return();
         retval.start = input.LT(1);
 
         CommonTree root_0 = null;
 
-        Token WS40=null;
-        Token LESSER41=null;
-        Token WS42=null;
-        QueryParser.field_return field39 = null;
+        Token WS41=null;
+        Token REGEX_MATCH42=null;
+        Token WS43=null;
+        QueryParser.field_return field40 = null;
 
-        QueryParser.value_return value43 = null;
+        QueryParser.value_return value44 = null;
 
 
-        CommonTree WS40_tree=null;
-        CommonTree LESSER41_tree=null;
-        CommonTree WS42_tree=null;
+        CommonTree WS41_tree=null;
+        CommonTree REGEX_MATCH42_tree=null;
+        CommonTree WS43_tree=null;
 
         try {
-            // src/riemann/Query.g:53:8: ( field ( WS )* LESSER ( WS )* value )
-            // src/riemann/Query.g:53:10: field ( WS )* LESSER ( WS )* value
+            // src/riemann/Query.g:56:2: ( field ( WS )* REGEX_MATCH ( WS )* value )
+            // src/riemann/Query.g:56:4: field ( WS )* REGEX_MATCH ( WS )* value
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            pushFollow(FOLLOW_field_in_lesser361);
-            field39=field();
+            pushFollow(FOLLOW_field_in_regex_match376);
+            field40=field();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, field39.getTree());
-            // src/riemann/Query.g:53:16: ( WS )*
+            adaptor.addChild(root_0, field40.getTree());
+            // src/riemann/Query.g:56:10: ( WS )*
             loop15:
             do {
                 int alt15=2;
@@ -1177,11 +1192,11 @@ public class QueryParser extends Parser {
 
                 switch (alt15) {
             	case 1 :
-            	    // src/riemann/Query.g:53:16: WS
+            	    // src/riemann/Query.g:56:10: WS
             	    {
-            	    WS40=(Token)match(input,WS,FOLLOW_WS_in_lesser363);
-            	    WS40_tree = (CommonTree)adaptor.create(WS40);
-            	    adaptor.addChild(root_0, WS40_tree);
+            	    WS41=(Token)match(input,WS,FOLLOW_WS_in_regex_match378); 
+            	    WS41_tree = (CommonTree)adaptor.create(WS41);
+            	    adaptor.addChild(root_0, WS41_tree);
 
 
             	    }
@@ -1192,11 +1207,11 @@ public class QueryParser extends Parser {
                 }
             } while (true);
 
-            LESSER41=(Token)match(input,LESSER,FOLLOW_LESSER_in_lesser366);
-            LESSER41_tree = (CommonTree)adaptor.create(LESSER41);
-            root_0 = (CommonTree)adaptor.becomeRoot(LESSER41_tree, root_0);
+            REGEX_MATCH42=(Token)match(input,REGEX_MATCH,FOLLOW_REGEX_MATCH_in_regex_match381); 
+            REGEX_MATCH42_tree = (CommonTree)adaptor.create(REGEX_MATCH42);
+            root_0 = (CommonTree)adaptor.becomeRoot(REGEX_MATCH42_tree, root_0);
 
-            // src/riemann/Query.g:53:28: ( WS )*
+            // src/riemann/Query.g:56:27: ( WS )*
             loop16:
             do {
                 int alt16=2;
@@ -1209,11 +1224,11 @@ public class QueryParser extends Parser {
 
                 switch (alt16) {
             	case 1 :
-            	    // src/riemann/Query.g:53:28: WS
+            	    // src/riemann/Query.g:56:27: WS
             	    {
-            	    WS42=(Token)match(input,WS,FOLLOW_WS_in_lesser369);
-            	    WS42_tree = (CommonTree)adaptor.create(WS42);
-            	    adaptor.addChild(root_0, WS42_tree);
+            	    WS43=(Token)match(input,WS,FOLLOW_WS_in_regex_match384); 
+            	    WS43_tree = (CommonTree)adaptor.create(WS43);
+            	    adaptor.addChild(root_0, WS43_tree);
 
 
             	    }
@@ -1224,12 +1239,136 @@ public class QueryParser extends Parser {
                 }
             } while (true);
 
-            pushFollow(FOLLOW_value_in_lesser372);
-            value43=value();
+            pushFollow(FOLLOW_value_in_regex_match387);
+            value44=value();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, value43.getTree());
+            adaptor.addChild(root_0, value44.getTree());
+
+            }
+
+            retval.stop = input.LT(-1);
+
+            retval.tree = (CommonTree)adaptor.rulePostProcessing(root_0);
+            adaptor.setTokenBoundaries(retval.tree, retval.start, retval.stop);
+
+        }
+        catch (RecognitionException re) {
+            reportError(re);
+            recover(input,re);
+    	retval.tree = (CommonTree)adaptor.errorNode(input, retval.start, input.LT(-1), re);
+
+        }
+        finally {
+        }
+        return retval;
+    }
+    // $ANTLR end "regex_match"
+
+    public static class lesser_return extends ParserRuleReturnScope {
+        CommonTree tree;
+        public Object getTree() { return tree; }
+    };
+
+    // $ANTLR start "lesser"
+    // src/riemann/Query.g:57:1: lesser : field ( WS )* LESSER ( WS )* value ;
+    public final QueryParser.lesser_return lesser() throws RecognitionException {
+        QueryParser.lesser_return retval = new QueryParser.lesser_return();
+        retval.start = input.LT(1);
+
+        CommonTree root_0 = null;
+
+        Token WS46=null;
+        Token LESSER47=null;
+        Token WS48=null;
+        QueryParser.field_return field45 = null;
+
+        QueryParser.value_return value49 = null;
+
+
+        CommonTree WS46_tree=null;
+        CommonTree LESSER47_tree=null;
+        CommonTree WS48_tree=null;
+
+        try {
+            // src/riemann/Query.g:57:8: ( field ( WS )* LESSER ( WS )* value )
+            // src/riemann/Query.g:57:10: field ( WS )* LESSER ( WS )* value
+            {
+            root_0 = (CommonTree)adaptor.nil();
+
+            pushFollow(FOLLOW_field_in_lesser394);
+            field45=field();
+
+            state._fsp--;
+
+            adaptor.addChild(root_0, field45.getTree());
+            // src/riemann/Query.g:57:16: ( WS )*
+            loop17:
+            do {
+                int alt17=2;
+                int LA17_0 = input.LA(1);
+
+                if ( (LA17_0==WS) ) {
+                    alt17=1;
+                }
+
+
+                switch (alt17) {
+            	case 1 :
+            	    // src/riemann/Query.g:57:16: WS
+            	    {
+            	    WS46=(Token)match(input,WS,FOLLOW_WS_in_lesser396); 
+            	    WS46_tree = (CommonTree)adaptor.create(WS46);
+            	    adaptor.addChild(root_0, WS46_tree);
+
+
+            	    }
+            	    break;
+
+            	default :
+            	    break loop17;
+                }
+            } while (true);
+
+            LESSER47=(Token)match(input,LESSER,FOLLOW_LESSER_in_lesser399); 
+            LESSER47_tree = (CommonTree)adaptor.create(LESSER47);
+            root_0 = (CommonTree)adaptor.becomeRoot(LESSER47_tree, root_0);
+
+            // src/riemann/Query.g:57:28: ( WS )*
+            loop18:
+            do {
+                int alt18=2;
+                int LA18_0 = input.LA(1);
+
+                if ( (LA18_0==WS) ) {
+                    alt18=1;
+                }
+
+
+                switch (alt18) {
+            	case 1 :
+            	    // src/riemann/Query.g:57:28: WS
+            	    {
+            	    WS48=(Token)match(input,WS,FOLLOW_WS_in_lesser402); 
+            	    WS48_tree = (CommonTree)adaptor.create(WS48);
+            	    adaptor.addChild(root_0, WS48_tree);
+
+
+            	    }
+            	    break;
+
+            	default :
+            	    break loop18;
+                }
+            } while (true);
+
+            pushFollow(FOLLOW_value_in_lesser405);
+            value49=value();
+
+            state._fsp--;
+
+            adaptor.addChild(root_0, value49.getTree());
 
             }
 
@@ -1257,103 +1396,103 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "lesser_equal"
-    // src/riemann/Query.g:54:1: lesser_equal : field ( WS )* LESSER_EQUAL ( WS )* value ;
+    // src/riemann/Query.g:58:1: lesser_equal : field ( WS )* LESSER_EQUAL ( WS )* value ;
     public final QueryParser.lesser_equal_return lesser_equal() throws RecognitionException {
         QueryParser.lesser_equal_return retval = new QueryParser.lesser_equal_return();
         retval.start = input.LT(1);
 
         CommonTree root_0 = null;
 
-        Token WS45=null;
-        Token LESSER_EQUAL46=null;
-        Token WS47=null;
-        QueryParser.field_return field44 = null;
+        Token WS51=null;
+        Token LESSER_EQUAL52=null;
+        Token WS53=null;
+        QueryParser.field_return field50 = null;
 
-        QueryParser.value_return value48 = null;
+        QueryParser.value_return value54 = null;
 
 
-        CommonTree WS45_tree=null;
-        CommonTree LESSER_EQUAL46_tree=null;
-        CommonTree WS47_tree=null;
+        CommonTree WS51_tree=null;
+        CommonTree LESSER_EQUAL52_tree=null;
+        CommonTree WS53_tree=null;
 
         try {
-            // src/riemann/Query.g:55:2: ( field ( WS )* LESSER_EQUAL ( WS )* value )
-            // src/riemann/Query.g:55:4: field ( WS )* LESSER_EQUAL ( WS )* value
+            // src/riemann/Query.g:59:2: ( field ( WS )* LESSER_EQUAL ( WS )* value )
+            // src/riemann/Query.g:59:4: field ( WS )* LESSER_EQUAL ( WS )* value
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            pushFollow(FOLLOW_field_in_lesser_equal380);
-            field44=field();
+            pushFollow(FOLLOW_field_in_lesser_equal413);
+            field50=field();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, field44.getTree());
-            // src/riemann/Query.g:55:10: ( WS )*
-            loop17:
+            adaptor.addChild(root_0, field50.getTree());
+            // src/riemann/Query.g:59:10: ( WS )*
+            loop19:
             do {
-                int alt17=2;
-                int LA17_0 = input.LA(1);
+                int alt19=2;
+                int LA19_0 = input.LA(1);
 
-                if ( (LA17_0==WS) ) {
-                    alt17=1;
+                if ( (LA19_0==WS) ) {
+                    alt19=1;
                 }
 
 
-                switch (alt17) {
+                switch (alt19) {
             	case 1 :
-            	    // src/riemann/Query.g:55:10: WS
+            	    // src/riemann/Query.g:59:10: WS
             	    {
-            	    WS45=(Token)match(input,WS,FOLLOW_WS_in_lesser_equal382);
-            	    WS45_tree = (CommonTree)adaptor.create(WS45);
-            	    adaptor.addChild(root_0, WS45_tree);
+            	    WS51=(Token)match(input,WS,FOLLOW_WS_in_lesser_equal415); 
+            	    WS51_tree = (CommonTree)adaptor.create(WS51);
+            	    adaptor.addChild(root_0, WS51_tree);
 
 
             	    }
             	    break;
 
             	default :
-            	    break loop17;
+            	    break loop19;
                 }
             } while (true);
 
-            LESSER_EQUAL46=(Token)match(input,LESSER_EQUAL,FOLLOW_LESSER_EQUAL_in_lesser_equal385);
-            LESSER_EQUAL46_tree = (CommonTree)adaptor.create(LESSER_EQUAL46);
-            root_0 = (CommonTree)adaptor.becomeRoot(LESSER_EQUAL46_tree, root_0);
+            LESSER_EQUAL52=(Token)match(input,LESSER_EQUAL,FOLLOW_LESSER_EQUAL_in_lesser_equal418); 
+            LESSER_EQUAL52_tree = (CommonTree)adaptor.create(LESSER_EQUAL52);
+            root_0 = (CommonTree)adaptor.becomeRoot(LESSER_EQUAL52_tree, root_0);
 
-            // src/riemann/Query.g:55:28: ( WS )*
-            loop18:
+            // src/riemann/Query.g:59:28: ( WS )*
+            loop20:
             do {
-                int alt18=2;
-                int LA18_0 = input.LA(1);
+                int alt20=2;
+                int LA20_0 = input.LA(1);
 
-                if ( (LA18_0==WS) ) {
-                    alt18=1;
+                if ( (LA20_0==WS) ) {
+                    alt20=1;
                 }
 
 
-                switch (alt18) {
+                switch (alt20) {
             	case 1 :
-            	    // src/riemann/Query.g:55:28: WS
+            	    // src/riemann/Query.g:59:28: WS
             	    {
-            	    WS47=(Token)match(input,WS,FOLLOW_WS_in_lesser_equal388);
-            	    WS47_tree = (CommonTree)adaptor.create(WS47);
-            	    adaptor.addChild(root_0, WS47_tree);
+            	    WS53=(Token)match(input,WS,FOLLOW_WS_in_lesser_equal421); 
+            	    WS53_tree = (CommonTree)adaptor.create(WS53);
+            	    adaptor.addChild(root_0, WS53_tree);
 
 
             	    }
             	    break;
 
             	default :
-            	    break loop18;
+            	    break loop20;
                 }
             } while (true);
 
-            pushFollow(FOLLOW_value_in_lesser_equal391);
-            value48=value();
+            pushFollow(FOLLOW_value_in_lesser_equal424);
+            value54=value();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, value48.getTree());
+            adaptor.addChild(root_0, value54.getTree());
 
             }
 
@@ -1381,103 +1520,103 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "greater"
-    // src/riemann/Query.g:56:1: greater : field ( WS )* GREATER ( WS )* value ;
+    // src/riemann/Query.g:60:1: greater : field ( WS )* GREATER ( WS )* value ;
     public final QueryParser.greater_return greater() throws RecognitionException {
         QueryParser.greater_return retval = new QueryParser.greater_return();
         retval.start = input.LT(1);
 
         CommonTree root_0 = null;
 
-        Token WS50=null;
-        Token GREATER51=null;
-        Token WS52=null;
-        QueryParser.field_return field49 = null;
+        Token WS56=null;
+        Token GREATER57=null;
+        Token WS58=null;
+        QueryParser.field_return field55 = null;
 
-        QueryParser.value_return value53 = null;
+        QueryParser.value_return value59 = null;
 
 
-        CommonTree WS50_tree=null;
-        CommonTree GREATER51_tree=null;
-        CommonTree WS52_tree=null;
+        CommonTree WS56_tree=null;
+        CommonTree GREATER57_tree=null;
+        CommonTree WS58_tree=null;
 
         try {
-            // src/riemann/Query.g:56:9: ( field ( WS )* GREATER ( WS )* value )
-            // src/riemann/Query.g:56:11: field ( WS )* GREATER ( WS )* value
+            // src/riemann/Query.g:60:9: ( field ( WS )* GREATER ( WS )* value )
+            // src/riemann/Query.g:60:11: field ( WS )* GREATER ( WS )* value
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            pushFollow(FOLLOW_field_in_greater398);
-            field49=field();
+            pushFollow(FOLLOW_field_in_greater431);
+            field55=field();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, field49.getTree());
-            // src/riemann/Query.g:56:17: ( WS )*
-            loop19:
+            adaptor.addChild(root_0, field55.getTree());
+            // src/riemann/Query.g:60:17: ( WS )*
+            loop21:
             do {
-                int alt19=2;
-                int LA19_0 = input.LA(1);
+                int alt21=2;
+                int LA21_0 = input.LA(1);
 
-                if ( (LA19_0==WS) ) {
-                    alt19=1;
+                if ( (LA21_0==WS) ) {
+                    alt21=1;
                 }
 
 
-                switch (alt19) {
+                switch (alt21) {
             	case 1 :
-            	    // src/riemann/Query.g:56:17: WS
+            	    // src/riemann/Query.g:60:17: WS
             	    {
-            	    WS50=(Token)match(input,WS,FOLLOW_WS_in_greater400);
-            	    WS50_tree = (CommonTree)adaptor.create(WS50);
-            	    adaptor.addChild(root_0, WS50_tree);
+            	    WS56=(Token)match(input,WS,FOLLOW_WS_in_greater433); 
+            	    WS56_tree = (CommonTree)adaptor.create(WS56);
+            	    adaptor.addChild(root_0, WS56_tree);
 
 
             	    }
             	    break;
 
             	default :
-            	    break loop19;
+            	    break loop21;
                 }
             } while (true);
 
-            GREATER51=(Token)match(input,GREATER,FOLLOW_GREATER_in_greater403);
-            GREATER51_tree = (CommonTree)adaptor.create(GREATER51);
-            root_0 = (CommonTree)adaptor.becomeRoot(GREATER51_tree, root_0);
+            GREATER57=(Token)match(input,GREATER,FOLLOW_GREATER_in_greater436); 
+            GREATER57_tree = (CommonTree)adaptor.create(GREATER57);
+            root_0 = (CommonTree)adaptor.becomeRoot(GREATER57_tree, root_0);
 
-            // src/riemann/Query.g:56:30: ( WS )*
-            loop20:
+            // src/riemann/Query.g:60:30: ( WS )*
+            loop22:
             do {
-                int alt20=2;
-                int LA20_0 = input.LA(1);
+                int alt22=2;
+                int LA22_0 = input.LA(1);
 
-                if ( (LA20_0==WS) ) {
-                    alt20=1;
+                if ( (LA22_0==WS) ) {
+                    alt22=1;
                 }
 
 
-                switch (alt20) {
+                switch (alt22) {
             	case 1 :
-            	    // src/riemann/Query.g:56:30: WS
+            	    // src/riemann/Query.g:60:30: WS
             	    {
-            	    WS52=(Token)match(input,WS,FOLLOW_WS_in_greater406);
-            	    WS52_tree = (CommonTree)adaptor.create(WS52);
-            	    adaptor.addChild(root_0, WS52_tree);
+            	    WS58=(Token)match(input,WS,FOLLOW_WS_in_greater439); 
+            	    WS58_tree = (CommonTree)adaptor.create(WS58);
+            	    adaptor.addChild(root_0, WS58_tree);
 
 
             	    }
             	    break;
 
             	default :
-            	    break loop20;
+            	    break loop22;
                 }
             } while (true);
 
-            pushFollow(FOLLOW_value_in_greater409);
-            value53=value();
+            pushFollow(FOLLOW_value_in_greater442);
+            value59=value();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, value53.getTree());
+            adaptor.addChild(root_0, value59.getTree());
 
             }
 
@@ -1505,103 +1644,103 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "greater_equal"
-    // src/riemann/Query.g:57:1: greater_equal : field ( WS )* GREATER_EQUAL ( WS )* value ;
+    // src/riemann/Query.g:61:1: greater_equal : field ( WS )* GREATER_EQUAL ( WS )* value ;
     public final QueryParser.greater_equal_return greater_equal() throws RecognitionException {
         QueryParser.greater_equal_return retval = new QueryParser.greater_equal_return();
         retval.start = input.LT(1);
 
         CommonTree root_0 = null;
 
-        Token WS55=null;
-        Token GREATER_EQUAL56=null;
-        Token WS57=null;
-        QueryParser.field_return field54 = null;
+        Token WS61=null;
+        Token GREATER_EQUAL62=null;
+        Token WS63=null;
+        QueryParser.field_return field60 = null;
 
-        QueryParser.value_return value58 = null;
+        QueryParser.value_return value64 = null;
 
 
-        CommonTree WS55_tree=null;
-        CommonTree GREATER_EQUAL56_tree=null;
-        CommonTree WS57_tree=null;
+        CommonTree WS61_tree=null;
+        CommonTree GREATER_EQUAL62_tree=null;
+        CommonTree WS63_tree=null;
 
         try {
-            // src/riemann/Query.g:58:2: ( field ( WS )* GREATER_EQUAL ( WS )* value )
-            // src/riemann/Query.g:58:4: field ( WS )* GREATER_EQUAL ( WS )* value
+            // src/riemann/Query.g:62:2: ( field ( WS )* GREATER_EQUAL ( WS )* value )
+            // src/riemann/Query.g:62:4: field ( WS )* GREATER_EQUAL ( WS )* value
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            pushFollow(FOLLOW_field_in_greater_equal417);
-            field54=field();
+            pushFollow(FOLLOW_field_in_greater_equal450);
+            field60=field();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, field54.getTree());
-            // src/riemann/Query.g:58:10: ( WS )*
-            loop21:
+            adaptor.addChild(root_0, field60.getTree());
+            // src/riemann/Query.g:62:10: ( WS )*
+            loop23:
             do {
-                int alt21=2;
-                int LA21_0 = input.LA(1);
+                int alt23=2;
+                int LA23_0 = input.LA(1);
 
-                if ( (LA21_0==WS) ) {
-                    alt21=1;
+                if ( (LA23_0==WS) ) {
+                    alt23=1;
                 }
 
 
-                switch (alt21) {
+                switch (alt23) {
             	case 1 :
-            	    // src/riemann/Query.g:58:10: WS
+            	    // src/riemann/Query.g:62:10: WS
             	    {
-            	    WS55=(Token)match(input,WS,FOLLOW_WS_in_greater_equal419);
-            	    WS55_tree = (CommonTree)adaptor.create(WS55);
-            	    adaptor.addChild(root_0, WS55_tree);
+            	    WS61=(Token)match(input,WS,FOLLOW_WS_in_greater_equal452); 
+            	    WS61_tree = (CommonTree)adaptor.create(WS61);
+            	    adaptor.addChild(root_0, WS61_tree);
 
 
             	    }
             	    break;
 
             	default :
-            	    break loop21;
+            	    break loop23;
                 }
             } while (true);
 
-            GREATER_EQUAL56=(Token)match(input,GREATER_EQUAL,FOLLOW_GREATER_EQUAL_in_greater_equal422);
-            GREATER_EQUAL56_tree = (CommonTree)adaptor.create(GREATER_EQUAL56);
-            root_0 = (CommonTree)adaptor.becomeRoot(GREATER_EQUAL56_tree, root_0);
+            GREATER_EQUAL62=(Token)match(input,GREATER_EQUAL,FOLLOW_GREATER_EQUAL_in_greater_equal455); 
+            GREATER_EQUAL62_tree = (CommonTree)adaptor.create(GREATER_EQUAL62);
+            root_0 = (CommonTree)adaptor.becomeRoot(GREATER_EQUAL62_tree, root_0);
 
-            // src/riemann/Query.g:58:29: ( WS )*
-            loop22:
+            // src/riemann/Query.g:62:29: ( WS )*
+            loop24:
             do {
-                int alt22=2;
-                int LA22_0 = input.LA(1);
+                int alt24=2;
+                int LA24_0 = input.LA(1);
 
-                if ( (LA22_0==WS) ) {
-                    alt22=1;
+                if ( (LA24_0==WS) ) {
+                    alt24=1;
                 }
 
 
-                switch (alt22) {
+                switch (alt24) {
             	case 1 :
-            	    // src/riemann/Query.g:58:29: WS
+            	    // src/riemann/Query.g:62:29: WS
             	    {
-            	    WS57=(Token)match(input,WS,FOLLOW_WS_in_greater_equal425);
-            	    WS57_tree = (CommonTree)adaptor.create(WS57);
-            	    adaptor.addChild(root_0, WS57_tree);
+            	    WS63=(Token)match(input,WS,FOLLOW_WS_in_greater_equal458); 
+            	    WS63_tree = (CommonTree)adaptor.create(WS63);
+            	    adaptor.addChild(root_0, WS63_tree);
 
 
             	    }
             	    break;
 
             	default :
-            	    break loop22;
+            	    break loop24;
                 }
             } while (true);
 
-            pushFollow(FOLLOW_value_in_greater_equal428);
-            value58=value();
+            pushFollow(FOLLOW_value_in_greater_equal461);
+            value64=value();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, value58.getTree());
+            adaptor.addChild(root_0, value64.getTree());
 
             }
 
@@ -1629,103 +1768,103 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "not_equal"
-    // src/riemann/Query.g:59:1: not_equal : field ( WS )* NOT_EQUAL ( WS )* value ;
+    // src/riemann/Query.g:63:1: not_equal : field ( WS )* NOT_EQUAL ( WS )* value ;
     public final QueryParser.not_equal_return not_equal() throws RecognitionException {
         QueryParser.not_equal_return retval = new QueryParser.not_equal_return();
         retval.start = input.LT(1);
 
         CommonTree root_0 = null;
 
-        Token WS60=null;
-        Token NOT_EQUAL61=null;
-        Token WS62=null;
-        QueryParser.field_return field59 = null;
+        Token WS66=null;
+        Token NOT_EQUAL67=null;
+        Token WS68=null;
+        QueryParser.field_return field65 = null;
 
-        QueryParser.value_return value63 = null;
+        QueryParser.value_return value69 = null;
 
 
-        CommonTree WS60_tree=null;
-        CommonTree NOT_EQUAL61_tree=null;
-        CommonTree WS62_tree=null;
+        CommonTree WS66_tree=null;
+        CommonTree NOT_EQUAL67_tree=null;
+        CommonTree WS68_tree=null;
 
         try {
-            // src/riemann/Query.g:60:2: ( field ( WS )* NOT_EQUAL ( WS )* value )
-            // src/riemann/Query.g:60:4: field ( WS )* NOT_EQUAL ( WS )* value
+            // src/riemann/Query.g:64:2: ( field ( WS )* NOT_EQUAL ( WS )* value )
+            // src/riemann/Query.g:64:4: field ( WS )* NOT_EQUAL ( WS )* value
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            pushFollow(FOLLOW_field_in_not_equal436);
-            field59=field();
+            pushFollow(FOLLOW_field_in_not_equal469);
+            field65=field();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, field59.getTree());
-            // src/riemann/Query.g:60:10: ( WS )*
-            loop23:
+            adaptor.addChild(root_0, field65.getTree());
+            // src/riemann/Query.g:64:10: ( WS )*
+            loop25:
             do {
-                int alt23=2;
-                int LA23_0 = input.LA(1);
+                int alt25=2;
+                int LA25_0 = input.LA(1);
 
-                if ( (LA23_0==WS) ) {
-                    alt23=1;
+                if ( (LA25_0==WS) ) {
+                    alt25=1;
                 }
 
 
-                switch (alt23) {
+                switch (alt25) {
             	case 1 :
-            	    // src/riemann/Query.g:60:10: WS
+            	    // src/riemann/Query.g:64:10: WS
             	    {
-            	    WS60=(Token)match(input,WS,FOLLOW_WS_in_not_equal438);
-            	    WS60_tree = (CommonTree)adaptor.create(WS60);
-            	    adaptor.addChild(root_0, WS60_tree);
+            	    WS66=(Token)match(input,WS,FOLLOW_WS_in_not_equal471); 
+            	    WS66_tree = (CommonTree)adaptor.create(WS66);
+            	    adaptor.addChild(root_0, WS66_tree);
 
 
             	    }
             	    break;
 
             	default :
-            	    break loop23;
+            	    break loop25;
                 }
             } while (true);
 
-            NOT_EQUAL61=(Token)match(input,NOT_EQUAL,FOLLOW_NOT_EQUAL_in_not_equal441);
-            NOT_EQUAL61_tree = (CommonTree)adaptor.create(NOT_EQUAL61);
-            root_0 = (CommonTree)adaptor.becomeRoot(NOT_EQUAL61_tree, root_0);
+            NOT_EQUAL67=(Token)match(input,NOT_EQUAL,FOLLOW_NOT_EQUAL_in_not_equal474); 
+            NOT_EQUAL67_tree = (CommonTree)adaptor.create(NOT_EQUAL67);
+            root_0 = (CommonTree)adaptor.becomeRoot(NOT_EQUAL67_tree, root_0);
 
-            // src/riemann/Query.g:60:25: ( WS )*
-            loop24:
+            // src/riemann/Query.g:64:25: ( WS )*
+            loop26:
             do {
-                int alt24=2;
-                int LA24_0 = input.LA(1);
+                int alt26=2;
+                int LA26_0 = input.LA(1);
 
-                if ( (LA24_0==WS) ) {
-                    alt24=1;
+                if ( (LA26_0==WS) ) {
+                    alt26=1;
                 }
 
 
-                switch (alt24) {
+                switch (alt26) {
             	case 1 :
-            	    // src/riemann/Query.g:60:25: WS
+            	    // src/riemann/Query.g:64:25: WS
             	    {
-            	    WS62=(Token)match(input,WS,FOLLOW_WS_in_not_equal444);
-            	    WS62_tree = (CommonTree)adaptor.create(WS62);
-            	    adaptor.addChild(root_0, WS62_tree);
+            	    WS68=(Token)match(input,WS,FOLLOW_WS_in_not_equal477); 
+            	    WS68_tree = (CommonTree)adaptor.create(WS68);
+            	    adaptor.addChild(root_0, WS68_tree);
 
 
             	    }
             	    break;
 
             	default :
-            	    break loop24;
+            	    break loop26;
                 }
             } while (true);
 
-            pushFollow(FOLLOW_value_in_not_equal447);
-            value63=value();
+            pushFollow(FOLLOW_value_in_not_equal480);
+            value69=value();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, value63.getTree());
+            adaptor.addChild(root_0, value69.getTree());
 
             }
 
@@ -1753,103 +1892,103 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "equal"
-    // src/riemann/Query.g:61:1: equal : field ( WS )* EQUAL ( WS )* value ;
+    // src/riemann/Query.g:65:1: equal : field ( WS )* EQUAL ( WS )* value ;
     public final QueryParser.equal_return equal() throws RecognitionException {
         QueryParser.equal_return retval = new QueryParser.equal_return();
         retval.start = input.LT(1);
 
         CommonTree root_0 = null;
 
-        Token WS65=null;
-        Token EQUAL66=null;
-        Token WS67=null;
-        QueryParser.field_return field64 = null;
+        Token WS71=null;
+        Token EQUAL72=null;
+        Token WS73=null;
+        QueryParser.field_return field70 = null;
 
-        QueryParser.value_return value68 = null;
+        QueryParser.value_return value74 = null;
 
 
-        CommonTree WS65_tree=null;
-        CommonTree EQUAL66_tree=null;
-        CommonTree WS67_tree=null;
+        CommonTree WS71_tree=null;
+        CommonTree EQUAL72_tree=null;
+        CommonTree WS73_tree=null;
 
         try {
-            // src/riemann/Query.g:61:7: ( field ( WS )* EQUAL ( WS )* value )
-            // src/riemann/Query.g:61:9: field ( WS )* EQUAL ( WS )* value
+            // src/riemann/Query.g:65:7: ( field ( WS )* EQUAL ( WS )* value )
+            // src/riemann/Query.g:65:9: field ( WS )* EQUAL ( WS )* value
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            pushFollow(FOLLOW_field_in_equal455);
-            field64=field();
+            pushFollow(FOLLOW_field_in_equal488);
+            field70=field();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, field64.getTree());
-            // src/riemann/Query.g:61:15: ( WS )*
-            loop25:
+            adaptor.addChild(root_0, field70.getTree());
+            // src/riemann/Query.g:65:15: ( WS )*
+            loop27:
             do {
-                int alt25=2;
-                int LA25_0 = input.LA(1);
+                int alt27=2;
+                int LA27_0 = input.LA(1);
 
-                if ( (LA25_0==WS) ) {
-                    alt25=1;
+                if ( (LA27_0==WS) ) {
+                    alt27=1;
                 }
 
 
-                switch (alt25) {
+                switch (alt27) {
             	case 1 :
-            	    // src/riemann/Query.g:61:15: WS
+            	    // src/riemann/Query.g:65:15: WS
             	    {
-            	    WS65=(Token)match(input,WS,FOLLOW_WS_in_equal457);
-            	    WS65_tree = (CommonTree)adaptor.create(WS65);
-            	    adaptor.addChild(root_0, WS65_tree);
+            	    WS71=(Token)match(input,WS,FOLLOW_WS_in_equal490); 
+            	    WS71_tree = (CommonTree)adaptor.create(WS71);
+            	    adaptor.addChild(root_0, WS71_tree);
 
 
             	    }
             	    break;
 
             	default :
-            	    break loop25;
+            	    break loop27;
                 }
             } while (true);
 
-            EQUAL66=(Token)match(input,EQUAL,FOLLOW_EQUAL_in_equal460);
-            EQUAL66_tree = (CommonTree)adaptor.create(EQUAL66);
-            root_0 = (CommonTree)adaptor.becomeRoot(EQUAL66_tree, root_0);
+            EQUAL72=(Token)match(input,EQUAL,FOLLOW_EQUAL_in_equal493); 
+            EQUAL72_tree = (CommonTree)adaptor.create(EQUAL72);
+            root_0 = (CommonTree)adaptor.becomeRoot(EQUAL72_tree, root_0);
 
-            // src/riemann/Query.g:61:26: ( WS )*
-            loop26:
+            // src/riemann/Query.g:65:26: ( WS )*
+            loop28:
             do {
-                int alt26=2;
-                int LA26_0 = input.LA(1);
+                int alt28=2;
+                int LA28_0 = input.LA(1);
 
-                if ( (LA26_0==WS) ) {
-                    alt26=1;
+                if ( (LA28_0==WS) ) {
+                    alt28=1;
                 }
 
 
-                switch (alt26) {
+                switch (alt28) {
             	case 1 :
-            	    // src/riemann/Query.g:61:26: WS
+            	    // src/riemann/Query.g:65:26: WS
             	    {
-            	    WS67=(Token)match(input,WS,FOLLOW_WS_in_equal463);
-            	    WS67_tree = (CommonTree)adaptor.create(WS67);
-            	    adaptor.addChild(root_0, WS67_tree);
+            	    WS73=(Token)match(input,WS,FOLLOW_WS_in_equal496); 
+            	    WS73_tree = (CommonTree)adaptor.create(WS73);
+            	    adaptor.addChild(root_0, WS73_tree);
 
 
             	    }
             	    break;
 
             	default :
-            	    break loop26;
+            	    break loop28;
                 }
             } while (true);
 
-            pushFollow(FOLLOW_value_in_equal466);
-            value68=value();
+            pushFollow(FOLLOW_value_in_equal499);
+            value74=value();
 
             state._fsp--;
 
-            adaptor.addChild(root_0, value68.getTree());
+            adaptor.addChild(root_0, value74.getTree());
 
             }
 
@@ -1877,62 +2016,62 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "tagged"
-    // src/riemann/Query.g:63:1: tagged : TAGGED ( WS )* String ;
+    // src/riemann/Query.g:67:1: tagged : TAGGED ( WS )* String ;
     public final QueryParser.tagged_return tagged() throws RecognitionException {
         QueryParser.tagged_return retval = new QueryParser.tagged_return();
         retval.start = input.LT(1);
 
         CommonTree root_0 = null;
 
-        Token TAGGED69=null;
-        Token WS70=null;
-        Token String71=null;
+        Token TAGGED75=null;
+        Token WS76=null;
+        Token String77=null;
 
-        CommonTree TAGGED69_tree=null;
-        CommonTree WS70_tree=null;
-        CommonTree String71_tree=null;
+        CommonTree TAGGED75_tree=null;
+        CommonTree WS76_tree=null;
+        CommonTree String77_tree=null;
 
         try {
-            // src/riemann/Query.g:63:8: ( TAGGED ( WS )* String )
-            // src/riemann/Query.g:63:10: TAGGED ( WS )* String
+            // src/riemann/Query.g:67:8: ( TAGGED ( WS )* String )
+            // src/riemann/Query.g:67:10: TAGGED ( WS )* String
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            TAGGED69=(Token)match(input,TAGGED,FOLLOW_TAGGED_in_tagged474);
-            TAGGED69_tree = (CommonTree)adaptor.create(TAGGED69);
-            root_0 = (CommonTree)adaptor.becomeRoot(TAGGED69_tree, root_0);
+            TAGGED75=(Token)match(input,TAGGED,FOLLOW_TAGGED_in_tagged507); 
+            TAGGED75_tree = (CommonTree)adaptor.create(TAGGED75);
+            root_0 = (CommonTree)adaptor.becomeRoot(TAGGED75_tree, root_0);
 
-            // src/riemann/Query.g:63:18: ( WS )*
-            loop27:
+            // src/riemann/Query.g:67:18: ( WS )*
+            loop29:
             do {
-                int alt27=2;
-                int LA27_0 = input.LA(1);
+                int alt29=2;
+                int LA29_0 = input.LA(1);
 
-                if ( (LA27_0==WS) ) {
-                    alt27=1;
+                if ( (LA29_0==WS) ) {
+                    alt29=1;
                 }
 
 
-                switch (alt27) {
+                switch (alt29) {
             	case 1 :
-            	    // src/riemann/Query.g:63:18: WS
+            	    // src/riemann/Query.g:67:18: WS
             	    {
-            	    WS70=(Token)match(input,WS,FOLLOW_WS_in_tagged477);
-            	    WS70_tree = (CommonTree)adaptor.create(WS70);
-            	    adaptor.addChild(root_0, WS70_tree);
+            	    WS76=(Token)match(input,WS,FOLLOW_WS_in_tagged510); 
+            	    WS76_tree = (CommonTree)adaptor.create(WS76);
+            	    adaptor.addChild(root_0, WS76_tree);
 
 
             	    }
             	    break;
 
             	default :
-            	    break loop27;
+            	    break loop29;
                 }
             } while (true);
 
-            String71=(Token)match(input,String,FOLLOW_String_in_tagged480);
-            String71_tree = (CommonTree)adaptor.create(String71);
-            adaptor.addChild(root_0, String71_tree);
+            String77=(Token)match(input,String,FOLLOW_String_in_tagged513); 
+            String77_tree = (CommonTree)adaptor.create(String77);
+            adaptor.addChild(root_0, String77_tree);
 
 
             }
@@ -1961,137 +2100,137 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "value"
-    // src/riemann/Query.g:65:1: value : ( String | t | f | nil | INT | FLOAT ) ;
+    // src/riemann/Query.g:69:1: value : ( String | t | f | nil | INT | FLOAT ) ;
     public final QueryParser.value_return value() throws RecognitionException {
         QueryParser.value_return retval = new QueryParser.value_return();
         retval.start = input.LT(1);
 
         CommonTree root_0 = null;
 
-        Token String72=null;
-        Token INT76=null;
-        Token FLOAT77=null;
-        QueryParser.t_return t73 = null;
+        Token String78=null;
+        Token INT82=null;
+        Token FLOAT83=null;
+        QueryParser.t_return t79 = null;
 
-        QueryParser.f_return f74 = null;
+        QueryParser.f_return f80 = null;
 
-        QueryParser.nil_return nil75 = null;
+        QueryParser.nil_return nil81 = null;
 
 
-        CommonTree String72_tree=null;
-        CommonTree INT76_tree=null;
-        CommonTree FLOAT77_tree=null;
+        CommonTree String78_tree=null;
+        CommonTree INT82_tree=null;
+        CommonTree FLOAT83_tree=null;
 
         try {
-            // src/riemann/Query.g:65:7: ( ( String | t | f | nil | INT | FLOAT ) )
-            // src/riemann/Query.g:65:10: ( String | t | f | nil | INT | FLOAT )
+            // src/riemann/Query.g:69:7: ( ( String | t | f | nil | INT | FLOAT ) )
+            // src/riemann/Query.g:69:10: ( String | t | f | nil | INT | FLOAT )
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            // src/riemann/Query.g:65:10: ( String | t | f | nil | INT | FLOAT )
-            int alt28=6;
+            // src/riemann/Query.g:69:10: ( String | t | f | nil | INT | FLOAT )
+            int alt30=6;
             switch ( input.LA(1) ) {
             case String:
                 {
-                alt28=1;
-                }
-                break;
-            case 26:
-                {
-                alt28=2;
+                alt30=1;
                 }
                 break;
             case 27:
                 {
-                alt28=3;
+                alt30=2;
                 }
                 break;
             case 28:
-            case 29:
                 {
-                alt28=4;
+                alt30=3;
+                }
+                break;
+            case 29:
+            case 30:
+                {
+                alt30=4;
                 }
                 break;
             case INT:
                 {
-                alt28=5;
+                alt30=5;
                 }
                 break;
             case FLOAT:
                 {
-                alt28=6;
+                alt30=6;
                 }
                 break;
             default:
                 NoViableAltException nvae =
-                    new NoViableAltException("", 28, 0, input);
+                    new NoViableAltException("", 30, 0, input);
 
                 throw nvae;
             }
 
-            switch (alt28) {
+            switch (alt30) {
                 case 1 :
-                    // src/riemann/Query.g:65:11: String
+                    // src/riemann/Query.g:69:11: String
                     {
-                    String72=(Token)match(input,String,FOLLOW_String_in_value490);
-                    String72_tree = (CommonTree)adaptor.create(String72);
-                    adaptor.addChild(root_0, String72_tree);
+                    String78=(Token)match(input,String,FOLLOW_String_in_value523); 
+                    String78_tree = (CommonTree)adaptor.create(String78);
+                    adaptor.addChild(root_0, String78_tree);
 
 
                     }
                     break;
                 case 2 :
-                    // src/riemann/Query.g:65:20: t
+                    // src/riemann/Query.g:69:20: t
                     {
-                    pushFollow(FOLLOW_t_in_value494);
-                    t73=t();
+                    pushFollow(FOLLOW_t_in_value527);
+                    t79=t();
 
                     state._fsp--;
 
-                    adaptor.addChild(root_0, t73.getTree());
+                    adaptor.addChild(root_0, t79.getTree());
 
                     }
                     break;
                 case 3 :
-                    // src/riemann/Query.g:65:24: f
+                    // src/riemann/Query.g:69:24: f
                     {
-                    pushFollow(FOLLOW_f_in_value498);
-                    f74=f();
+                    pushFollow(FOLLOW_f_in_value531);
+                    f80=f();
 
                     state._fsp--;
 
-                    adaptor.addChild(root_0, f74.getTree());
+                    adaptor.addChild(root_0, f80.getTree());
 
                     }
                     break;
                 case 4 :
-                    // src/riemann/Query.g:65:28: nil
+                    // src/riemann/Query.g:69:28: nil
                     {
-                    pushFollow(FOLLOW_nil_in_value502);
-                    nil75=nil();
+                    pushFollow(FOLLOW_nil_in_value535);
+                    nil81=nil();
 
                     state._fsp--;
 
-                    adaptor.addChild(root_0, nil75.getTree());
+                    adaptor.addChild(root_0, nil81.getTree());
 
                     }
                     break;
                 case 5 :
-                    // src/riemann/Query.g:65:34: INT
+                    // src/riemann/Query.g:69:34: INT
                     {
-                    INT76=(Token)match(input,INT,FOLLOW_INT_in_value506);
-                    INT76_tree = (CommonTree)adaptor.create(INT76);
-                    adaptor.addChild(root_0, INT76_tree);
+                    INT82=(Token)match(input,INT,FOLLOW_INT_in_value539); 
+                    INT82_tree = (CommonTree)adaptor.create(INT82);
+                    adaptor.addChild(root_0, INT82_tree);
 
 
                     }
                     break;
                 case 6 :
-                    // src/riemann/Query.g:65:40: FLOAT
+                    // src/riemann/Query.g:69:40: FLOAT
                     {
-                    FLOAT77=(Token)match(input,FLOAT,FOLLOW_FLOAT_in_value510);
-                    FLOAT77_tree = (CommonTree)adaptor.create(FLOAT77);
-                    adaptor.addChild(root_0, FLOAT77_tree);
+                    FLOAT83=(Token)match(input,FLOAT,FOLLOW_FLOAT_in_value543); 
+                    FLOAT83_tree = (CommonTree)adaptor.create(FLOAT83);
+                    adaptor.addChild(root_0, FLOAT83_tree);
 
 
                     }
@@ -2126,26 +2265,26 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "t"
-    // src/riemann/Query.g:67:1: t : 'true' ;
+    // src/riemann/Query.g:71:1: t : 'true' ;
     public final QueryParser.t_return t() throws RecognitionException {
         QueryParser.t_return retval = new QueryParser.t_return();
         retval.start = input.LT(1);
 
         CommonTree root_0 = null;
 
-        Token string_literal78=null;
+        Token string_literal84=null;
 
-        CommonTree string_literal78_tree=null;
+        CommonTree string_literal84_tree=null;
 
         try {
-            // src/riemann/Query.g:67:3: ( 'true' )
-            // src/riemann/Query.g:67:5: 'true'
+            // src/riemann/Query.g:71:3: ( 'true' )
+            // src/riemann/Query.g:71:5: 'true'
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            string_literal78=(Token)match(input,26,FOLLOW_26_in_t519);
-            string_literal78_tree = (CommonTree)adaptor.create(string_literal78);
-            adaptor.addChild(root_0, string_literal78_tree);
+            string_literal84=(Token)match(input,27,FOLLOW_27_in_t552); 
+            string_literal84_tree = (CommonTree)adaptor.create(string_literal84);
+            adaptor.addChild(root_0, string_literal84_tree);
 
 
             }
@@ -2174,26 +2313,26 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "f"
-    // src/riemann/Query.g:68:1: f : 'false' ;
+    // src/riemann/Query.g:72:1: f : 'false' ;
     public final QueryParser.f_return f() throws RecognitionException {
         QueryParser.f_return retval = new QueryParser.f_return();
         retval.start = input.LT(1);
 
         CommonTree root_0 = null;
 
-        Token string_literal79=null;
+        Token string_literal85=null;
 
-        CommonTree string_literal79_tree=null;
+        CommonTree string_literal85_tree=null;
 
         try {
-            // src/riemann/Query.g:68:3: ( 'false' )
-            // src/riemann/Query.g:68:5: 'false'
+            // src/riemann/Query.g:72:3: ( 'false' )
+            // src/riemann/Query.g:72:5: 'false'
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            string_literal79=(Token)match(input,27,FOLLOW_27_in_f526);
-            string_literal79_tree = (CommonTree)adaptor.create(string_literal79);
-            adaptor.addChild(root_0, string_literal79_tree);
+            string_literal85=(Token)match(input,28,FOLLOW_28_in_f559); 
+            string_literal85_tree = (CommonTree)adaptor.create(string_literal85);
+            adaptor.addChild(root_0, string_literal85_tree);
 
 
             }
@@ -2222,27 +2361,27 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "nil"
-    // src/riemann/Query.g:69:1: nil : ( 'null' | 'nil' );
+    // src/riemann/Query.g:73:1: nil : ( 'null' | 'nil' );
     public final QueryParser.nil_return nil() throws RecognitionException {
         QueryParser.nil_return retval = new QueryParser.nil_return();
         retval.start = input.LT(1);
 
         CommonTree root_0 = null;
 
-        Token set80=null;
+        Token set86=null;
 
-        CommonTree set80_tree=null;
+        CommonTree set86_tree=null;
 
         try {
-            // src/riemann/Query.g:69:5: ( 'null' | 'nil' )
+            // src/riemann/Query.g:73:5: ( 'null' | 'nil' )
             // src/riemann/Query.g:
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            set80=(Token)input.LT(1);
-            if ( (input.LA(1)>=28 && input.LA(1)<=29) ) {
+            set86=(Token)input.LT(1);
+            if ( (input.LA(1)>=29 && input.LA(1)<=30) ) {
                 input.consume();
-                adaptor.addChild(root_0, (CommonTree)adaptor.create(set80));
+                adaptor.addChild(root_0, (CommonTree)adaptor.create(set86));
                 state.errorRecovery=false;
             }
             else {
@@ -2277,27 +2416,27 @@ public class QueryParser extends Parser {
     };
 
     // $ANTLR start "field"
-    // src/riemann/Query.g:71:1: field : ( 'host' | 'service' | 'state' | 'description' | 'metric_f' | 'metric' | 'ttl' | 'time' ) ;
+    // src/riemann/Query.g:75:1: field : ( 'host' | 'service' | 'state' | 'description' | 'metric_f' | 'metric' | 'ttl' | 'time' ) ;
     public final QueryParser.field_return field() throws RecognitionException {
         QueryParser.field_return retval = new QueryParser.field_return();
         retval.start = input.LT(1);
 
         CommonTree root_0 = null;
 
-        Token set81=null;
+        Token set87=null;
 
-        CommonTree set81_tree=null;
+        CommonTree set87_tree=null;
 
         try {
-            // src/riemann/Query.g:71:7: ( ( 'host' | 'service' | 'state' | 'description' | 'metric_f' | 'metric' | 'ttl' | 'time' ) )
-            // src/riemann/Query.g:71:9: ( 'host' | 'service' | 'state' | 'description' | 'metric_f' | 'metric' | 'ttl' | 'time' )
+            // src/riemann/Query.g:75:7: ( ( 'host' | 'service' | 'state' | 'description' | 'metric_f' | 'metric' | 'ttl' | 'time' ) )
+            // src/riemann/Query.g:75:9: ( 'host' | 'service' | 'state' | 'description' | 'metric_f' | 'metric' | 'ttl' | 'time' )
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            set81=(Token)input.LT(1);
-            if ( (input.LA(1)>=30 && input.LA(1)<=37) ) {
+            set87=(Token)input.LT(1);
+            if ( (input.LA(1)>=31 && input.LA(1)<=38) ) {
                 input.consume();
-                adaptor.addChild(root_0, (CommonTree)adaptor.create(set81));
+                adaptor.addChild(root_0, (CommonTree)adaptor.create(set87));
                 state.errorRecovery=false;
             }
             else {
@@ -2338,14 +2477,14 @@ public class QueryParser extends Parser {
     static final String DFA8_minS =
         "\2\4\2\uffff";
     static final String DFA8_maxS =
-        "\1\31\1\17\2\uffff";
+        "\1\32\1\20\2\uffff";
     static final String DFA8_acceptS =
         "\2\uffff\1\2\1\1";
     static final String DFA8_specialS =
         "\4\uffff}>";
     static final String[] DFA8_transitionS = {
-            "\1\3\1\2\11\uffff\1\1\11\uffff\1\2",
-            "\1\3\1\2\11\uffff\1\1",
+            "\1\3\1\2\12\uffff\1\1\11\uffff\1\2",
+            "\1\3\1\2\12\uffff\1\1",
             "",
             ""
     };
@@ -2380,29 +2519,31 @@ public class QueryParser extends Parser {
             this.transition = DFA8_transition;
         }
         public String getDescription() {
-            return "()* loopback of 29:23: ( ( WS )* AND ( WS )* ( not | primary ) )*";
+            return "()* loopback of 30:23: ( ( WS )* AND ( WS )* ( not | primary ) )*";
         }
     }
     static final String DFA12_eotS =
-        "\16\uffff";
+        "\17\uffff";
     static final String DFA12_eofS =
-        "\16\uffff";
+        "\17\uffff";
     static final String DFA12_minS =
-        "\1\16\4\uffff\2\7\7\uffff";
+        "\1\17\4\uffff\2\7\10\uffff";
     static final String DFA12_maxS =
-        "\1\45\4\uffff\2\17\7\uffff";
+        "\1\46\4\uffff\2\20\10\uffff";
     static final String DFA12_acceptS =
-        "\1\uffff\1\1\1\2\1\3\1\4\2\uffff\1\10\1\11\1\6\1\13\1\5\1\7\1\12";
+        "\1\uffff\1\1\1\2\1\3\1\4\2\uffff\1\11\1\6\1\13\1\12\1\10\1\14\1"+
+        "\7\1\5";
     static final String DFA12_specialS =
-        "\16\uffff}>";
+        "\17\uffff}>";
     static final String[] DFA12_transitionS = {
             "\1\4\13\uffff\1\1\1\2\2\3\10\5",
             "",
             "",
             "",
             "",
-            "\1\13\1\15\1\12\1\11\1\14\1\7\1\10\1\uffff\1\6",
-            "\1\13\1\15\1\12\1\11\1\14\1\7\1\10\1\uffff\1\6",
+            "\1\16\1\10\1\11\1\14\1\15\1\13\1\7\1\12\1\uffff\1\6",
+            "\1\16\1\10\1\11\1\14\1\15\1\13\1\7\1\12\1\uffff\1\6",
+            "",
             "",
             "",
             "",
@@ -2442,91 +2583,97 @@ public class QueryParser extends Parser {
             this.transition = DFA12_transition;
         }
         public String getDescription() {
-            return "40:10: ( t | f | nil | tagged | approximately | lesser | lesser_equal | greater | greater_equal | not_equal | equal )";
+            return "41:10: ( t | f | nil | tagged | approximately | regex_match | lesser | lesser_equal | greater | greater_equal | not_equal | equal )";
         }
     }
+ 
 
-
-    public static final BitSet FOLLOW_or_in_expr137 = new BitSet(new long[]{0x0000000000000000L});
-    public static final BitSet FOLLOW_EOF_in_expr139 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_and_in_or152 = new BitSet(new long[]{0x0000000000008022L});
-    public static final BitSet FOLLOW_WS_in_or155 = new BitSet(new long[]{0x0000000000008020L});
-    public static final BitSet FOLLOW_OR_in_or158 = new BitSet(new long[]{0x0000003FFD00C040L});
-    public static final BitSet FOLLOW_WS_in_or161 = new BitSet(new long[]{0x0000003FFD00C040L});
-    public static final BitSet FOLLOW_and_in_or164 = new BitSet(new long[]{0x0000000000008022L});
-    public static final BitSet FOLLOW_not_in_and175 = new BitSet(new long[]{0x0000000000008012L});
-    public static final BitSet FOLLOW_primary_in_and179 = new BitSet(new long[]{0x0000000000008012L});
-    public static final BitSet FOLLOW_WS_in_and183 = new BitSet(new long[]{0x0000000000008010L});
-    public static final BitSet FOLLOW_AND_in_and186 = new BitSet(new long[]{0x0000003FFD00C040L});
-    public static final BitSet FOLLOW_WS_in_and189 = new BitSet(new long[]{0x0000003FFD00C040L});
-    public static final BitSet FOLLOW_not_in_and193 = new BitSet(new long[]{0x0000000000008012L});
-    public static final BitSet FOLLOW_primary_in_and197 = new BitSet(new long[]{0x0000000000008012L});
-    public static final BitSet FOLLOW_NOT_in_not208 = new BitSet(new long[]{0x0000003FFD00C040L});
-    public static final BitSet FOLLOW_WS_in_not211 = new BitSet(new long[]{0x0000003FFD00C040L});
-    public static final BitSet FOLLOW_not_in_not215 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_primary_in_not219 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_24_in_primary236 = new BitSet(new long[]{0x0000003FFD00C040L});
-    public static final BitSet FOLLOW_or_in_primary238 = new BitSet(new long[]{0x0000000002000000L});
-    public static final BitSet FOLLOW_25_in_primary240 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_simple_in_primary254 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_t_in_simple274 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_f_in_simple278 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_nil_in_simple282 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_tagged_in_simple288 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_approximately_in_simple294 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_lesser_in_simple300 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_lesser_equal_in_simple306 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_greater_in_simple312 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_greater_equal_in_simple318 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_not_equal_in_simple324 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_equal_in_simple330 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_field_in_approximately343 = new BitSet(new long[]{0x0000000000008080L});
-    public static final BitSet FOLLOW_WS_in_approximately345 = new BitSet(new long[]{0x0000000000008080L});
-    public static final BitSet FOLLOW_APPROXIMATELY_in_approximately348 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_WS_in_approximately351 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_value_in_approximately354 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_field_in_lesser361 = new BitSet(new long[]{0x0000000000008400L});
-    public static final BitSet FOLLOW_WS_in_lesser363 = new BitSet(new long[]{0x0000000000008400L});
-    public static final BitSet FOLLOW_LESSER_in_lesser366 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_WS_in_lesser369 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_value_in_lesser372 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_field_in_lesser_equal380 = new BitSet(new long[]{0x0000000000008800L});
-    public static final BitSet FOLLOW_WS_in_lesser_equal382 = new BitSet(new long[]{0x0000000000008800L});
-    public static final BitSet FOLLOW_LESSER_EQUAL_in_lesser_equal385 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_WS_in_lesser_equal388 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_value_in_lesser_equal391 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_field_in_greater398 = new BitSet(new long[]{0x0000000000009000L});
-    public static final BitSet FOLLOW_WS_in_greater400 = new BitSet(new long[]{0x0000000000009000L});
-    public static final BitSet FOLLOW_GREATER_in_greater403 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_WS_in_greater406 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_value_in_greater409 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_field_in_greater_equal417 = new BitSet(new long[]{0x000000000000A000L});
-    public static final BitSet FOLLOW_WS_in_greater_equal419 = new BitSet(new long[]{0x000000000000A000L});
-    public static final BitSet FOLLOW_GREATER_EQUAL_in_greater_equal422 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_WS_in_greater_equal425 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_value_in_greater_equal428 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_field_in_not_equal436 = new BitSet(new long[]{0x0000000000008100L});
-    public static final BitSet FOLLOW_WS_in_not_equal438 = new BitSet(new long[]{0x0000000000008100L});
-    public static final BitSet FOLLOW_NOT_EQUAL_in_not_equal441 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_WS_in_not_equal444 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_value_in_not_equal447 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_field_in_equal455 = new BitSet(new long[]{0x0000000000008200L});
-    public static final BitSet FOLLOW_WS_in_equal457 = new BitSet(new long[]{0x0000000000008200L});
-    public static final BitSet FOLLOW_EQUAL_in_equal460 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_WS_in_equal463 = new BitSet(new long[]{0x000000003C078000L});
-    public static final BitSet FOLLOW_value_in_equal466 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_TAGGED_in_tagged474 = new BitSet(new long[]{0x0000000000018000L});
-    public static final BitSet FOLLOW_WS_in_tagged477 = new BitSet(new long[]{0x0000000000018000L});
-    public static final BitSet FOLLOW_String_in_tagged480 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_String_in_value490 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_t_in_value494 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_f_in_value498 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_nil_in_value502 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_INT_in_value506 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_FLOAT_in_value510 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_26_in_t519 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_27_in_f526 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_or_in_expr145 = new BitSet(new long[]{0x0000000000000000L});
+    public static final BitSet FOLLOW_EOF_in_expr147 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_and_in_or160 = new BitSet(new long[]{0x0000000000010022L});
+    public static final BitSet FOLLOW_WS_in_or163 = new BitSet(new long[]{0x0000000000010020L});
+    public static final BitSet FOLLOW_OR_in_or166 = new BitSet(new long[]{0x0000007FFA018040L});
+    public static final BitSet FOLLOW_WS_in_or169 = new BitSet(new long[]{0x0000007FFA018040L});
+    public static final BitSet FOLLOW_and_in_or172 = new BitSet(new long[]{0x0000000000010022L});
+    public static final BitSet FOLLOW_not_in_and183 = new BitSet(new long[]{0x0000000000010012L});
+    public static final BitSet FOLLOW_primary_in_and187 = new BitSet(new long[]{0x0000000000010012L});
+    public static final BitSet FOLLOW_WS_in_and191 = new BitSet(new long[]{0x0000000000010010L});
+    public static final BitSet FOLLOW_AND_in_and194 = new BitSet(new long[]{0x0000007FFA018040L});
+    public static final BitSet FOLLOW_WS_in_and197 = new BitSet(new long[]{0x0000007FFA018040L});
+    public static final BitSet FOLLOW_not_in_and201 = new BitSet(new long[]{0x0000000000010012L});
+    public static final BitSet FOLLOW_primary_in_and205 = new BitSet(new long[]{0x0000000000010012L});
+    public static final BitSet FOLLOW_NOT_in_not216 = new BitSet(new long[]{0x0000007FFA018040L});
+    public static final BitSet FOLLOW_WS_in_not219 = new BitSet(new long[]{0x0000007FFA018040L});
+    public static final BitSet FOLLOW_not_in_not223 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_primary_in_not227 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_25_in_primary244 = new BitSet(new long[]{0x0000007FFA018040L});
+    public static final BitSet FOLLOW_or_in_primary246 = new BitSet(new long[]{0x0000000004000000L});
+    public static final BitSet FOLLOW_26_in_primary248 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_simple_in_primary262 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_t_in_simple282 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_f_in_simple286 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_nil_in_simple290 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_tagged_in_simple296 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_approximately_in_simple302 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_regex_match_in_simple308 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_lesser_in_simple314 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_lesser_equal_in_simple320 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_greater_in_simple326 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_greater_equal_in_simple332 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_not_equal_in_simple338 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_equal_in_simple344 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_field_in_approximately357 = new BitSet(new long[]{0x0000000000010080L});
+    public static final BitSet FOLLOW_WS_in_approximately359 = new BitSet(new long[]{0x0000000000010080L});
+    public static final BitSet FOLLOW_APPROXIMATELY_in_approximately362 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_WS_in_approximately365 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_value_in_approximately368 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_field_in_regex_match376 = new BitSet(new long[]{0x0000000000010100L});
+    public static final BitSet FOLLOW_WS_in_regex_match378 = new BitSet(new long[]{0x0000000000010100L});
+    public static final BitSet FOLLOW_REGEX_MATCH_in_regex_match381 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_WS_in_regex_match384 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_value_in_regex_match387 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_field_in_lesser394 = new BitSet(new long[]{0x0000000000010800L});
+    public static final BitSet FOLLOW_WS_in_lesser396 = new BitSet(new long[]{0x0000000000010800L});
+    public static final BitSet FOLLOW_LESSER_in_lesser399 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_WS_in_lesser402 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_value_in_lesser405 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_field_in_lesser_equal413 = new BitSet(new long[]{0x0000000000011000L});
+    public static final BitSet FOLLOW_WS_in_lesser_equal415 = new BitSet(new long[]{0x0000000000011000L});
+    public static final BitSet FOLLOW_LESSER_EQUAL_in_lesser_equal418 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_WS_in_lesser_equal421 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_value_in_lesser_equal424 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_field_in_greater431 = new BitSet(new long[]{0x0000000000012000L});
+    public static final BitSet FOLLOW_WS_in_greater433 = new BitSet(new long[]{0x0000000000012000L});
+    public static final BitSet FOLLOW_GREATER_in_greater436 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_WS_in_greater439 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_value_in_greater442 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_field_in_greater_equal450 = new BitSet(new long[]{0x0000000000014000L});
+    public static final BitSet FOLLOW_WS_in_greater_equal452 = new BitSet(new long[]{0x0000000000014000L});
+    public static final BitSet FOLLOW_GREATER_EQUAL_in_greater_equal455 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_WS_in_greater_equal458 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_value_in_greater_equal461 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_field_in_not_equal469 = new BitSet(new long[]{0x0000000000010200L});
+    public static final BitSet FOLLOW_WS_in_not_equal471 = new BitSet(new long[]{0x0000000000010200L});
+    public static final BitSet FOLLOW_NOT_EQUAL_in_not_equal474 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_WS_in_not_equal477 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_value_in_not_equal480 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_field_in_equal488 = new BitSet(new long[]{0x0000000000010400L});
+    public static final BitSet FOLLOW_WS_in_equal490 = new BitSet(new long[]{0x0000000000010400L});
+    public static final BitSet FOLLOW_EQUAL_in_equal493 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_WS_in_equal496 = new BitSet(new long[]{0x00000000780F0000L});
+    public static final BitSet FOLLOW_value_in_equal499 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_TAGGED_in_tagged507 = new BitSet(new long[]{0x0000000000030000L});
+    public static final BitSet FOLLOW_WS_in_tagged510 = new BitSet(new long[]{0x0000000000030000L});
+    public static final BitSet FOLLOW_String_in_tagged513 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_String_in_value523 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_t_in_value527 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_f_in_value531 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_nil_in_value535 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_INT_in_value539 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_FLOAT_in_value543 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_27_in_t552 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_28_in_f559 = new BitSet(new long[]{0x0000000000000002L});
     public static final BitSet FOLLOW_set_in_nil0 = new BitSet(new long[]{0x0000000000000002L});
-    public static final BitSet FOLLOW_set_in_field545 = new BitSet(new long[]{0x0000000000000002L});
+    public static final BitSet FOLLOW_set_in_field578 = new BitSet(new long[]{0x0000000000000002L});
 
 }

--- a/src/riemann/query.clj
+++ b/src/riemann/query.clj
@@ -50,6 +50,8 @@
       "<="  (list 'when (first kids) (apply list '<= kids))
       "=~"  (list 'when (first kids) (list 're-find (make-regex (last kids))
                                            (first kids)))
+      "~="  (list 'when (first kids) (list 're-find (re-pattern (last kids))
+                                           (first kids)))
       "!="  (list 'not (apply list '= kids))
       "tagged"      (list 'when 'tags (list 'member? (first kids) 'tags))
       "("           :useless

--- a/test/riemann/test/query.clj
+++ b/test/riemann/test/query.clj
@@ -116,6 +116,11 @@
             [{:host "s."} {:host "foos."}]
             [{:host "a."} {:host "s.murf"} {}]))
 
+(deftest regexp
+         (f "host ~= \"foo?[1-9]+\""
+            [{:host "foo19"} {:host "foo1"} {:host "fo42"}]
+            [{:host "abc"} {:host "foo"} {:host "fooo42"} {}]))
+
 (deftest inequality
          (f "metric > 1e10"
             [{:metric 1e11}]


### PR DESCRIPTION
This fixes #124. The patch is a bit messy due to QueryLexer.java and QueryParser.java getting regenerated, but other than those two, I think it is pretty simple.
