### PR TITLE
slack: properly setup :fallback in bundled formatters

### DIFF
--- a/src/riemann/slack.clj
+++ b/src/riemann/slack.clj
@@ -11,7 +11,7 @@
   (escape message {\< "&lt;" \> "&gt;" \& "&amp;"}))
 
 (defn slack-fallback
-  ""
+  "Minimal, plain-text event formatting. Used for dumb clients such as IRC."
   [events]
   (slack-escape
     (str

--- a/src/riemann/slack.clj
+++ b/src/riemann/slack.clj
@@ -10,12 +10,24 @@
   [message]
   (escape message {\< "&lt;" \> "&gt;" \& "&amp;"}))
 
+(defn slack-fallback
+  ""
+  [events]
+  (slack-escape
+    (str
+      "*Host:* " (or (:host events) "-")
+      " *Service:* " (or (:service events) "-")
+      " *State:* " (or (:state events) "-")
+      " *Description:* " (or (:description events) "-")
+      " *Metric:* " (or (:metric events) "-"))))
+
 
 (defn default-formatter
   "Simple formatter for rendering an event as a Slack attachment."
   [events]
   {:attachments
-   [{:fields
+   [{:fallback (slack-fallback events)
+     :fields
      [{:title "Riemann Event"
        :value (slack-escape
                 (str "Host:   " (or (:host events) "-") "\n"
@@ -32,19 +44,7 @@
   [events]
   {:text "This event requires your attention!",
    :attachments
-   [{:fallback
-     (slack-escape
-       (str
-         "*Service:* "
-         (:service events)
-         "*Description:* "
-         (:description events)
-         " *Host:* "
-         (:host events)
-         " *Metric:* "
-         (:metric events)
-         " *State:* "
-         (:state events))),
+   [{:fallback (slack-fallback events)
      :text (slack-escape (or (:description events) "")),
      :pretext "Event Details:",
      :color

--- a/test/riemann/slack_test.clj
+++ b/test/riemann/slack_test.clj
@@ -53,7 +53,11 @@
                     :description "Mailer failed", :metric 42, :tags ["first", "second"]})
           (is (= (json/parse-string (:body @post-request))
                  {"attachments" [{"fields" [{"title" "Riemann Event"
-                                             "value" "Host:   localhost\nService:   mailer\nState:   error\nDescription:   Mailer failed\nMetric:   42\nTag:   -\n" "short" true}]}] "channel" "#test-channel" "username" "test-user" "icon_emoji" ":warning:"}))))
+                                             "value" "Host:   localhost\nService:   mailer\nState:   error\nDescription:   Mailer failed\nMetric:   42\nTag:   -\n" "short" true}]
+                                  "fallback" "*Host:* localhost *Service:* mailer *State:* error *Description:* Mailer failed *Metric:* 42"}]
+                  "channel" "#test-channel"
+                  "username" "test-user"
+                  "icon_emoji" ":warning:"}))))
 
       (testing "allows formatting characters in main message text with custom formatter"
         (let [formatter (fn [e] {:text (str "<http://health.check.api/" (:service e) "|" (:service e) ">")})


### PR DESCRIPTION
Adds a short plain-text summary to the slack attachments generated. This
is the text displayed by clients which don't support fancy formatting,
such as the slack IRC gateway.