### PR TITLE
update dependencies, with report from lein-ancient

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,33 +10,33 @@
   }
   :maintainer {:email "aphyr@aphyr.com"}
   :dependencies [
-    [org.clojure/algo.generic "0.1.1"]
+    [org.clojure/algo.generic "0.1.2"]
     [org.clojure/clojure "1.5.1"]
-    [org.clojure/math.numeric-tower "0.0.2"]
+    [org.clojure/math.numeric-tower "0.0.4"]
     [org.clojure/tools.logging "0.2.6"]
     [org.clojure/tools.nrepl "0.2.3"]
     [org.clojure/core.cache "0.6.3"]
-    [org.clojure/java.classpath "0.2.1"]
+    [org.clojure/java.classpath "0.2.2"]
     [clojure-complete "0.2.3"]
-    [log4j/log4j "1.2.16" :exclusions [javax.mail/mail
+    [log4j/log4j "1.2.17" :exclusions [javax.mail/mail
                                        javax.jms/jms
                                        com.sun.jdmk/jmxtools
                                        com.sun.jmx/jmxri]]
     [net.logstash.log4j/jsonevent-layout "1.5"]
-    [aleph "0.3.1"]
-    [clj-http "0.7.7"]
-    [cheshire "5.2.0"]
+    [aleph "0.3.2"]
+    [clj-http "0.9.1"]
+    [cheshire "5.3.1"]
     [clj-librato "0.0.4-SNAPSHOT"]
     [clj-time "0.6.0"]
     [clj-wallhack "1.0.1"]
-    [com.boundary/high-scale-lib "1.0.3"]
+    [com.boundary/high-scale-lib "1.0.4"]
     [com.draines/postal "1.11.1"]
-    [com.amazonaws/aws-java-sdk "1.4.1"]
+    [com.amazonaws/aws-java-sdk "1.7.5"]
     [interval-metrics "0.0.2"]
     [io.netty/netty "3.8.0.Final"]
     [log4j/apache-log4j-extras "1.0"]
     [org.antlr/antlr "3.2"]
-    [org.slf4j/slf4j-log4j12 "1.7.5"]
+    [org.slf4j/slf4j-log4j12 "1.7.7"]
     [riemann-clojure-client "0.2.10-SNAPSHOT"]
     [slingshot "0.10.3"]
     [clj-campfire "2.2.0"]
@@ -45,7 +45,7 @@
   ]
   :plugins [[codox "0.6.1"]
             [lein-rpm "0.0.5"]]
-  :profiles {:dev {:dependencies [[criterium "0.4.1"]]}}
+  :profiles {:dev {:dependencies [[criterium "0.4.3"]]}}
   :test-selectors {:default (fn [x] (not (or (:integration x)
                                              (:time x)
                                              (:bench x))))


### PR DESCRIPTION
Tests still passing, this is the output from lein-ancient now,
jsonevent-layout and netty must remain at these versions for now.

```
[net.logstash.log4j/jsonevent-layout "1.6"] is available but we use "1.5"
[io.netty/netty "4.0.0.Alpha8"] is available but we use "3.8.0.Final"
[log4j/apache-log4j-extras "1.2.17"] is available but we use "1.0"
[org.antlr/antlr "3.5.2"] is available but we use "3.2"
```
