### PR TITLE
Avoid NPEs in expiry by killing badly formed events

### DIFF
--- a/src/riemann/index.clj
+++ b/src/riemann/index.clj
@@ -54,7 +54,7 @@
 
       (expire [this]
               (filter
-                (fn [{:keys [ttl time] :or {ttl default-ttl} :as state}]
+                (fn [{:keys [ttl time] :or {ttl default-ttl time 0} :as state}]
                   (let [age (- (unix-time) time)]
                     (when (> age ttl)
                       (delete this state)


### PR DESCRIPTION
Without this, inputting an event with no time will generate NPEs in the expiry process. I think "timeless" events should just be wiped out of the index.
