### PR TITLE
howto: provide a debugging config example

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -136,14 +136,14 @@ sudo service riemann reload
   <div class="sixcol">
     <p>We present here a minimal configuration which only prints incoming events to
       standard output. This configuration can prove useful when debugging clients to
-      make sure expected events are reaching riemann.</p>
+      make sure expected events are reaching Riemann.</p>
 
     <p>This example includes a full configuration, later examples will focus on streams.
       The following actions are performed:
 
       <ul>
-        <li><code>logging/init</code>: Setting-up logging to log to standard out.</li>
-        <li><code>tcp-server</code>: Starting a riemann TCP server on port 5555 (the default).</li>
+        <li><code>logging/init</code>: Setting-up logging to log to standard output (<code>STDOUT</code>).</li>
+        <li><code>tcp-server</code>: Starting a Riemann TCP server on port 5555 (the default).</li>
         <li><code>instrumentation</code>: Disabling internal event production.</li>
       </ul>
     </p>

--- a/howto.html
+++ b/howto.html
@@ -131,6 +131,40 @@ sudo service riemann reload
   </div>
 </div>
 
+<h3>A minimal configuration</h3>
+<div class="row">
+  <div class="sixcol">
+    <p>We present here a minimal configuration which only prints incoming events to
+      standard output. This configuration can prove useful when debugging clients to
+      make sure expected events are reaching riemann.</p>
+
+    <p>This example includes a full configuration, later examples will focus on streams.
+      The following actions are performed:
+
+      <ul>
+        <li><code>logging/init</code>: Setting-up logging to log to standard out.</li>
+        <li><code>tcp-server</code>: Starting a riemann TCP server on port 5555 (the default).</li>
+        <li><code>instrumentation</code>: Disabling internal event production.</li>
+      </ul>
+    </p>
+
+    <p>Since streams expects a list of functions to call with individual events, we can
+       output any input by calling <code>prn</code> on them.
+    </p>
+      
+  </div>
+  <div class="sixcol last">
+{% highlight clj %}
+(logging/init {:console true})
+(tcp-server {})
+(instrumentation {:enabled? false})
+
+(streams
+ prn) 
+{% endhighlight %}    
+  </div>
+</div>
+
 <h3>Including configuration from multiple files</h3>
 <div class="row">
   <div class="sixcol">


### PR DESCRIPTION
When testing new clients, I think it is useful to start with a config that dumps events.
I found that doing this isn't well understood and might be a good target for documentation.