### PR TITLE
Extend changed to optionally capture previous value

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1505,9 +1505,16 @@
           (dorun
             (map 
               (fn [child arity]
-                (if (= 1 arity)
-                    (child event)
-                    (child (second kept) event))
+                (try
+                  (if (= 1 arity)
+                      (child event)
+                      (child (second kept) event))
+                  (catch Throwable e
+                    (warn e (str child " threw"))
+                    (if-let [ex-stream *exception-stream*]
+                      (ex-stream (exception->event e)))
+                  )
+                )
               )
               children
               child-arities

--- a/test/riemann/streams_test.clj
+++ b/test/riemann/streams_test.clj
@@ -1140,6 +1140,16 @@
            (is (= [[:ok :bad] [:bad :ok] [:ok :evil] [:evil :bad]]
                   @output))))
 
+(deftest changed-with-exception-test
+        (logging/suppress 
+          "riemann.streams"
+           (let [exceptions (atom [])]
+             (binding [riemann.streams/*exception-stream* #(swap! exceptions conj %)]
+               (run-stream (changed :state (fn [x]
+                                             (throw (Throwable. "boo!"))))
+                           [(riemann.common/event {:state :critical})]))
+             (is (= 1 (count @exceptions))))))
+
 (deftest changed-state-test
          ; Each test stream keeps track of the first host/service it sees, and
          ; confirms that each subsequent event matches that host, and that


### PR DESCRIPTION
Providing this information allows the child streams to know what the previous
state was, which could be used to drive notifications or corrective actions.

This is my very first bit of Clojure, and I'm still a complete Riemann neophyte.
It's entirely possible I'm on the wrong track, here, but I wanted to get some
feedback.
