### PR TITLE
Renamed com.aphyr to io.riemann in Documentation

### DIFF
--- a/clients.html
+++ b/clients.html
@@ -103,11 +103,11 @@ title: Riemann - Clients
       provides a basic thread-safe TCP and UDP client built on Netty. It offers
       synchronous and asynchronous APIs and is used by Riemann internally. You
       can grab it from <a
-        href="http://clojars.org/com.aphyr/riemann-java-client">clojars</a>.</p>
+        href="http://clojars.org/io.riemann/riemann-java-client">clojars</a>.</p>
 
       <p>mgodave's <a
         href="https://github.com/mgodave/riemann-client">riemann-client</a> is
-      based on Netty and Java Futures.</p> 
+      based on Netty and Java Futures.</p>
 
       <h2 id="lua">Lua</h2>
 
@@ -220,7 +220,6 @@ title: Riemann - Clients
          SNMP poller, with very low system overhead. It publishes the output
         of its SNMP polls to a riemann host</a>. A great fit when you need
         some data from these pesky SNMP-only proprietary network devices.</p>
-      
 
       <h2 id="jmx">JMX</h2> <p><a
         href="https://github.com/twosigma/riemann-jmx">The Clojure fork of
@@ -302,7 +301,7 @@ title: Riemann - Clients
       <p>Additional functionality within riemann provided by external libraries</p>
 
       <h2 id="riemann-acknowledgement">riemann-acknowledgement</h2>
-    <p>Provides the ability to acknowledge hosts & services temporarily, suppressing alert sending.
+    <p>Provides the ability to acknowledge hosts &amp; services temporarily, suppressing alert sending.
       Acnowledgements are handled through a simple web interface.
       <a href="https://github.com/exoscale/riemann-acknowledgement">https://github.com/exoscale/riemann-acknowledgement</a>
     </p>


### PR DESCRIPTION
Assumes https://github.com/riemann/riemann-java-client/pull/71 has been
merged.