### PR TITLE
Minor edit to clients.html - borntyping/python-riemann-client now supports TLS and attributes

### DIFF
--- a/clients.html
+++ b/clients.html
@@ -107,9 +107,9 @@ title: Riemann - Clients
       transport with support for long and float metrics.</p>
 
       <p>There's also <a
-        href="https://github.com/borntyping/python-riemann-client">BornTyping's
-      riemann-client</a>, which supports UDP, TCP, and queuing events for
-      delivery--but no custom event attributes or TLS.</p>
+        href="https://github.com/borntyping/python-riemann-client">borntyping's
+      riemann-client</a>, which supports UDP, TCP and TLS, as well as queuing events
+      for delivery.</p>
 
       <p><a href="https://github.com/banjiewen/bernhard">Bernhard</a> is
       Banjiewen's Python client. You can install it with <code>pip install


### PR DESCRIPTION
https://github.com/borntyping/python-riemann-client/releases/tag/v4.1.0
