### PR TITLE
streams/sdo: Special case for 0 and 1 arg versions

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -235,9 +235,11 @@
   a single variable.
 
   (sdo prn (rate 5 index))"
-  [& children]
-  (fn stream [event]
-    (call-rescue event children)))
+  ([] bit-bucket)
+  ([child] child)
+  ([child & children]
+     (fn stream [event]
+       (call-rescue event (cons child children)))))
 
 (defn stream
   [& args]

--- a/test/riemann/streams_test.clj
+++ b/test/riemann/streams_test.clj
@@ -78,6 +78,11 @@
         add2    #(swap! vals2 conj %)]
     (run-stream (sdo add1 add2) [1 2 3])
     (is (= @vals1 [1 2 3]))
+    (is (= @vals2 [1 2 3]))
+    (run-stream (sdo add1) [4 5 6])
+    (is (= @vals1 [1 2 3 4 5 6]))
+    (run-stream (sdo) [6 7 8])
+    (is (= @vals1 [1 2 3 4 5 6]))
     (is (= @vals2 [1 2 3]))))
 
 (deftest exception-stream-test


### PR DESCRIPTION
This changes sdo to have special cases for 0 and 1 args, calling bit-bucket in the 0-arg case, and the child directly in the second case.

Fixes #398.
