### PR TITLE
Use sysconfig for RPM bin

### DIFF
--- a/pkg/rpm/riemann
+++ b/pkg/rpm/riemann
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+if [ -f /etc/sysconfig/riemann ]; then
+    . /etc/sysconfig/riemann
+fi
+
+JAR="$EXTRA_CLASSPATH:/usr/lib/riemann/riemann.jar"
+CONFIG="/etc/riemann/riemann.config"
+AGGRESSIVE_OPTS="-XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSParallelRemarkEnabled -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -XX:+UseCompressedOops"
+
+usage()
+{
+  cat << EOF
+usage: $0 [-a] [java options ...] [config-file]
+
+Runs Riemann with the given configuration file.
+
+OPTIONS:
+  -h    Show this message
+  -a    Adds some default aggressive, nonportable JVM optimization flags.
+
+  Any unrecognized options (e.g. -XX:+UseParNewGC) will be passed on to java.
+EOF
+}
+
+OPTS=
+for arg in "$@"; do
+  case $arg in
+    "-a")
+      OPTS="$AGGRESSIVE_OPTS $OPTS"
+      ;;
+    "-h")
+      usage
+      exit 0
+      ;;
+    -*)
+      OPTS="$OPTS $arg"
+      ;;
+    *)
+      CONFIG="$arg"
+     ;;
+  esac
+done
+
+exec java $EXTRA_JAVA_OPTS $OPTS -cp "$JAR" riemann.bin "$CONFIG"

--- a/tasks/leiningen/fatrpm.clj
+++ b/tasks/leiningen/fatrpm.clj
@@ -109,7 +109,7 @@
         ; Binary
         {:directory "/usr/bin"
          :filemode "755"
-         :sources [(source (file (:root project) "pkg" "deb" "riemann")
+         :sources [(source (file (:root project) "pkg" "rpm" "riemann")
                            "riemann")]}
 
         ; Log dir


### PR DESCRIPTION
This adds a binary for the RPM package that uses `/etc/sysconfig/riemann` instead of the Debian `/etc/default/riemann`.
