### PR TITLE
Add support for KairosDB HTTP integration and metric TTLs

### DIFF
--- a/test/riemann/kairosdb_test.clj
+++ b/test/riemann/kairosdb_test.clj
@@ -7,24 +7,25 @@
 (logging/init)
 
 (deftest ^:kairosdb ^:integration kairosdb-test
-         (let [k (kairosdb {:block-start true})]
-           (k {:host "riemann.local"
-               :service "kairosdb test"
-               :state "ok"
-               :description "all clear, uh, situation normal"
-               :metric -2
-               :time (unix-time)}))
+  (let [k (kairosdb {:block-start true})]
+    (k {:host "riemann.local"
+        :service "kairosdb test"
+        :state "ok"
+        :description "all clear, uh, situation normal"
+        :metric -2
+        :time (unix-time)}))
 
-         (let [k (kairosdb {:block-start true})]
-           (k {:service "kairosdb test"
-               :state "ok"
-               :description "all clear, uh, situation normal"
-               :metric 3.14159
-               :time (unix-time)}))
+  (let [k (kairosdb {:block-start true})]
+    (k {:service "kairosdb test"
+        :state "ok"
+        :description "all clear, uh, situation normal"
+        :metric 3.14159
+        :time (unix-time)}))
 
-         (let [k (kairosdb {:block-start true})]
-           (k {:host "no-service.riemann.local"
-               :state "ok"
-               :description "Missing service, not transmitted"
-               :metric 4
-               :time (unix-time)})))
+  (let [k (kairosdb {:block-start true})]
+    (k {:host "no-service.riemann.local"
+        :state "ok"
+        :description "Missing service, not transmitted"
+        :metric 4
+        :time (unix-time)})))
+

--- a/test/riemann/kairosdb_test.clj
+++ b/test/riemann/kairosdb_test.clj
@@ -6,7 +6,7 @@
 
 (logging/init)
 
-(deftest ^:kairosdb ^:integration kairosdb-test
+(deftest ^:kairosdb ^:integration kairosdb-send-test
   (let [k (kairosdb {:block-start true})]
     (k {:host "riemann.local"
         :service "kairosdb test"
@@ -27,5 +27,39 @@
         :state "ok"
         :description "Missing service, not transmitted"
         :metric 4
+        :time (unix-time)}))
+
+  (let [k (kairosdb {:block-start true
+                     :protocol :http
+                     :port 8080})]
+    (k {:host "no-service.riemann.local"
+        :state "ok"
+        :description "Missing service, not transmitted"
+        :metric 5
         :time (unix-time)})))
 
+(deftest ^:kairosdb kairosdb-batching-test
+  (let [events [{:host "no-service.riemann.local"
+                 :service "kairosdb test"
+                 :state "ok"
+                 :description "Missing service, not transmitted"
+                 :metric 4
+                 :time (unix-time)}
+                {:host "riemann.local"
+                 :service "kairosdb test"
+                 :state "ok"
+                 :description "Situation nominal"
+                 :metric 5
+                 :time (unix-time)}]
+        output (atom [])
+        mock-client (reify KairosDBClient
+                      (open [this] this)
+                      (close [this] this)
+                      (send-metrics [this metrics] (swap! output conj metrics)))]
+    (with-redefs [riemann.kairosdb/make-kairosdb-client (fn [_ _ _] mock-client)]
+      (let [k (kairosdb {:protocol :tcp
+                         :batch true
+                         :batch-opts {:n 2 :dt 60}})]
+        (doseq [event events]
+          (k event)))
+      (is (= (map count @output) [2])))))


### PR DESCRIPTION
Currently, the Riemann KairosDB integration only supports the KairosDB telnet/TCP interface, which doesn't offer support for the per-data-point TTL feature. This PR adds the ability to use the KairosDB HTTP API, which does allow you to specify TTLs for every data point. TCP will remain the default.

Also, since the KairosDB HTTP endpoint is considerably slower than the TCP endpoint, this also adds optional support for batching metrics to KairosDB to help overcome the significant latency that results from making individual add data point calls over HTTP.