### PR TITLE
Xymon: fixes, scalability, multiple xymon host, error handling

### DIFF
--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -153,7 +153,7 @@
 
 (defn xymon
   "Returns a function which accepts an event or a vector of events and
-  which sends them to Xymon, as 'combo' messages if needed. Filters
+  which sends them to Xymon, as 'combo' messages if specified. Filters
   events with nil :state or :service. Use:
 
   (xymon {:host \"127.0.0.1\" :port 1984
@@ -163,10 +163,12 @@
   java.net.Socket documentation.
   "
   [opts]
-  (let [formatter (or (:formatter opts) event->status)]
+  (let [formatter (or (:formatter opts) event->status)
+        formatter (if (:combo opts false)
+                    (partial events->combo formatter)
+                    (partial map formatter))]
     (fn [events]
-      (doseq [message (events->combo
-                       formatter
+      (doseq [message (formatter
                        (filter #(and (:service %) (:state %))
                                (if (sequential? events) events [events])))]
         (send-message opts message)))))

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -119,7 +119,8 @@
            (not (:host opts)))
     (let [hosts (:hosts opts)
           opts (dissoc opts :hosts)]
-      (map (fn [host] (send-single-message (merge opts host) message)) hosts))
+      (doseq [host hosts]
+        (send-single-message (merge opts host) message)))
     (send-single-message opts message)))
 
 (def message-max-length 4096)

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -118,7 +118,7 @@
   (if (and (seq (:hosts opts))
            (not (:host opts)))
     (let [hosts (:hosts opts)
-          opts (discard opts :hosts)]
+          opts (dissoc opts :hosts)]
       (map (fn [host] (send-message (merge opts host) message)) hosts))
     (send-single-message opts message)))
 

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -91,20 +91,20 @@
   as a function with the exception as its parameter.
   "
   [opts line]
