### PR TITLE
Add batch forwarding for datadog

### DIFF
--- a/src/riemann/datadog.clj
+++ b/src/riemann/datadog.clj
@@ -19,29 +19,43 @@
   [(vector (:time event) (:metric event))])
 
 (defn post-datapoint
-  "Post the riemann metrics datapoints."
+  "Post the riemann metrics as datapoints."
   [api-key data]
   (let [url (str gateway-url "?api_key=" api-key)
         http-options {:body data
                       :content-type :json}]
     (client/post url http-options)))
 
+(defn generate-event [event]
+  {:metric (datadog-metric-name event)
+   :type "gauge"
+   :host (:host event)
+   :tags (:tags event)
+   :points (generate-datapoint event)})
+
 (defn datadog
-  "Return a function which accepts event and sends it to datadog.
+  "Return a function which accepts either single events or batches of
+   events in a vector and sends them to datadog. Batching reduces latency
+   by at least one order of magnitude and is highly recommended.
   Usage:
-
   (datadog {:api-key \"bn14a6ac2e3b5h795085217d49cde7eb\"})
-
   Option:
-
-  :api-key    Datadog's API Key for authentication."
+  :api-key    Datadog's API Key for authentication.
+  Example:
+  (def datadog-forwarder
+    (batch 100 1/10
+      (async-queue!
+        :datadog-forwarder    ; A name for the forwarder
+        {:queue-size     1e4  ; 10,000 events max
+         :core-pool-size 5    ; Minimum 5 threads
+         :max-pools-size 100} ; Maxium 100 threads
+        (datadog {:api-key \"bn14a6ac2e3b5h795085217d49cde7eb\"}))))"
   [opts]
   (let [opts (merge {:api-key "datadog-api-key"} opts)]
     (fn [event]
-      (let [post-data {:series [{:metric (datadog-metric-name event)
-                                 :type "gauge"
-                                 :host (:host event)
-                                 :tags (:tags event)
-                                 :points (generate-datapoint event)}]}
+      (let [events (if (sequential? event)
+                     event
+                     [event])
+            post-data {:series (mapv generate-event events)}
             json-data (generate-string post-data)]
         (post-datapoint (:api-key opts) json-data)))))

--- a/test/riemann/datadog_test.clj
+++ b/test/riemann/datadog_test.clj
@@ -4,41 +4,60 @@
         clojure.test)
   (:require [riemann.logging :as logging]))
 
+(def datadog-key (or (System/getenv "DATADOG_API_KEY")
+                     (do (println "export DATADOG_API_KEY=\"...\" to run these tests.")
+                         "datadog-test-key")))
+
 (logging/init)
 
 (deftest ^:datadog ^:integration datadog-test
-         (let [k (datadog {:api-key "datadog-test-key"})]
-           (k {:host "riemann.local"
-               :service "datadog test"
-               :state "ok"
-               :description "all clear, uh, situation normal"
-               :metric -2
-               :time (unix-time)}))
+  (let [k (datadog {:api-key datadog-key})]
+    (k {:host        "riemann.local"
+        :service     "datadog test"
+        :state       "ok"
+        :description "all clear, uh, situation normal"
+        :metric      -2
+        :time        (unix-time)}))
 
-         (let [k (datadog {:api-key "datadog-test-key"})]
-           (k {:service "datadog test"
-               :state "ok"
-               :description "all clear, uh, situation normal"
-               :metric 3.14159
-               :time (unix-time)}))
+  (let [k (datadog {:api-key datadog-key})]
+    (k {:service     "datadog test"
+        :state       "ok"
+        :description "all clear, uh, situation normal"
+        :metric      3.14159
+        :time        (unix-time)}))
 
-         (let [k (datadog {:api-key "datadog-test-key"})]
-           (k {:host "no-service.riemann.local"
-               :state "ok"
-               :description "Missing service, not transmitted"
-               :metric 4
-               :time (unix-time)}))
+  (let [k (datadog {:api-key datadog-key})]
+    (k {:host        "no-service.riemann.local"
+        :state       "ok"
+        :description "Missing service, not transmitted"
+        :metric      4
+        :time        (unix-time)}))
 
-         (let [k (datadog {:api-key "datadog-test-key"})]
-           (k [
-               {:host "no-service.riemann.local"
-                :state "ok"
-                :description "Missing service, not transmitted"
-                :metric 4
-                :time (unix-time)},
-               {:host "no-service.riemann.local"
-                :state "ok"
-                :description "Missing service, not transmitted"
-                :metric 4
-                :time (unix-time)}
-              ])))
+  (let [k (datadog {:api-key datadog-key})]
+    (k [{:host        "no-service.riemann.local"
+         :state       "ok"
+         :description "Missing service, not transmitted"
+         :metric      4
+         :time        (unix-time)},
+        {:host        "no-service.riemann.local"
+         :state       "ok"
+         :description "Missing service, not transmitted"
+         :metric      4
+         :time        (unix-time)}])
+    (k [{:host        "no-service.riemann.local"
+         :service     "datadog test"
+         :state       "ok"
+         :description "all clear, uh, situation normal"
+         :metric      4
+         :time        (unix-time)},
+        {:host        "batch-test.riemann.local"
+         :service     "datadog test"
+         :state       "ok"
+         :description "all clear, uh, situation normal"
+         :metric      4
+         :time        (unix-time)}
+        {:host        "batch-test.riemann.local" ;; look for this service and host
+         :service     "datadog test"             ;; tag in datadog's "metric summary"
+         :state       "ok"
+         :description "no metric"
+         :time        (unix-time)}])))


### PR DESCRIPTION
Make the datadog forwarder accept either single events or batches.
This greatly reduces the latency and increases throughput by at
least one order of magnatude.

Signed-off-by: Arthur Ulfeldt <arthur@ulfeldt.com>