### PR TITLE
Experimental support for more scalable coalesce

### DIFF
--- a/test/riemann/streams_test.clj
+++ b/test/riemann/streams_test.clj
@@ -1258,27 +1258,34 @@
                s (coalesce #(reset! out %))
                a1 {:service :a :state "one" :time 0}
                b1 {:service :b :state "one" :time 0}
-               a2 {:service :a :state "two" :time 0 :ttl 1}
+               a2 {:service :a :state "two" :time 3 :ttl 2}
                c1 {:service :c :state "one" :time 0}
                b2 {:service :b :state "two" :time 0}]
 
            (s a1)
+           (advance! 1.1)
            (is (= (set @out) #{a1}))
 
            (s b1)
+           (advance! 2.1)
            (is (= (set @out) #{a1 b1}))
 
            (s a2)
+           (advance! 3.1)
            (is (= (set @out) #{a2 b1}))
 
            ; Wait for ttl expiry of a2
-           (advance! 2)
-
            ; Should receive expired a2 once
+
+           ; a2 arrived at 3, expired at 5,
+           ; and the final expiry flush happens at 6
+           ; (due to the batching in coalesce)
            (s c1)
+           (advance! 6.1)
            (is (= (set @out) #{a2 b1 c1}))
            
            (s b2)
+           (advance! 7.1)
            (is (= (set @out) #{b2 c1}))))
 
 (deftest stable-test


### PR DESCRIPTION
I'm opening this pull request to get your feedback on this feature--it's not ready for merging, and i'm trying to get it there. There are 2 problems I'm having now:
1. Even though I'm using `advance!`, the time doesn't seem to be advancing for the callback that's scheduled by the `every!`. Could this be due to the `with-redefs` in `time.controlled`, or should I be reviewing my implementation? The only thing that I haven't tested is using `call-rescue` on the children rather than invoking them directly (as I have been using previously).
2. I know that the `every!` task should be canceled when the callback is empty. Do you mind (stylewise) if I use the `ConcurrentHashMap` as the monitor for guarding the creation/deletion of the task with `lock`?
