### PR TITLE
Send events to Logstash, even if they don't have metrics

### DIFF
--- a/src/riemann/logstash.clj
+++ b/src/riemann/logstash.clj
@@ -106,7 +106,6 @@
                 :regenerate-interval  (:reconnect-interval opts)})]
 
     (fn [event]
-      (when (:metric event)
-        (with-pool [client pool (:claim-timeout opts)]
-                   (let [string (event-to-json (merge event {:source (:host event)}))]
-                     (send-line client (str string "\n"))))))))
+      (with-pool [client pool (:claim-timeout opts)]
+                 (let [string (event-to-json (merge event {:source (:host event)}))]
+                   (send-line client (str string "\n")))))))


### PR DESCRIPTION
There's no need to filter out events that don't have metrics.
