### PR TITLE
make rpm default config same as deb/tar

### DIFF
--- a/pkg/rpm/riemann.config
+++ b/pkg/rpm/riemann.config
@@ -1,24 +1,21 @@
 ; -*- mode: clojure; -*-
 ; vim: filetype=clojure
 
-(logging/init :file "/var/log/riemann/riemann.log")
+(logging/init {:file "/var/log/riemann/riemann.log"})
 
 ; Listen on the local interface over TCP (5555), UDP (5555), and websockets
 ; (5556)
 (let [host "127.0.0.1"]
-  (tcp-server :host host)
-  (udp-server :host host)
-  (ws-server  :host host))
+  (tcp-server {:host host})
+  (udp-server {:host host})
+  (ws-server  {:host host}))
 
 ; Expire old events from the index every 5 seconds.
 (periodically-expire 5)
 
-; Keep events in the index for 5 minutes by default.
-(let [index (default :ttl 300 (update-index (index)))]
-
+(let [index (index)]
   ; Inbound events will be passed to these streams:
   (streams
-
     ; Index all events immediately.
     index
 
@@ -28,5 +25,4 @@
 
     ; Log expired events.
     (expired
-      (fn [event] (info "expired" event)))
-))
+      (fn [event] (info "expired" event)))))


### PR DESCRIPTION
Mostly syntax differences, except for (update-index) which is
obsolete now, and therefore removed.
