### PR TITLE
Change example to set a default ttl on all events

### DIFF
--- a/riemann.config
+++ b/riemann.config
@@ -16,8 +16,9 @@
 
 (periodically-expire 1)
 
-(let [index (default :ttl 3 (index))]
+(let [index (index)]
   (streams
-    (expired #(prn "Expired" %))
-    (where (not (service #"^riemann "))
-           index)))
+    (default :ttl 3
+      (expired #(prn "Expired" %))
+      (where (not (service #"^riemann "))
+             index))))


### PR DESCRIPTION
I have run into issues where events passed to `(rate)` never expired because the `:ttl` was not set before it was passed to `(rate)`.

It ends up part of my problem was due to where I put `(default)`, which I grabbed from this example riemann.config without thinking through the implications.
