### PR TITLE
Fix example and add a hint

### DIFF
--- a/src/riemann/slack.clj
+++ b/src/riemann/slack.clj
@@ -49,12 +49,16 @@
   Takes your account name, webhook token, bot username and channel name.
   Returns a function that will post a message into slack.com channel:
 
-  (def credentials {:account \"some_org\", :token \"53CR3T\"}
+  (def credentials {:account \"some_org\", :token \"53CR3T\"})
   (def slacker (slack credentials {:username \"Riemann bot\"
                                    :channel \"#monitoring\"
                                    :icon \":smile:\"}))
 
   (by [:service] slacker)
+
+  Hint: token is the last part of the webhook URL that Slack gives you.
+  https://hooks.slack.com/services/QWERSAFG0/AFOIUYTQ48/120984SAFJSFR
+  Token in this case would be 120984SAFJSFR
 
   You can also supply a custom formatter for formatting events into Slack
   messages. Formatter result may contain:


### PR DESCRIPTION
Fix the first example and add a hint about where to get the token from. The webhook_uri support still isn't working right, but this should be a decent work around for anyone trying to use this module for now.
