### PR TITLE
Option to supply a custom message formatter for Slack integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ pom.xml
 .*.swp
 *.log
 .lein-repl-history
+.nrepl-port
 lib
 classes
 build

--- a/src/riemann/slack.clj
+++ b/src/riemann/slack.clj
@@ -4,29 +4,61 @@
             [cheshire.core :as json])
   (:use [clojure.string :only [escape join upper-case]]))
 
-  (defn slack_format [message]
-    "Format message according to slack formatting spec."
-    (escape message {\< "&lt;" \> "&gt;"}))
+(defn slack-escape [message]
+  "Escape message according to slack formatting spec."
+  (escape message {\< "&lt;" \> "&gt;" \& "&amp;"}))
 
-  (defn slack
-    "Posts events into a slack.com channel using Incoming Webhooks.
-    Takes your account name, webhook token, bot username and room name.
-    Returns a function that will post a message into slack.com room.
+(defn- default-formatter [events]
+  {:text (str "*Host:* " (:host events)
+              " *State:* " (:state events)
+              " *Description:* " (:description events)
+              " *Metric:* " (:metric events))})
 
-    (by [:service]
-      (let [alert (slack \"some_org\" \"....\" \"Riemann bot\" \"#monitoring\")]
-                                                      alert))
-    "
-    [account_name token username room]
-    (fn [event]
-      (client/post (str "https://" account_name ".slack.com/services/hooks/incoming-webhook?token=" token)
-                   {:form-params
-                    {:payload (json/generate-string
-                                {:text (slack_format (str "*Host:* " (:host event)
-                                                          " *State:* " (:state event)
-                                                          " *Description:* " (:description event)
-                                                          " *Metric:* " (:metric event)
-                                                          ))
-                                 :channel room
-                                 :username username
-                                 :icon_emoji ":warning:"})}})))
+(defn slack
+  "Posts events into a slack.com channel using Incoming Webhooks.
+  Takes your account name, webhook token, bot username and channel name.
+  Returns a function that will post a message into slack.com channel:
+
+  (def credentials {:account \"some_org\", :token \"53CR3T\"}
+  (def slacker (slack credentials {:username \"Riemann bot\"
+                                   :channel \"#monitoring\"
+                                   :icon \":smile:\"}))
+
+  (by [:service] slacker)
+
+  You can also supply a custom formatter for formatting events into Slack
+  messages. Formatter result may contain:
+
+    * `username` - overrides the username provided upon construction
+    * `channel` - overrides the channel provided upon construction
+    * `icon` - overrides the icon provided upon construction
+    * `text` - main text formatted using Slack markup
+    * `attachments` - array of attachments according to https://api.slack.com/docs/attachments
+
+  (def slacker (slack credentials {:username \"Riemann bot\", :channel \"#monitoring\"
+                                   :formatter (fn [e] {:text (:state e)
+                                                       :icon \":happy:\"})))
+
+  You can use `slack` inside of a grouping function which produces a seq of
+  events, like `rollup`:
+
+  (def slacker (slack credentials {:username \"Riemann bot\", :channel \"#monitoring\"
+                                   :formatter (fn [es] {:text (apply str (map :state es))})))
+
+  (rollup 5 60 slacker)
+  "
+  ([account_name token username channel] (slack {:account account_name, :token token}
+                                                {:username username, :channel channel}))
+  ([{:keys [account token]} {:keys [username channel icon formatter] :or {formatter default-formatter}}]
+   (fn [events]
+     (let [{:keys [text attachments] :as result} (formatter events)
+           icon (:icon result (or icon ":warning:"))
+           channel (:channel result channel)
+           username (:username result username)]
+       (client/post (str "https://" account ".slack.com/services/hooks/incoming-webhook?token=" token)
+                    {:form-params
+                     {:payload (json/generate-string
+                                 (merge
+                                  {:channel channel, :username username, :icon_emoji icon}
+                                  (when text {:text (slack-escape text)})
+                                  (dissoc result :icon :text)))}})))))

--- a/test/riemann/slack_test.clj
+++ b/test/riemann/slack_test.clj
@@ -1,7 +1,8 @@
 (ns riemann.slack-test
-  (:use riemann.slack
-        clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:use clojure.test)
+  (:require [riemann.logging :as logging]
+            [riemann.slack :as slack]
+            [clj-http.client :as client]))
 
 
 (def api-key (System/getenv "SLACK_API_KEY"))
@@ -21,9 +22,79 @@
 (logging/init)
 
 (deftest ^:slack ^:integration test_event
-  (let [slack_connect (slack account api-key user room)]
+  (let [slack_connect (slack/slack account api-key user room)]
     (slack_connect {:host "localhost"
                     :service "good event test"
                     :description "Testing slack.com alerts from riemann"
                     :metric 42
                     :state "ok"})))
+
+(defn- capture-post [result-atom url params]
+  (reset! result-atom {:url url, :body (get-in params [:form-params :payload])}))
+
+(def ^:private any-account {:account "any", :token "any"})
+(defn- with-formatter [formatter-fn]
+  {:username "any", :channel "any", :formatter formatter-fn})
+
+(deftest slack
+  (let [post-request (atom {})]
+    (with-redefs [client/post (partial capture-post post-request)]
+
+      (testing "forms correct slack URL"
+        (let [slacker (slack/slack "test-account" "test-token" "any" "any")]
+          (slacker {})
+          (is (= (:url @post-request)
+                 "https://test-account.slack.com/services/hooks/incoming-webhook?token=test-token"))))
+
+      (testing "formats event by default"
+        (let [slacker (slack/slack "any" "any" "test-user" "#test-channel")]
+          (slacker {:host "localhost", :service "mailer", :state "error",
+                    :description "Mailer failed", :metric 42, :tags ["first", "second"]})
+          (is (= (:body @post-request)
+                 (str "{\"text\":\"*Host:* localhost "
+                                  "*State:* error "
+                                  "*Description:* Mailer failed "
+                                  "*Metric:* 42\","
+                      "\"channel\":\"#test-channel\","
+                      "\"username\":\"test-user\","
+                      "\"icon_emoji\":\":warning:\"}")))))
+
+      (testing "escapes formatting characters in main message text"
+        (let [slacker (slack/slack any-account (with-formatter (fn [e] {:text (:host e)})))]
+          (slacker {:host "<>&"})
+          (is (seq (re-seq #"&lt;&gt;&amp;" (:body @post-request))))))
+
+      (testing "allows for empty message text"
+        (let [slacker (slack/slack any-account (with-formatter (constantly {})))]
+          (slacker {:host "empty"})
+          (is (= (:body @post-request)
+                 (str "{\"channel\":\"any\","
+                       "\"username\":\"any\","
+                       "\"icon_emoji\":\":warning:\"}")))))
+
+      (testing "specifies username, channel and icon when initializing slacker"
+        (let [slacker (slack/slack any-account
+                                   {:username "test-user", :channel "#test-channel", :icon ":ogre:"
+                                    :formatter (constantly {})})]
+          (slacker [{:host "localhost", :service "mailer"}])
+          (is (= (:body @post-request)
+                 (str "{\"channel\":\"#test-channel\","
+                      "\"username\":\"test-user\","
+                      "\"icon_emoji\":\":ogre:\"}")))))
+
+      (testing "formats multiple events with a custom formatter"
+        (let [slacker (slack/slack {:account "any", :token "any"}
+                                   {:username "test-user", :channel "#test-channel", :icon ":ogre:"
+                                    :formatter (fn [events] {:text (apply str (map #(str (:tags %)) events))
+                                                             :icon ":ship:"
+                                                             :username "another-user"
+                                                             :channel "#another-channel"
+                                                             :attachments [{:pretext "pretext"}]})})]
+          (slacker [{:host "localhost", :service "mailer", :tags ["first" "second"]}
+                    {:host "localhost", :service "mailer", :tags ["third" "fourth"]}])
+          (is (= (:body @post-request)
+                 (str "{\"attachments\":[{\"pretext\":\"pretext\"}],"
+                       "\"text\":\"[\\\"first\\\" \\\"second\\\"][\\\"third\\\" \\\"fourth\\\"]\","
+                       "\"channel\":\"#another-channel\","
+                       "\"username\":\"another-user\","
+                       "\"icon_emoji\":\":ship:\"}"))))))))


### PR DESCRIPTION
- Customize messages sent to Slack (icon, attachments, text, username, channel)
- Cover with unit-tests
- Superset of https://github.com/aphyr/riemann/pull/395
- Backwards compatible
