### PR TITLE
make "combine streams" example easier to understand

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -755,11 +755,19 @@ client << {service: "thumbnailer rate",
   <div class="sixcol last">
 {% highlight clj %}
 (let [index (index)
-      aggregate (rate 5 index)]
-  (where (service "http req rate")
-    aggregate)
-  (where (service "0mq req rate")
-    (scale 2 aggregate)))
+      ; every 5s, aggregate everything submitted to this stream and forward
+      ; the result to the index
+      aggregate (rate 5
+        (with :service "aggregated req rate" index))]
+
+  (streams
+    (where (service "http req rate")
+      index      ; save the individual value to the index
+      aggregate) ; and also submit it for aggregation
+
+    (where (service "0mq req rate")
+      index                  ; save the individual value to the index
+      (scale 2 aggregate)))) ; and submit the doubled value for aggregation
 {% endhighlight %}
   </div>
 </div>


### PR DESCRIPTION
I spent a fair amount of time trying to grasp how to merge 2 streams, and this terse example frustrated me somewhat.

Copy-pasting the previous code didn't seem to do anything. After adding the `(streams ...)` block, you can now see something when you query the index. Furthermore, I also suggest indexing the 2 source streams as well as the calculated rate with a different service name. This makes the example a bit longer, but what you see in the dash then makes a lot more sense and helps understanding imho.

It can also be that I completely misunderstood the whole thing... Let me know, I won't be disappointed if you don't merge it ;)
