### PR TITLE
Load hipchat into riemann namespace

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -29,6 +29,7 @@
         [riemann.campfire :only [campfire]]
         [riemann.librato :only [librato-metrics]]
         [riemann.nagios :only [nagios]]
+        [riemann.hipchat :only [hipchat]]
         riemann.streams))
 
 (def core "The currently running core."


### PR DESCRIPTION
When trying to use hipchat with basic config:

``` clj
(let [host "127.0.0.1"]
  (tcp-server :host host)
  (udp-server :host host)
  (ws-server  :host host))

(def hc (hipchat {:token "..."
                   :room "12345"
                   :from "Alert Robot"
                   :notify 1}))
(periodically-expire 5)
(let [index (default :ttl 300 (update-index (index)))]
  (streams
    (match :host "test01"
           hc)))
```

I got an error:

```
INFO [2013-12-10 17:36:26,647] main - riemann.bin - PID 81295

ERROR [2013-12-10 17:36:26,674] main - riemann.bin - Couldn't start java.lang.RuntimeException: Unable to resolve symbol: hipchat in this context, compiling:(etc/riemann.config:6:9)
```

Loading hipchat into the namespace fixes it. 
