### PR TITLE
Remove unneeded info logging

### DIFF
--- a/src/riemann/logentries.clj
+++ b/src/riemann/logentries.clj
@@ -85,5 +85,4 @@
 
     (fn [event]
       (with-pool [client pool claim-timeout]
-        (info "Event message: " (event-to-le-format event))
         (send-line client (event-to-le-format event))))))


### PR DESCRIPTION
This one slipped through when I opened the pull request yesterday. It was useful during development, but I don't think it's useful any more.

Thanks.
