### PR TITLE
close channel when it becomes unwritable

### DIFF
--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -54,6 +54,11 @@
   ChannelInboundHandlerAdapter which calls (handler core stats
   channel-handler-context message) for each received message.
 
+  To prevent Netty outbound buffer from filling up in the case of clients not 
+  reading ack messages, we close the channel when it becomes unwritable. Clients
+  should then be ready to reconnect if need be as they will receive some form
+  of exception in this case.
+
   Automatically handles channel closure, and handles exceptions thrown by the
   handler by logging an error and closing the channel."
   [core stats ^ChannelGroup channel-group handler]
@@ -61,6 +66,11 @@
     (channelActive [ctx]
       (.add channel-group (.channel ctx)))
 
+    (channelWritabilityChanged [^ChannelHandlerContext ctx]
+      (let [channel (.channel ctx)]
+        (when (not (.isWritable channel))
+          (.close channel))))
+    
     (channelRead [^ChannelHandlerContext ctx ^Object message]
       (try
         (handler @core stats ctx message)
@@ -93,6 +103,7 @@
     (.. ctx
       ; Actually handle request
       (writeAndFlush (handle core message))
+
       ; Record time from parse to write completion
       (addListener
         (reify ChannelFutureListener

--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -69,6 +69,8 @@
     (channelWritabilityChanged [^ChannelHandlerContext ctx]
       (let [channel (.channel ctx)]
         (when (not (.isWritable channel))
+          (warn "forcefully closing connection from " (.remoteAddress channel)
+                ". Client might be not reading acks fast enough or network is broken")
           (.close channel))))
     
     (channelRead [^ChannelHandlerContext ctx ^Object message]

--- a/test/riemann/transport_test.clj
+++ b/test/riemann/transport_test.clj
@@ -12,10 +12,13 @@
             [riemann.transport.sse :refer [sse-server]]
             [cheshire.core :as json]
             [riemann.client :as client]
+            [riemann.codec :as codec]
             [riemann.index :as index])
   (:import (java.net Socket
+                     SocketException
                      InetAddress)
-           (java.io IOException)))
+           (java.io IOException
+                    DataOutputStream)))
 
 (logging/init)
 
@@ -194,3 +197,40 @@
         (finally
           (.close sock)
           (stop! core))))))
+
+(defn tcp-client-ignoring-acks
+  "A TCP client that send events to server but does not read acks received"
+  [client-opts server-opts]
+  ;; TODO use plain socket to connect to server and send hand-crafted protobuf messages
+  ;; using something similar to the following: protobuf messages can be read from/written to
+  ;; byte arrays
+  (let [server (tcp-server server-opts)
+        index (wrap-index (index/index))
+        core (transition! (core) {:index index
+                                  :services [server]
+                                  :streams [index]})]
+    (let  [sock (Socket. "localhost" (:port client-opts))
+           out  (DataOutputStream. (.getOutputStream sock))
+           msg  (codec/encode-pb-msg {:events [
+                                               {:host "localhost"
+                                                :service "foo"
+                                                :metric 42}]})]
+      (try
+        (loop [stop false]
+          (when (not stop)
+            (do
+              (.writeInt out (.getSerializedSize msg))
+              (.writeTo msg out)
+              (recur false))))
+        (finally
+          (stop! core))))))
+
+(deftest prevent-outbound-buffer-overflow-test
+  (let [server {:port 15555}
+        client {:port 15555}]
+ 
+      ; Fails when connection is closed by server
+      (is (thrown? SocketException
+                   (tcp-client-ignoring-acks client                   
+                                             server))))
+    )


### PR DESCRIPTION
this happens when channel's  buffer is filled with pending messages because client
does not read them fast enough (or at all). This should prevent OOME from occuring
because of misbehaving clients. This should fix #623 