### PR TITLE
Fix: Cannot use shinken adapter in config

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -38,6 +38,7 @@
         [riemann.hipchat :only [hipchat]]
         [riemann.slack :only [slack]]
         [riemann.stackdriver :only [stackdriver]]
+        [riemann.shinken :only [shinken]]
         riemann.streams))
 
 (def core "The currently running core."


### PR DESCRIPTION
I believe this is why I couldn't import the shinken adapter in my config...
