### PR TITLE
Add test cases for reload bug in riemann.config/index

### DIFF
--- a/test/riemann/config_test.clj
+++ b/test/riemann/config_test.clj
@@ -129,15 +129,29 @@
 
 (deftest index-test
          (let [i (index)]
-           (is (satisfies? Index i))
-           (is (= i (:index @next-core)))
-           (is (nil? (:index @core)))))
+           (testing "ensure the index creation helper creates the index properly"
+             (is (satisfies? Index i))
+             (is (= i (:index @next-core)))
+             (is (nil? (:index @core))))
+           (testing "ensure the index is applied to the core properly during initial load"
+             (apply!)
+             (is (identical? i (:index @core))))
+           (testing "ensure we have the proper reference to the index after a reload"
+             (let [i' (index)]
+               (is (identical? i' (:index @next-core)))
+               (is (not (identical? i' (:index @core))))
+               (apply!)
+               (is (identical? i' (:index @core)))))))
 
 (deftest update-index-test
          (let [i (index)]
            (apply!)
            (i {:service 1 :state "ok" :time 0})
-           (is (= (seq i) [{:service 1 :state "ok" :time 0}]))))
+           (is (= (seq i) [{:service 1 :state "ok" :time 0}]))
+           (testing "Ensure that accessible index persists reloads"
+             (let [i' (index)]
+               (apply!)
+               (is (= (seq i') [{:service 1 :state "ok" :time 0}]))))))
 
 (deftest delete-from-index-test
          (let [i (index)


### PR DESCRIPTION
`WrappedIndex`es are not working across reloads as they do not take into
account the fact that when an index already exists, the index inserted
into `next-core` is thrown away during a core merge.

This has the effect of breaking event expiration.
