### PR TITLE
Add OpenTSDB server support

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -12,6 +12,7 @@
             [riemann.transport.websockets :as websockets]
             [riemann.transport.sse        :as sse]
             [riemann.transport.graphite   :as graphite]
+            [riemann.transport.opentsdb   :as opentsdb]
             [riemann.logging :as logging]
             [riemann.folds :as folds]
             [riemann.pubsub :as pubsub]
@@ -136,6 +137,13 @@
   (graphite-server {:port 2222})"
   [& opts]
   (service! (graphite/graphite-server (kwargs-or-map opts))))
+
+(defn opentsdb-server
+  "Add a new OpenTSDB TCP server with opts to the default core.
+
+  (opentsdb-server {:port 4242})"
+  [& opts]
+  (service! (opentsdb/opentsdb-server (kwargs-or-map opts))))
 
 (defn udp-server
   "Add a new UDP server with opts to the default core.

--- a/src/riemann/transport/opentsdb.clj
+++ b/src/riemann/transport/opentsdb.clj
@@ -1,0 +1,133 @@
+(ns riemann.transport.opentsdb
+  (:import [org.jboss.netty.util CharsetUtil]
+           (org.jboss.netty.channel MessageEvent)
+           [org.jboss.netty.handler.codec.oneone OneToOneDecoder]
+           [org.jboss.netty.handler.codec.string StringDecoder StringEncoder]
+           [org.jboss.netty.handler.codec.frame
+            DelimiterBasedFrameDecoder
+            Delimiters])
+  (:require [interval-metrics.core :as metrics])
+  (:use [riemann.core :only [stream!]]
+        [riemann.codec :only [->Event]]
+        [riemann.transport.tcp :only [tcp-server
+                                      gen-tcp-handler]]
+        [riemann.transport :only [channel-pipeline-factory
+                                  channel-group
+                                  shared-execution-handler]]
+        [interval-metrics.measure :only [measure-latency]]
+        [slingshot.slingshot :only [try+ throw+]]
+        [clojure.string :only [split
+                               join]]
+        [clojure.tools.logging :only [warn]]))
+
+(defn decode-opentsdb-line
+  [line]
+  (let [[verb service timestamp metric & tags] (split line #"\s")]
+    ; Validate format
+    (cond
+          (= "version" verb)
+          (throw+ "version request")
+
+          (= "" verb)
+          (throw+ "blank line")
+
+          (not service)
+          (throw+ "no metric name")
+
+          (not timestamp)
+          (throw+ "no timestamp")
+
+          (not metric)
+          (throw+ "no metric")
+
+          (re-find #"(?i)nan" metric)
+          (throw+ "NaN metric"))
+
+    ; Parse numbers
+    (let [metric (try (Double. metric)
+                      (catch NumberFormatException e
+                        (throw+ "invalid metric")))
+          timestamp (try (Long. timestamp)
+                         (catch NumberFormatException e
+                           (throw+ "invalid timestamp")))
+          description service
+          service (if-let [tagstr (when-not (empty? tags) (join " " tags))]
+                              (str service " " tagstr)
+                              service)
+          host (when-let [h (-> (filter (fn [tag] (.startsWith tag "host=")) tags)
+                                first)]
+                         (subs h 5))
+          ]
+
+      ; Construct event
+      ; (defrecord Event [host service state description metric tags time ttl])
+      (->Event host
+               service
+               nil
+               description
+               metric
+               tags
+               timestamp
+               nil))))
+
+(defn opentsdb-frame-decoder
+  [parser-fn]
+  (let [parser-fn (or parser-fn identity)]
+    (proxy [OneToOneDecoder] []
+      (decode [context channel message]
+        (try+
+          (if (= "version" message)
+            (do
+              (. channel
+                (write
+                  (str "net.opentsdb\n"
+                       "Built on ... (riemann-opentsdb)\n"
+                       )))
+              {:service "version" :time (System/nanoTime)})
+            (-> message
+                decode-opentsdb-line
+                parser-fn))
+          (catch Object e
+            (throw (RuntimeException.
+                     (str "OpenTSDB server parse error (" e "): "
+                          (pr-str message))))))))))
+
+(defn opentsdb-handler
+  "Given a core and a MessageEvent, applies the message to core."
+  [core stats ^MessageEvent e]
+  (stream! core (.getMessage e)))
+
+(defn opentsdb-server
+  "Start a opentsdb-server. Options:
+
+  :host       \"127.0.0.1\"
+  :port       4242
+  :parser-fn  an optional function given to decode-opentsdb-line"
+  ([] (opentsdb-server {}))
+  ([opts]
+     (let [core  (get opts :core (atom nil))
+           host  (get opts :host "127.0.0.1")
+           port  (get opts :port 4242)
+           stats (metrics/rate+latency)
+           server tcp-server
+           channel-group (channel-group (str "opentsdb server " host ":" port))
+           opentsdb-message-handler (gen-tcp-handler
+                                        core stats channel-group opentsdb-handler)
+           pipeline-factory (channel-pipeline-factory
+                              frame-decoder  (DelimiterBasedFrameDecoder.
+                                               1024
+                                               (Delimiters/lineDelimiter))
+                              ^:shared string-decoder (StringDecoder.
+                                                        CharsetUtil/UTF_8)
+                              ^:shared string-encoder (StringEncoder.
+                                                        CharsetUtil/UTF_8)
+                              ^:shared executor shared-execution-handler
+                              ^:shared opentsdb-decoder (opentsdb-frame-decoder
+                                                          (:parser-fn opts))
+                              ^:shared handler opentsdb-message-handler)]
+       (server (merge opts
+                          {:host host
+                           :port port
+                           :core core
+                           :channel-group channel-group
+                           :pipeline-factory pipeline-factory})))))

--- a/test/riemann/transport/opentsdb_test.clj
+++ b/test/riemann/transport/opentsdb_test.clj
@@ -1,0 +1,30 @@
+(ns riemann.transport.opentsdb-test
+  (:use clojure.test
+        [riemann.common :only [event]]
+        riemann.transport.opentsdb
+        [slingshot.slingshot :only [try+]])
+  (:require [riemann.logging :as logging]))
+
+(deftest decode-opentsdb-line-success-test
+  (is (= (event {:service "name", :description "name", :metric 456.0, :time 123})
+         (decode-opentsdb-line "put name 123 456")))
+  (is (= (event {:host "host", :service "name host=host", :description "name", :metric 456.0, :tags (list "host=host"), :time 123})
+         (decode-opentsdb-line "put name 123 456 host=host")))
+  (is (= (event {:service "name tag=value", :description "name", :metric 456.0, :tags (list "tag=value"), :time 123})
+         (decode-opentsdb-line "put name 123 456 tag=value")))
+  (is (= (event {:service "name tag=value tag2=value2", :description "name", :metric 456.0, :tags (list "tag=value" "tag2=value2"), :time 123})
+         (decode-opentsdb-line "put name 123 456 tag=value tag2=value2")))
+)
+
+(deftest decode-opentsdb-line-failure-test
+  (let [err #(try+ (decode-opentsdb-line %)
+                   (catch Object e e))]
+    (is (= (err "") "blank line"))
+    (is (= (err "version") "version request"))
+    (is (= (err "put") "no metric name"))
+    (is (= (err "put name") "no timestamp"))
+    (is (= (err "put name 123") "no metric"))
+    (is (= (err "put name 123 NaN") "NaN metric"))
+    (is (= (err "put name 123 metric") "invalid metric"))
+    (is (= (err "put name timestamp 123") "invalid timestamp"))
+  ))


### PR DESCRIPTION
Consume OpenTSDB datapoints and convert them into Riemann events.

This work was mostly based on `riemann.transport.graphite`, as the concept is very similar.
