### PR TITLE
Handle spaces in graphite metric names

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
     [org.clojure/tools.logging "0.2.6"]
     [org.clojure/tools.nrepl "0.2.3"]
     [org.clojure/core.cache "0.6.3"]
+    [org.clojure/core.match "0.2.1"]
     [org.clojure/java.classpath "0.2.1"]
     [clojure-complete "0.2.3"]
     [log4j/log4j "1.2.16" :exclusions [javax.mail/mail

--- a/test/riemann/transport/graphite_test.clj
+++ b/test/riemann/transport/graphite_test.clj
@@ -1,0 +1,22 @@
+(ns riemann.transport.graphite-test
+  (:use clojure.test
+        riemann.transport.graphite)
+  (:require [riemann.logging :as logging]))
+
+(deftest decode-graphite-line-success-test
+  (let [parser-fun nil]
+    (is (= {:service "name", :metric 123.0, :time 456}
+           (decode-graphite-line "name 123 456" parser-fun)))))
+
+(deftest decode-graphite-line-failure-test
+  (logging/suppress ["riemann.transport.graphite"]
+  (let [parser-fun nil]
+    (is (= nil (decode-graphite-line "line" parser-fun)))
+    (is (= nil (decode-graphite-line "name nan 456" parser-fun)))
+    (is (= nil (decode-graphite-line "name metric timestamp" parser-fun)))
+    (is (= nil (decode-graphite-line "name with space 123 456" parser-fun))))))
+
+(deftest parser-fn-test
+  (let [parser-fun (fn [line] {:service "something_else"})]
+    (is (= {:service "something_else", :metric 123.0, :time 456}
+           (decode-graphite-line "something 123 456" parser-fun)))))


### PR DESCRIPTION
Incoming graphite metric names can contain spaces, for example `jvm/JvmMetrics/GcTimeMillisPS Scavenge` or `jvm/JvmMetrics/GcCountPS MarkSweep` coming from Ganglia. This caused exceptions(number format) which, even though they were caught, seemed to have prevented expired events from being streamed. I didn't get any respective log entries before this fix and get plenty now.
I am a Clojure beginner which is why I left out stuff that I didn't understand and didn't seem to have an effect(namely when-let and ^String). Let me know if I should change something.
