### PR TITLE
Use typo-version that exists in clojars

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
     [aleph "0.3.1"]
     [clj-http "0.7.7"]
     [cheshire "5.2.0"]
-    [clj-librato "0.0.4-SNAPSHOT"]
+    [clj-librato "0.0.4-SHAPSHOT"]
     [clj-time "0.6.0"]
     [clj-wallhack "1.0.1"]
     [com.boundary/high-scale-lib "1.0.3"]


### PR DESCRIPTION
This really should be a bug against aphyr/clj-librato I suppose, but `lein deps` and etc. are broken in 7da5cdbafd / #285 because the clojars repo for clj-librato has a typo and is named "0.0.4-SHAPSHOT", so this works around that.
