### PR TITLE
Add mailgun output plugin to riemann.config ns

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -43,6 +43,7 @@
         [cemerick.pomegranate :only [add-dependencies]]
         [riemann.shinken :only [shinken]]
 	[riemann.xymon :only [xymon]]
+        [riemann.mailgun :only [mailgun]]
         riemann.streams))
 
 (def core "The currently running core."


### PR DESCRIPTION
Add mailgun output plugin to riemann.config ns so it is available within
riemann configuration and explicit `require` statements are not
necessary.

Forgot to add this in my original PR, oops!
