### PR TITLE
Renamed com.aphyr to io.riemann in Riemann core

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,10 @@
+# Version 0.2.12
+
+## Deprecations and API changes
+
+- The `com.aphyr` namespace used by the Riemamn Java client has been
+  updated to `io.riemann`. The client is now updated in Riemann.
+
 # Version 0.2.11
 
 This update includes a variety of bug fixes and improvements. Also

--- a/src/riemann/common.clj
+++ b/src/riemann/common.clj
@@ -3,7 +3,7 @@
   definitions and codecs, some vector set ops, etc."
   (:import [java.util Date]
            (java.io InputStream)
-           [com.aphyr.riemann Proto$Query Proto$Event Proto$Msg]
+           [io.riemann.riemann Proto$Query Proto$Event Proto$Msg]
            [java.net InetAddress])
   (:require clj-time.core
             clj-time.format

--- a/src/riemann/transport.clj
+++ b/src/riemann/transport.clj
@@ -14,7 +14,7 @@
     (java.util List)
     (java.util.concurrent TimeUnit
                           Executors)
-    (com.aphyr.riemann Proto$Msg)
+    (io.riemann.riemann Proto$Msg)
     (io.netty.channel ChannelInitializer
                       Channel
                       ChannelPipeline
@@ -38,7 +38,7 @@
 (def ioutil-lock
   "There's a bug in JDK 6, 7, and 8 which can cause a deadlock initializing
   sse-server and netty concurrently; we serialize them with this lock.
-  https://github.com/aphyr/riemann/issues/617"
+  https://github.com/riemann/riemann/issues/617"
   (Object.))
 
 (defn ^DefaultChannelGroup channel-group

--- a/test/riemann/client_test.clj
+++ b/test/riemann/client_test.clj
@@ -48,7 +48,7 @@
 
       (try
         (is (thrown-with-msg?
-              com.aphyr.riemann.client.ServerError
+              io.riemann.riemann.client.ServerError
               #"^mismatched input 'no' expecting \{<EOF>, 'or', 'and'\}$"
               @(query client "oh no not again")))
         (finally

--- a/test/riemann/transport_test.clj
+++ b/test/riemann/transport_test.clj
@@ -157,7 +157,7 @@
     ; Works with valid config
     (test-tcp-client client server)
 
-    (logging/suppress ["com.aphyr.riemann.client.TcpTransport"]
+    (logging/suppress ["io.riemann.riemann.client.TcpTransport"]
       ; Fails with mismatching client key/cert
       (is (thrown? IOException
                    (test-tcp-client (assoc client :key (:key server))


### PR DESCRIPTION
Assumes https://github.com/riemann/riemann-java-client/pull/71 has
been merged.