### PR TITLE
Expiring (by)

### DIFF
--- a/src/riemann/ttl_cache.clj
+++ b/src/riemann/ttl_cache.clj
@@ -1,0 +1,53 @@
+(ns riemann.ttl-cache
+  "Variation of clojure.core.cache.TTLCache which uses a priority-map to track key expiration"
+  (:require [clojure.core.cache :refer [defcache CacheProtocol lookup has? hit miss seed evict]])
+  (:require [clojure.data.priority-map :refer [priority-map]]))
+
+(defn- key-killer
+  [ttl expiry now]
+  (let [ks (map key (take-while #(> (- now (val %)) expiry) ttl))]
+    #(apply dissoc % ks)))
+
+(defcache TTLCache [cache ttl ttl-ms]
+  CacheProtocol
+  (lookup [this item]
+    (let [ret (lookup this item ::nope)]
+      (when-not (= ret ::nope) ret)))
+  (lookup [this item not-found]
+    (if (has? this item)
+      (get cache item)
+      not-found))
+  (has? [_ item]
+    (let [t (get ttl item (- ttl-ms))]
+      (< (- (System/currentTimeMillis)
+            t)
+         ttl-ms)))
+  (hit [this item] this)
+  (miss [this item result]
+    (let [now  (System/currentTimeMillis)
+          kill-old (key-killer ttl ttl-ms now)]
+      (TTLCache. (assoc (kill-old cache) item result)
+                 (assoc (kill-old ttl) item now)
+                 ttl-ms)))
+  (seed [_ base]
+    (let [now (System/currentTimeMillis)]
+      (TTLCache. base
+                 (apply priority-map (for [x base] [(key x) now]))
+                 ttl-ms)))
+  (evict [_ key]
+    (TTLCache. (dissoc cache key)
+               (dissoc ttl key)
+               ttl-ms))
+  Object
+  (toString [_]
+    (str cache \, \space ttl \, \space ttl-ms)))
+
+(defn ttl-cache-factory
+  "Returns a TTL cache with the cache and expiration-table initialied to `base` --
+   each with the same time-to-live.
+   This function also allows an optional `:ttl` argument that defines the default
+   time in milliseconds that entries are allowed to reside in the cache."
+  [base & {ttl :ttl :or {ttl 2000}}]
+  {:pre [(number? ttl) (<= 0 ttl)
+         (map? base)]}
+  (clojure.core.cache/seed (TTLCache. {} {} ttl) base))

--- a/src/riemann/ttl_cache.clj
+++ b/src/riemann/ttl_cache.clj
@@ -1,14 +1,15 @@
 (ns riemann.ttl-cache
-  "Variation of clojure.core.cache.TTLCache which uses a priority-map to track key expiration"
-  (:require [clojure.core.cache :refer [defcache CacheProtocol lookup has? hit miss seed evict]])
-  (:require [clojure.data.priority-map :refer [priority-map]]))
+  "Variation of clojure.core.cache.TTLCache which uses a priority-map to track key expiration.
+   Object expiration is expected to be passed in as (:expires object)"
+  (:require [clojure.core.cache :refer [defcache CacheProtocol lookup has? hit miss seed evict]]
+            [clojure.data.priority-map :refer [priority-map]]
+            [riemann.time :refer [unix-time]]))
 
-(defn- key-killer
-  [ttl expiry now]
-  (let [ks (map key (take-while #(> (- now (val %)) expiry) ttl))]
+(defn- key-killer [ttl now]
+  (let [ks (map key (take-while #(> now (val %)) ttl))]
     #(apply dissoc % ks)))
 
-(defcache TTLCache [cache ttl ttl-ms]
+(defcache TTLCache [cache ttl]
   CacheProtocol
   (lookup [this item]
     (let [ret (lookup this item ::nope)]
@@ -18,36 +19,29 @@
       (get cache item)
       not-found))
   (has? [_ item]
-    (let [t (get ttl item (- ttl-ms))]
-      (< (- (System/currentTimeMillis)
-            t)
-         ttl-ms)))
+    (let [t (get ttl item -1)]
+      (< (unix-time) t)))
   (hit [this item] this)
   (miss [this item result]
-    (let [now  (System/currentTimeMillis)
-          kill-old (key-killer ttl ttl-ms now)]
+    (let [now (unix-time)
+          kill-old (key-killer ttl now)]
       (TTLCache. (assoc (kill-old cache) item result)
-                 (assoc (kill-old ttl) item now)
-                 ttl-ms)))
+                 (assoc (kill-old ttl) item (:expires result)))))
   (seed [_ base]
-    (let [now (System/currentTimeMillis)]
-      (TTLCache. base
-                 (apply priority-map (for [x base] [(key x) now]))
-                 ttl-ms)))
+    (TTLCache. base
+               (apply priority-map (for [x base] [(key x) (:expires (val x))]))))
   (evict [_ key]
     (TTLCache. (dissoc cache key)
-               (dissoc ttl key)
-               ttl-ms))
+               (dissoc ttl key)))
   Object
   (toString [_]
-    (str cache \, \space ttl \, \space ttl-ms)))
+    (str cache \, \space ttl)))
 
 (defn ttl-cache-factory
   "Returns a TTL cache with the cache and expiration-table initialied to `base` --
    each with the same time-to-live.
    This function also allows an optional `:ttl` argument that defines the default
    time in milliseconds that entries are allowed to reside in the cache."
-  [base & {ttl :ttl :or {ttl 2000}}]
-  {:pre [(number? ttl) (<= 0 ttl)
-         (map? base)]}
-  (clojure.core.cache/seed (TTLCache. {} {} ttl) base))
+  [base]
+  {:pre [(map? base)]}
+  (clojure.core.cache/seed (TTLCache. {} {}) base))


### PR DESCRIPTION
This is my take on limiting the resource consumption of (by) (https://github.com/riemann/riemann/pull/526).

I actually offer 2 different solutions, in 2 different commits.
The first commit provides a generic way of limiting the streams (by ttl / lru / whatever cache implementation you want - see: https://github.com/clojure/core.cache).
The second commit provides an expiry based solution and is not as generic.

I'd like to get some feedback on this, not sure which direction is better.