### PR TITLE
Make with handle lists of events

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1276,12 +1276,15 @@
             (reduce (fn [m, [k, v]]
                       (if (nil? v) (dissoc m k) (assoc m k v)))
                     individual-event m))]
-      (fn stream [event]
-        (if (vector? event)
-          (call-rescue
-            (into [] (map transform-event event))
-            children)
-          (call-rescue (transform-event event) children))))
+      (if (empty? m)
+        (fn stream [event]
+          (call-rescue event children))
+        (fn stream [event]
+          (if (vector? event)
+            (call-rescue
+              (into [] (map transform-event event))
+              children)
+            (call-rescue (transform-event event) children)))))
 
     ; Change a particular key.
     (let [[k v & children] args

--- a/test/riemann/streams_test.clj
+++ b/test/riemann/streams_test.clj
@@ -689,7 +689,8 @@
 
 (deftest with-map
          (let [r (ref nil)
-               s (with {:service "foo" :state nil} (fn [e] (dosync (ref-set r e))))]
+               s (with {:service "foo" :state nil} (fn [e] (dosync (ref-set r e))))
+               empty-s (with {} (fn [e] (dosync (ref-set r e))))]
            (s (event {:service nil}))
            (is (= "foo" (:service (deref r))))
            (is (= nil (:state (deref r))))
@@ -700,7 +701,10 @@
 
            (s (event {:service "bar" :test "baz" :state "evil"}))
            (is (= "foo" (:service (deref r))))
-           (is (= nil (:state (deref r))))))
+           (is (= nil (:state (deref r))))
+
+           (empty-s (event {:service "bar" :test "baz"}))
+           (is (= "bar" (:service (deref r))))))
 
 (deftest by-single
          ; Each test stream keeps track of the first host it sees, and confirms


### PR DESCRIPTION
Currently if you put `with` inside `rollup`, you get this kind of error:

```
java.lang.IllegalArgumentException: Key must be integer

clojure.lang.APersistentVector.assoc(APersistentVector.java:335)
clojure.lang.APersistentVector.assoc(APersistentVector.java:18)
clojure.lang.RT.assoc(RT.java:702)
clojure.core$assoc.invoke(core.clj:187)
riemann.streams$with$stream__10405.invoke(streams.clj:1287)
riemann.streams$rollup$side_effects__10148$fn__10160.invoke(streams.clj:1078)
riemann.streams$rollup$side_effects__10148.invoke(streams.clj:1078)
riemann.streams$part_time_simple$stream__9574.invoke(streams.clj:610)
riemann.streams$rollup$side_effects__10148$fn__10160.invoke(streams.clj:1078)
riemann.streams$rollup$side_effects__10148.invoke(streams.clj:1078)
riemann.streams$part_time_simple$stream__9574.invoke(streams.clj:610)
riemann.streams$throttle$side_effects__10114$fn__10125.invoke(streams.clj:1042)
riemann.streams$throttle$side_effects__10114.invoke(streams.clj:1042)
riemann.streams$part_time_simple$stream__9574.invoke(streams.clj:610)
riemann.config$eval46679$fn__46886$stream__51793$fn__51798.invoke(riemann.config:834)
riemann.config$eval46679$fn__46886$stream__51793.invoke(riemann.config:834)
```

This fixes that, and also improves performance if users call `(with {} children)` - it removes the traversal of the event (at stream startup time, so there's no additional overhead at runtime).
