### PR TITLE
Replace syntax highlighting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
 safe: true
-highlighter: pygments
+highlighter: rouge
 markdown: kramdown


### PR DESCRIPTION
Apparently the Jekyll 3.0 upgrade now uses `rouge` not `pygments`.