### PR TITLE
Fixed messages not being read in logstash.

### DIFF
--- a/src/riemann/logstash.clj
+++ b/src/riemann/logstash.clj
@@ -109,4 +109,4 @@
       (when (:metric event)
         (with-pool [client pool (:claim-timeout opts)]
                    (let [string (event-to-json (merge event {:source (:host event)}))]
-                     (send-line client string)))))))
+                     (send-line client (str string "\n"))))))))


### PR DESCRIPTION
I have been trying to send events to logstash but discovered that they arrived only when I was shutting down riemann. I found this [bug](https://logstash.jira.com/browse/LOGSTASH-967) in logstash where a comment says:

> the tcp input expects one event per line (separated by the newline character).

With the current implementation, we aren't sending any newline character so the events will never be read by logstash. Events only appear in logstash when closing the connection. So adding a newline character at the end of each message solves the problem.
