### PR TITLE
provide a default value for local host name lookups

### DIFF
--- a/src/riemann/common.clj
+++ b/src/riemann/common.clj
@@ -35,7 +35,11 @@
 (defn localhost
   "Returns the local host name."
   []
-  (.. InetAddress getLocalHost getHostName))
+  (try
+    (.. InetAddress getLocalHost getHostName)
+    (catch Exception _
+      (warn "could not determine local host name")
+      "localhost")))
 
 ; Times
 (defn time-at


### PR DESCRIPTION
This provides a better behavior for cases such as aphyr/riemann#233
