### PR TITLE
Optimize query for host and service

### DIFF
--- a/src/riemann/index.clj
+++ b/src/riemann/index.clj
@@ -42,13 +42,13 @@
   [query-ast]
   (if (and (list? query-ast)
            (= 'and (first query-ast)))
-    (let [and-exprs              (rest query-ast)
-          [eq-exprs other-exprs] (split-with #(= (first %) '=) and-exprs)
-          eq-map                 (into {} (map (comp vec rest) eq-exprs))]
-      (if (and (every? #(contains? eq-map %) '(host service))
-               (= 2 (count eq-exprs))
-               (empty? other-exprs))
-        (map eq-map ['host 'service])))))
+    (let [and-exprs (rest query-ast)]
+      (if (and (= 2 (count and-exprs))
+               (= 2 (count (filter #(= (first %) '=) and-exprs))))
+        (let [host    (first (filter #(= (second %) 'host) and-exprs))
+              service (first (filter #(= (second %) 'service) and-exprs))]
+          (if (and host service)
+            [(last host) (last service)]))))))
 
 (defn nbhm-index
   "Create a new nonblockinghashmap backed index"

--- a/test/riemann/index_test.clj
+++ b/test/riemann/index_test.clj
@@ -106,3 +106,7 @@
 (deftest is-query-for-host-and-service-with-more
   (let [ast (ast "host = nil and service = \"ser\" and metric > 5")]
     (is (= nil (query-for-host-and-service ast)))))
+
+(deftest is-query-for-host-and-host
+  (let [ast (ast "host = \"h1\" and host = \"h2\"")]
+    (is (= nil (query-for-host-and-service ast)))))


### PR DESCRIPTION
If a query is for exactly one host and source, do the lookup directly against the map.

This has the benefit of not needing `(eval)` and not being O(n) for queries in the form of `host = "h" and service = "s"`.
