### PR TITLE
Make `riemann` callable from Scala/Java

### DIFF
--- a/src/riemann/bin.clj
+++ b/src/riemann/bin.clj
@@ -5,7 +5,7 @@
             riemann.time
             riemann.pubsub)
   (:use clojure.tools.logging)
-  (:gen-class :name riemann.bin))
+  (:gen-class :name riemann.bin_runner))
 
 (def config-file
   "The configuration file loaded by the bin tool" 


### PR DESCRIPTION
Hi

I need [this simple Scala project](https://github.com/alexander-myltsev/riemann-runner) to work. We need this approach for integration tests.

I made fix to project to avoid an compile-time error

```
package riemann contains object and package with same name: bin
one of them needs to be removed from classpath
  riemann.bin.main(Array("./etc/riemann.conf"))
  ^
```

I appreciate if you suggest me more `clojure` idiomatic way to do it.

P.s. A a hint on how to publish `riemann` to nexus and put it in `Scala-sbt` dependencies is also welcome. Now I am deploying 44M `uberjar` with `theladders/lein-uberjar-deploy "1.0.0"`. Any painless way?
