### PR TITLE
websockets: Minor bug fixes

### DIFF
--- a/src/riemann/transport/websockets.clj
+++ b/src/riemann/transport/websockets.clj
@@ -71,14 +71,14 @@
                                    ; latency
                                    (let [t1 (System/nanoTime)]
                                      (run-pipeline
-                                       {:error-handler (fn [_] (close ch))}
                                        (enqueue ch (event-to-json event))
                                        ; When the write completes, measure
                                        ; latency
                                        (fn measure [_]
                                          (metrics/update!
                                            (:out stats)
-                                           (- (System/nanoTime) t1)))))))
+                                           (- (System/nanoTime) t1)))
+                                       {:error-handler (fn [_] (close ch))}))))
 
                                true)]
       (info "New websocket subscription to" topic ":" query)
@@ -188,16 +188,10 @@
           (info "Unknown URI " (:uri req) ", closing")
           (close ch)))
 
-    ; Route request
-    (condp re-matches (:uri req)
-      #"/events/?"       (put-events-handler @core stats ch req)
-      #"/index/?"        (ws-index-handler @core stats ch req)
-      #"/pubsub/[^/]+/?" (ws-pubsub-handler @core stats ch req)
-      (do
-        (info "Unknown URI " (:uri req) ", closing")
-        (close ch)))
       (catch Throwable t
-        (warn t "ws-handler caught; closing websocket connection.")))))
+        (do
+          (warn t "ws-handler caught; closing websocket connection.")
+          (close ch))))))
 
 (defrecord WebsocketServer [host port core server stats]
   ServiceEquiv


### PR DESCRIPTION
- Removed accidental duplicate of routes.
- Close channel in exception handler.
- :error-handler has to be non-first argument to `run-pipeline`.
