### PR TITLE
Support external log4j configuration

### DIFF
--- a/src/riemann/bin.clj
+++ b/src/riemann/bin.clj
@@ -57,7 +57,8 @@
   ([config]
    (-main "start" config))
   ([command config]
-   (riemann.logging/init)
+   (when (nil? (System/getProperty "log4j.configuration"))
+     (riemann.logging/init))
    (case command
      "start" (try
                (info "PID" (pid))


### PR DESCRIPTION
Support external log4j configuration. If the property
log4j.configuration is set, do not run `riemann.logging/init`.
`riemann.logging/init` prevents the use of external configuration files
because it removes all configured appenders.

So long as `riemann.logging/init`, it is possible to configure log4j
using a log4j.properties

Personally I prefer configuring log4j using external configuration files.
Configuring logging appenders from the riemann config file limits us to the
appenders supported by riemann already, or requires learning the log4j api.
