### PR TITLE
Add support for passing a map to sorted-sample

### DIFF
--- a/src/riemann/folds.clj
+++ b/src/riemann/folds.clj
@@ -33,15 +33,20 @@
   to (str service \" \" point). For instance, (sorted-sample events [0 1])
   returns a 2-element seq of the smallest event and the biggest event, by
   metric. The first has a service which ends in \" 0\" and the second one ends
-  in \" 1\".  Useful for extracting histograms and percentiles.
+  in \" 1\". If the points is a map, eg (sorted-sample events {0 \".min\" 1
+  \".max\"}, the the values will be appened to the service name directly.
+  Useful for extracting histograms and percentiles.
   
   When s is empty, returns an empty list."
   [s points]
-  (map (fn [point event]
-         (assoc event :service
-                (str (:service event) " " point)))
-       points
-       (sorted-sample-extract s points)))
+  (let [[points pnames] (if (vector? points)
+                         [points (map #(str " " %) points)]
+                         (apply map vector points))]
+    (map (fn [pname event]
+           (assoc event :service
+                  (str (:service event) pname)))
+         pnames
+         (sorted-sample-extract s points))))
 
 (defn non-nil-metrics
   "Given a sequence of events, returns a compact sequence of their

--- a/test/riemann/folds_test.clj
+++ b/test/riemann/folds_test.clj
@@ -9,7 +9,7 @@
 (use-fixtures :once control-time!)
 (use-fixtures :each reset-time!)
 
-(deftest sorted-sample-test
+(deftest sorted-sample-extract-test
          (are [es e] (= (sorted-sample-extract es [0 0.5 1]) e)
               []
               []
@@ -29,9 +29,39 @@
               [{:metric 6} {:metric 1} {:metric 2} {:metric 1} {:metric 1}]
               [{:metric 1} {:metric 1} {:metric 6}]))
 
+(deftest sorted-sample-test
+         (are [es e] (= (sorted-sample es [0 0.5 1]) e)
+              []
+              []
+
+              [{:metric nil}]
+              []
+
+              [{:metric 1}]
+              [{:metric 1 :service " 0"} {:metric 1 :service " 0.5"} {:metric 1 :service " 1"}]
+
+              [{:metric 2} {:metric 1}]
+              [{:metric 1 :service " 0"} {:metric 2 :service " 0.5"} {:metric 2 :service " 1"}]
+
+              [{:metric 3} {:metric 1} {:metric 2}]
+              [{:metric 1 :service " 0"} {:metric 2 :service " 0.5"} {:metric 3 :service " 1"}]
+
+              [{:metric 6} {:metric 1} {:metric 2} {:metric 1} {:metric 1}]
+              [{:metric 1 :service " 0"} {:metric 1 :service " 0.5"} {:metric 6 :service " 1"}])
+
+         (are [es e] (= (sorted-sample es {0 " min" 0.5 " median" 1 " max"}) e)
+              [{:metric 2} {:metric 1}]
+              [{:metric 1 :service " min"} {:metric 2 :service " median"} {:metric 2 :service " max"}]
+
+              [{:metric 3} {:metric 1} {:metric 2}]
+              [{:metric 1 :service " min"} {:metric 2 :service " median"} {:metric 3 :service " max"}]
+
+              [{:metric 6} {:metric 1} {:metric 2} {:metric 1} {:metric 1}]
+              [{:metric 1 :service " min"} {:metric 1 :service " median"} {:metric 6 :service " max"}]))
+
 (defn test-fold-common
   [fold operator]
-  (are [es] (= (fold es) 
+  (are [es] (= (fold es)
                (assoc (first es)
                       :metric
                       (reduce operator (map :metric es))))
@@ -66,7 +96,7 @@
   (is (nil? (fold [])))
   (is (nil? (fold [nil {:service "foo"}])))
   (is (= {:service "foo"
-          :metric nil 
+          :metric nil
           :description "An event or metric was nil."}
          (fold [{:service "foo"} {:metric 2}])))
   (is (= {:service "foo"
@@ -89,8 +119,8 @@
          (test-fold-all quotient /)
 
          (testing "exceptions"
-                  (is (= (quotient [{:service "hi" :metric 1} 
-                                   {:metric 2} 
+                  (is (= (quotient [{:service "hi" :metric 1}
+                                   {:metric 2}
                                    {:metric 0}])
                          {:service "hi"
                           :metric nil


### PR DESCRIPTION
When the points provided to sorted-sample (and by extension percentiles)
is a map, the values of that map will be appended to the service name
instead of the point value.
- Other whitespace cleanup in the folds tests.
