### PR TITLE
More relaxed decoding of graphite messages

### DIFF
--- a/src/riemann/transport/graphite.clj
+++ b/src/riemann/transport/graphite.clj
@@ -24,7 +24,7 @@
   "Decode a line coming from graphite.
 
   Graphite uses a simple scheme where each metric is given as a CRLF delimited
-  line, space split with three items:
+  line, whitespace split (space, tab) with three items:
 
   * The metric name
   * The metric value (optionally NaN)
@@ -33,7 +33,7 @@
   Decode-graphite-line will yield a simple event with just a service, metric,
   and timestamp."
   [line]
-  (let [[service metric timestamp & garbage] (split line #" ")]
+  (let [[service metric timestamp & garbage] (split line #"\s+")]
     ; Validate format
     (cond garbage
           (throw+ "too many fields")

--- a/test/riemann/transport/graphite_test.clj
+++ b/test/riemann/transport/graphite_test.clj
@@ -7,7 +7,21 @@
 
 (deftest decode-graphite-line-success-test
   (is (= (event {:service "name", :metric 123.0, :time 456})
-         (decode-graphite-line "name 123 456"))))
+         (decode-graphite-line "name 123 456")))
+  (is (= (event {:service "name", :metric 456.0 :time 789})
+         (decode-graphite-line "name\t456\t789")))
+  (is (= (event {:service "name", :metric 456.0 :time 789})
+         (decode-graphite-line "name\t 456\t 789")))
+  (is (= (event {:service "name", :metric 456.0 :time 789})
+         (decode-graphite-line "name\t\t456\t\t789")))
+  (is (= (event {:service "name", :metric 456.0 :time 789})
+         (decode-graphite-line "name\t\t456 789")))
+  (is (= (event {:service "name", :metric 456.0 :time 789})
+         (decode-graphite-line "name 456\t789")))
+  (is (= (event {:service "name", :metric 456.0 :time 789})
+         (decode-graphite-line "name\t456 789")))
+  (is (= (event {:service "name", :metric 456.0 :time 789})
+         (decode-graphite-line "name  456      789"))))
 
 (deftest decode-graphite-line-failure-test
   (let [err #(try+ (decode-graphite-line %)
@@ -16,4 +30,7 @@
     (is (= (err "name nan 456") "NaN metric"))
     (is (= (err "name metric 456") "invalid metric"))
     (is (= (err "name 123 timestamp") "invalid timestamp"))
-    (is (= (err "name with space 123 456") "too many fields"))))
+    (is (= (err "name with space 123 456") "too many fields"))
+    (is (= (err "name\twith\ttab\t123\t456") "too many fields"))
+    (is (= (err "name with space\tand\ttab 123\t456") "too many fields"))
+    (is (= (err "name\t\t123\t456\t\t\t789") "too many fields"))))


### PR DESCRIPTION
Technically the graphite spec at the below URL only specifies space
chars between message fields.
http://graphite.wikidot.com/getting-your-data-into-graphite

However several senders use space and tab chars e.g. the
Sensu::Plugin::Metric::CLI::Graphite class uses tab characters between
fields and there is a large number of deployed hosts using that plugin,
so it may be appropriate to split on characters beyond a single space.

The accompanying tests have additional assertions to test for messages
that contain multiple tabs and spaces between fields.