-  (try
-    (let [opts (merge
-                {:host "127.0.0.1" :port 1984 :timeout 5
-                 :error-handler *send-line-error-handler*}
-                opts)
-          addr (InetSocketAddress. (:host opts) (:port opts))
-          sock (Socket.)]
-      (.setSoTimeout sock (:timeout opts))
-      (.connect sock addr (:timeout opts))
-      (with-open [writer (io/writer sock)]
-        (.write writer line)
-        (.flush writer)))
-    (catch Exception e
-      ((:error-handler opts) e))))
+  (let [opts (merge
+              {:host "127.0.0.1" :port 1984 :timeout 5
+               :error-handler *send-line-error-handler*}
+              opts)]
+    (try
+      (let [addr (InetSocketAddress. (:host opts) (:port opts))
+            sock (Socket.)]
+        (.setSoTimeout sock (:timeout opts))
+        (.connect sock addr (:timeout opts))
+        (with-open [writer (io/writer sock)]
+          (.write writer line)
+          (.flush writer)))
+      (catch Exception e
+        ((:error-handler opts) e)))))
 
 (defn xymon
   "

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -136,7 +136,7 @@
      (events->combo formatter events combo-header combo-header-len)))
   ([formatter events message len]
    (if (empty? events)
-     '(message)
+     (list message)
      (let [next-message (formatter (first events))
            next-length (count next-message)
            length (+ len next-length 2)
@@ -144,7 +144,7 @@
        (cond
          ;; single message case // drop the combo
          (and (= len combo-header-len) (empty? events))
-         '(next-message)
+         (list next-message)
          ;; keep appending to message
          (< length message-max-length)
          (recur formatter events (str message next-message "\n\n") length)

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -69,10 +69,10 @@
     (format "disable %s.%s %s %s"
             host service (int (ceil (/ ttl 60))) description)))
 
-(defn *send-message-error-handler*
+(defn send-message-error
   "Logs given exception as an error message.
 
-  *send-message-error-handler* is the default error handler invoked by
+  send-message-error is the default error handler invoked by
   send-single-message if none is provided.
   "
   [opts exception]
@@ -85,13 +85,13 @@
   dedicated thread.
 
   If any exception is raised during the connect/send process, the
-  result of (:error-handler opts *send-message-error-handler*) is
-  invoked as a function with opts and the exception as its parameter.
+  result of (:error-handler opts send-message-error) is invoked as a
+  function with opts and the exception as its parameter.
   "
   [opts message]
   (let [opts (merge
               {:host "127.0.0.1" :port 1984 :timeout 5
-               :error-handler *send-message-error-handler*}
+               :error-handler send-message-error}
               opts)]
     (try
       (let [addr (InetSocketAddress. (:host opts) (:port opts))

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -176,8 +176,9 @@
 
 (defn xymon-batch
   "
-  Returns a function which accepts multiple events and send them to
-  xymon as 'combo' messages. Filters events with nil :state
+
+  Returns a function which accepts a vector of events and which sends
+  them to Xymon as 'combo' messages. Filters events with nil :state
   or :service.
   "
   [opts]

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -119,7 +119,7 @@
            (not (:host opts)))
     (let [hosts (:hosts opts)
           opts (dissoc opts :hosts)]
-      (map (fn [host] (send-message (merge opts host) message)) hosts))
+      (map (fn [host] (send-single-message (merge opts host) message)) hosts))
     (send-single-message opts message)))
 
 (def message-max-length 4096)
@@ -132,10 +132,11 @@
   message-max-length long.
   "
   ([formatter events]
-   (events->combo formatter events combo-header combo-header-len))
+   (if (seq events)
+     (events->combo formatter events combo-header combo-header-len)))
   ([formatter events message len]
    (if (empty? events)
-     (when-not (= len combo-header-len) '(message))
+     '(message)
      (let [next-message (formatter (first events))
            next-length (count next)
            length (+ len next-length 2)

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -138,7 +138,7 @@
    (if (empty? events)
      '(message)
      (let [next-message (formatter (first events))
-           next-length (count next)
+           next-length (count next-message)
            length (+ len next-length 2)
            events (rest events)]
        (cond

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -131,7 +131,8 @@
   Returns a lazy sequence of combo messages. Each message is at most
   xymon-max-line long.
   "
-  ([formatter events] (asdf formatter events combo-header combo-header-len))
+  ([formatter events]
+   (events->combo formatter events combo-header combo-header-len))
   ([formatter events message len]
    (if (empty? events)
      (when-not (= len combo-header-len) '(message))
@@ -141,7 +142,7 @@
            events (rest events)]
        (if (< length xymon-max-line)
          (recur formatter events (str message next "\n\n") length)
-         (cons message (lazy-seq (asdf formatter events))))))))
+         (cons message (lazy-seq (events->combo formatter events))))))))
 
 (defn send-combo
   "

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -8,12 +8,12 @@
 
 
 (defn host->xymon
-  "Format an hostname for Xymon. Basically, replace all dot chars by commas."
+  "Formats an hostname for Xymon. Basically, replaces all dot chars by commas."
   [host]
   (s/replace host "." ","))
 
 (defn service->xymon
-  "Format a service name to be understood by Xymon."
+  "Formats a service name to be understood by Xymon."
   [service]
   (s/replace service #"(\.| )" "_"))
 

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -42,8 +42,7 @@
             ttl-prefix host service state description)))
 
 (defn event->enable
-  "
-  Convert an event to an Xymon enable message:
+  "Converts an event to an Xymon enable message:
 
   enable HOSTNAME.TESTNAME
 
@@ -56,8 +55,8 @@
     (format "enable %s.%s" host service)))
 
 (defn event->disable
-  "
-  Convert an event to a Xymon disable message:
+  "Converts an event to a Xymon disable message:
+
   disable HOSTNAME.TESTNAME DURATION <additional text>
 
   Fields mapping is the same as event->status'. Also, the event ttl is
@@ -71,8 +70,7 @@
             host service (int (ceil (/ ttl 60))) description)))
 
 (defn *send-message-error-handler*
-  "
-  Logs given exception as an error message.
+  "Logs given exception as an error message.
 
   *send-message-error-handler* is the default error handler invoked by
   send-single-message if none is provided.
@@ -82,8 +80,7 @@
                            (:host opts) (:port opts))))
 
 (defn send-single-message
-  "
-  Connects to a Xymon server, sends message, then closes the
+  "Connects to a Xymon server, sends message, then closes the
   connection. This is a blocking operation and should happen on a
   dedicated thread.
 
@@ -108,8 +105,7 @@
         ((:error-handler opts) opts e)))))
 
 (defn send-message
-  "
-  Sends given message to Xymon host(s).
+  "Sends given message to Xymon host(s).
 
   If (:hosts opts) is a sequence _and_ (:host opts) is false, sends
   the message to all hosts described in (:hosts opts). When
@@ -127,8 +123,7 @@
     (send-single-message opts message)))
 
 (defn xymon
-  "
-  Returns a function which accepts an event and sends it to Xymon.
+  "Returns a function which accepts an event and sends it to Xymon.
   Drops events when Xymon is down. Use:
 
   (xymon {:host \"127.0.0.1\" :port 1984
@@ -147,8 +142,7 @@
 (def- combo-header-len (count combo-header))
 
 (defn events->combo
-  "
-  Returns a lazy sequence of combo messages. Each message is at most
+  "Returns a lazy sequence of combo messages. Each message is at most
   message-max-length long.
   "
   ([formatter events]
@@ -165,9 +159,8 @@
          (cons message (lazy-seq (events->combo formatter events))))))))
 
 (defn send-combo
-  "
-  Turns events into combo messages (using events->combo) and send them
-  to Xymon.
+  "Turns events into combo messages (using events->combo) and send
+  them to Xymon.
   "
   [opts events]
   (let [formatter (or (:formatter opts) event->status)]
@@ -175,11 +168,12 @@
       (send-message opts combo-message))))
 
 (defn xymon-batch
-  "
+  "Returns a function which accepts an event or a vector of events and
+  which sends them to Xymon, as 'combo' messages if needed. Filters
+  events with nil :state or :service.
 
-  Returns a function which accepts a vector of events and which sends
-  them to Xymon as 'combo' messages. Filters events with nil :state
-  or :service.
+  (xymon {:host \"127.0.0.1\" :port 1984
+          :timeout 5 :formatter event->status})
   "
   [opts]
   (fn [events]

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -90,7 +90,7 @@
   "
   [opts message]
   (let [opts (merge
-              {:host "127.0.0.1" :port 1984 :timeout 5
+              {:host "127.0.0.1" :port 1984 :timeout 5000
                :error-handler send-message-error}
               opts)]
     (try
@@ -157,7 +157,10 @@
   events with nil :state or :service. Use:
 
   (xymon {:host \"127.0.0.1\" :port 1984
-          :timeout 5 :formatter event->status})
+          :timeout 5000 :formatter event->status})
+
+  The :timeout value is expressed in milliseconds, as specified in
+  java.net.Socket documentation.
   "
   [opts]
   (let [formatter (or (:formatter opts) event->status)]

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -130,7 +130,7 @@
 (defn- make-combo [messages]
   (if (= (count messages) 1)            ; messages must not be empty
     (first messages)
-    (str combo-header (clojure.string/join "\n\n" messages) "\n\n")))
+    (str combo-header (s/join "\n\n" messages) "\n\n")))
 
 (defn events->combo
   "Returns a lazy sequence of combo messages. Each message is at most
@@ -171,10 +171,8 @@
   java.net.Socket documentation.
   "
   [opts]
-  (let [formatter (or (:formatter opts) event->status)
-        formatter (if (:combo opts false)
-                    (partial events->combo formatter)
-                    (partial map formatter))]
+  (let [formatter (partial (if (:combo opts false) events->combo map)
+                           (or (:formatter opts) event->status))]
     (fn [events]
       (doseq [message (formatter
                        (filter #(and (:service %) (:state %))

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -77,8 +77,9 @@
   *send-line-error-handler* is the default error handler invoked by
   send-line if none is provided.
   "
-  [exception]
-  (error exception "cannot reach xymon host"))
+  [opts exception]
+  (error exception (format "cannot reach xymon host (%s:%s)"
+                           (:host opts) (:port opts))))
 
 (defn send-line
   "
@@ -104,7 +105,7 @@
           (.write writer line)
           (.flush writer)))
       (catch Exception e
-        ((:error-handler opts) e)))))
+        ((:error-handler opts) opts e)))))
 
 (defn xymon
   "

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -156,7 +156,7 @@
 (defn xymon-batch
   "
   Returns a function which accepts multiple events and send them to
-  xymon as 'combo' messages. Filters events without nil :state
+  xymon as 'combo' messages. Filters events with nil :state
   or :service.
   "
   [opts]

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -124,8 +124,8 @@
 
 (def message-max-length 4096)
 
-(def- combo-header "combo\n")
-(def- combo-header-len (count combo-header))
+(def ^:private combo-header "combo\n")
+(def ^:private combo-header-len (count combo-header))
 
 (defn events->combo
   "Returns a lazy sequence of combo messages. Each message is at most

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -109,8 +109,7 @@
 (defn xymon
   "
   Returns a function which accepts an event and sends it to Xymon.
-  Silently drops events when xymon is down. Attempts to reconnect
-  automatically every five seconds. Use:
+  Drops events when Xymon is down. Use:
 
   (xymon {:host \"127.0.0.1\" :port 1984
           :timeout 5 :formatter event->status})
@@ -119,5 +118,5 @@
   (let [formatter (or (:formatter opts) event->status)]
     (fn [{:keys [state service] :as event}]
       (when (and state service)
-        (let [statusmessage ((:formatter opts) event)]
+        (let [statusmessage (formatter event)]
           (send-line opts statusmessage))))))

--- a/test/riemann/xymon_test.clj
+++ b/test/riemann/xymon_test.clj
@@ -74,6 +74,19 @@
     (doseq [[event line] pairs]
       (is (= line (event->disable event))))))
 
+(deftest ^:xymon-combo events->combo-test
+  (let [formatter #(str % "_s")
+        long-message (clojure.string/join (repeat 2048 "o"))
+        long-message_s (str long-message "_s")
+        pairs [[["foo"] ["foo_s"]]
+               [["foo" "bar" "asdf"]
+                ["combo\nfoo_s\n\nbar_s\n\nasdf_s\n\n"]]
+               [[long-message long-message]
+                [long-message_s long-message_s]]]]
+    (doseq [[events result] pairs]
+      (is (= result
+             (events->combo formatter events))))))
+
 (deftest ^:xymon ^:integration xymon-test
          (let [k (xymon nil)]
            (k {:host "riemann.local"

--- a/test/riemann/xymon_test.clj
+++ b/test/riemann/xymon_test.clj
@@ -82,7 +82,10 @@
                [["foo" "bar" "asdf"]
                 ["combo\nfoo_s\n\nbar_s\n\nasdf_s\n\n"]]
                [[long-message long-message]
-                [long-message_s long-message_s]]]]
+                [long-message_s long-message_s]]
+               [[long-message "foo" long-message]
+                [(str long-message_s "\n\nfoo_s\n\n")
+                 long-message_s]]]]
     (doseq [[events result] pairs]
       (is (= result
              (events->combo formatter events))))))

--- a/test/riemann/xymon_test.clj
+++ b/test/riemann/xymon_test.clj
@@ -2,7 +2,8 @@
   (:use riemann.xymon
         [riemann.time :only [unix-time]]
         clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:require [riemann.logging :as logging]
+            [clojure.string]))
 
 (logging/init)
 
@@ -84,7 +85,7 @@
                [[long-message long-message]
                 [long-message_s long-message_s]]
                [[long-message "foo" long-message]
-                [(str long-message_s "\n\nfoo_s\n\n")
+                [(str "combo\n" long-message_s "\n\nfoo_s\n\n")
                  long-message_s]]]]
     (doseq [[events result] pairs]
       (is (= result


### PR DESCRIPTION
Hello !

Here is a new bunch of updates for the riemann/xymon module which brings :
* Ability to send combo messages (multiple messages in a single TCP connection), through the new ```xymon-batch``` function. This should improve scalability and also makes more sense in statements such as ```(batch (xymon ...))```)
* Ability to send messages to multiple xymon hosts without too much pain.
* Ability to define per-xymon-server connection error handlers.
* A few minor bug fixes

Feel free to comment on the code quality, if need be.

Regards,
Damien.