### PR TITLE
Added Prometheus Plugin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -88,6 +88,7 @@
                    :blueflood :blueflood
                    :opsgenie :opsgenie
                    :boundary :boundary
+                   :prometheus :prometheus
                    :all (fn [_] true)}
 ;;  :javac-options     ["-target" "1.6" "-source" "1.6"]
   :java-source-paths ["src/riemann/"]

--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -37,6 +37,7 @@
                      [slack       :refer [slack]]
                      [sns         :refer [sns-publisher]]
                      [stackdriver :refer [stackdriver]]
+                     [prometheus  :refer [prometheus]]
                      [streams     :refer :all]
                      [test        :as test :refer [tap io tests]]
                      [time        :refer [unix-time linear-time once! every!]]

--- a/src/riemann/prometheus.clj
+++ b/src/riemann/prometheus.clj
@@ -17,7 +17,9 @@
 (defn generate-metricname
   "Generates the metric name as per prometheus specification."
   [event]
-  (replace-disallowed (:service event)))
+  (-> event
+      :service
+      replace-disallowed))
 
 (defn generate-datapoint
   "Accepts riemann event and converts it into prometheus datapoint."
@@ -28,12 +30,16 @@
 (defn create-label
   "Creates a Prometheus label out of a Riemann event."
   [filtered-event]
-  (str/join "" (map #(if-not (nil? (second %)) (str "/" (name (first %)) "/" (second %))) filtered-event)))
+  (-> ""
+      (str/join (->> filtered-event
+                     (map #(if-not (nil? (second %)) (str "/" (name (first %)) "/" (second %))))))))
 
 (defn filter-event
   "Filter attributes from a Riemann event."
   [event]
-  (select-keys event (filter #(if-not (contains? special-fields %) %) (keys event))))
+  (-> event
+      (select-keys (->> (keys event)
+                        (filter #(if-not (contains? special-fields %) %))))))
 
 (defn generate-labels
   "Generates the Prometheus labels from Riemann event attributes."

--- a/src/riemann/prometheus.clj
+++ b/src/riemann/prometheus.clj
@@ -30,16 +30,16 @@
 (defn create-label
   "Creates a Prometheus label out of a Riemann event."
   [filtered-event]
-  (-> ""
-      (str/join (->> filtered-event
-                     (map #(if-not (nil? (second %)) (str "/" (name (first %)) "/" (second %))))))))
+  (->> filtered-event
+       (map #(if-not (nil? (second %)) (str "/" (name (first %)) "/" (second %))))
+       (str/join "")))
 
 (defn filter-event
   "Filter attributes from a Riemann event."
   [event]
-  (-> event
-      (select-keys (->> (keys event)
-                        (filter #(if-not (contains? special-fields %) %))))))
+  (->> (keys event)
+       (filter #(if-not (contains? special-fields %) %))
+       (select-keys event)))
 
 (defn generate-labels
   "Generates the Prometheus labels from Riemann event attributes."

--- a/src/riemann/prometheus.clj
+++ b/src/riemann/prometheus.clj
@@ -1,0 +1,75 @@
+(ns riemann.prometheus
+  "Forwards riemann events to Prometheus Pushgateway."
+  (:require [clojure.string :as str]
+            [clj-http.client :as http]))
+
+;; Helper Functions
+
+(defn replace-disallowed
+  "Replaces all existence of space with underscore."
+  [field]
+  (str/escape field {\space "_", \. "_", \: "_" \- "_"}))
+
+(defn generate-metricname
+  "Generates the metric name as per prometheus specification."
+  [event]
+  (replace-disallowed (:service event)))
+
+(defn generate-datapoint
+  "Accepts riemann event and converts it into prometheus datapoint."
+  [event]
+  (when (and (:metric event) (:service event))
+    (str (generate-metricname event) \space (:metric event) \newline)))
+
+
+(defn generate-labels
+  "Generates the Prometheus labels from Riemann tags."
+  [tagv]
+  (let [tagk (->> (range)
+                  (-> tagv count)
+                  (vec))]
+    (clojure.string/join "" (map #(str "/tag" %1 "/" %2) tagk tagv))))
+
+(defn generate-url
+  "Generates the URL to which datapoint should be posted."
+  [opts event]
+  (let [scheme "http://"
+        host   (:host opts)
+        port   (:port opts)
+        endp   "/metrics/job/"
+        job    (:job opts)
+        lhost  (str "/host/" (:host event))
+        ltags  (generate-labels (:tags event))]
+    (str scheme host ":" port endp job lhost ltags)))
+
+(defn post-datapoint
+  "Post the riemann metric as prometheus datapoint."
+  [url datapoint]
+  (let [http-options {:body datapoint
+                      :content-type :json
+                      :conn-timeout 5000
+                      :socket-timeout 5000
+                      :throw-entire-message? true}]
+    (http/post url http-options)))
+
+(defn prometheus
+  "Returns a function which accepts an event and sends it to prometheus.
+
+   Usage:
+   (prometheus {:host \"prometheus.example.com\"})
+
+   Options:
+   `:host` Prometheus Pushgateway Server IP (default: \"localhost\")
+   `:port` Prometheus Pushgateway Server Port (default: 9091)
+   `:job`  Group Name to be assigned (default: \"riemann\")
+  "
+  [opts]
+  (let [opts (merge {:host "localhost"
+                     :port 9091
+                     :job  "riemann"}
+                    opts)]
+    (fn [event]
+      (let [url (generate-url opts event)
+            datapoint (generate-datapoint event)]
+        (when (and (:metric event) (:service event))
+          (post-datapoint url datapoint))))))

--- a/src/riemann/prometheus.clj
+++ b/src/riemann/prometheus.clj
@@ -44,9 +44,17 @@
 (defn generate-labels
   "Generates the Prometheus labels from Riemann event attributes."
   [opts event]
-  (let [instance  (str "/instance/" (:host opts))
-        tags      (if-not (empty? (:tags event))(str "/tags/" (str/join (:separator opts) (:tags event))))
-        labels    (create-label (filter-event event))]
+  (let [instance  (->> opts
+                       :host
+                       (str "/instance/"))
+        tags      (if-not (-> event
+                              :tags
+                              empty?) (->> (:tags event)
+                                           (str/join (:separator opts))
+                                           (str "/tags/")))
+        labels    (-> event
+                      filter-event
+                      create-label)]
     (str instance tags labels)))
 
 (defn generate-url

--- a/test/riemann/prometheus_test.clj
+++ b/test/riemann/prometheus_test.clj
@@ -45,3 +45,46 @@
                :conn-timeout 5000
                :content-type :json
                :throw-entire-message? true}])))))
+
+(deftest ^:prometheus prometheus-test-with-custom-field
+  (with-mock [calls client/post]
+    (let [d (prometheus/prometheus {:host "localhost"})]
+
+      (testing "an event with a custom field")
+      (d {:host    "testhost"
+          :service "testservice"
+          :metric  42
+          :time    123456789
+          :state   "ok"
+          :tags    ["tag1","tag2"]
+          :client  "X-Riemann-Client"})
+      (is (= 1 (count @calls)))
+      (is (= (vec (last @calls))
+             ["http://localhost:9091/metrics/job/riemann/host/testhost/instance/localhost/tags/tag1,tag2/host/testhost/state/ok/client/X-Riemann-Client"
+              {:body "testservice 42.0\n"
+               :socket-timeout 5000
+               :conn-timeout 5000
+               :content-type :json
+               :throw-entire-message? true}])))))
+
+(deftest ^:prometheus prometheus-test-with-custom-excluded-fields
+  (with-mock [calls client/post]
+    (let [d (prometheus/prometheus {:host "localhost"
+                                    :exclude-fields #{:service :metric :tags :time :ttl :state}})]
+
+      (testing "an event with a custom field")
+      (d {:host    "testhost"
+          :service "testservice"
+          :metric  42
+          :time    123456789
+          :state   "ok"
+          :tags    ["tag1","tag2"]
+          :client  "X-Riemann-Client"})
+      (is (= 1 (count @calls)))
+      (is (= (vec (last @calls))
+             ["http://localhost:9091/metrics/job/riemann/host/testhost/instance/localhost/tags/tag1,tag2/host/testhost/client/X-Riemann-Client"
+              {:body "testservice 42.0\n"
+               :socket-timeout 5000
+               :conn-timeout 5000
+               :content-type :json
+               :throw-entire-message? true}])))))

--- a/test/riemann/prometheus_test.clj
+++ b/test/riemann/prometheus_test.clj
@@ -1,0 +1,27 @@
+(ns riemann.prometheus-test
+  (:require [clj-http.client :as client]
+            [clojure.test :refer :all]
+            [riemann.prometheus :as prometheus]
+            [riemann.logging :as logging]
+            [riemann.test-utils :refer [with-mock]]))
+
+(logging/init)
+
+(deftest ^:prometheus prometheus-test
+  (with-mock [calls client/post]
+    (let [d (prometheus/prometheus {:host "localhost"})]
+
+      (testing "an event without tag")
+      (d {:host    "testhost"
+          :service "testservice"
+          :metric  42
+          :time    123456789
+          :state   "ok"})
+      (is (= 1 (count @calls)))
+      (is (= (vec (last @calls))
+             ["http://localhost:9091/metrics/job/riemann/host/testhost"
+              {:body "testservice 42\n"
+               :socket-timeout 5000
+               :conn-timeout 5000
+               :content-type :json
+               :throw-entire-message? true}])))))


### PR DESCRIPTION
This pull request adds support for [Prometheus](https://prometheus.io/) backend. Since Prometheus uses pull model for collecting metrics, it provides a [Pushgateway](https://prometheus.io/docs/instrumenting/pushing/) server which acts as an intermediate proxy for pushing datapoints.

Sample Screenshot:

![screen shot 2016-05-22 at 6 22 33 pm](https://cloud.githubusercontent.com/assets/2232667/15453981/58994e04-204a-11e6-96b1-8b6f3b511675.png?raw=true)