### PR TITLE
Include files from a directory in lexicographic order

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -329,7 +329,7 @@
 (defn include
   "Include another config file or directory. If the path points to a
    directory, all files with names ending in `.config` or `.clj` within
-   it will be loaded recursively.
+   it will be loaded recursively.  Filenames are sorted lexicographically.
 
   ; Relative to the current config file, or cwd
   (include \"foo.clj\")
@@ -342,7 +342,7 @@
     (binding [*config-file* path
               *ns* (find-ns 'riemann.config)]
       (if (.isDirectory file)
-        (doseq [f (file-seq file)]
+        (doseq [f (sort (file-seq file))]
           (when (config-file? f)
             (load-file (.toString f))))
         (load-file path)))))


### PR DESCRIPTION
file-seq uses java.io.File#listFiles(), which does not guarantee order.  The
items returned from file-seq are java.io.File objects, which implement
Comparable, and compare in lexicographic order.
