### PR TITLE
Fixed deprecation warning to use correct new function.

### DIFF
--- a/src/riemann/index.clj
+++ b/src/riemann/index.clj
@@ -123,5 +123,5 @@
 
 (defn update
   [index-instance event]
-  (deprecated "Update is now a reserved name in clojure, please use update!"
+  (deprecated "Update is now a reserved name in clojure, please use insert!"
               (insert index-instance event)))


### PR DESCRIPTION
The `update` deprecation warning was recursive. Now it is not.