### PR TITLE
Clarify GC behavior of (by) streams

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1496,7 +1496,7 @@
   Be aware that (by) over unbounded values can result in
   *many* substreams being created, so you wouldn't want to write
   (by metric prn): you'd get a separate prn for *every* unique metric that
-  came in."
+  came in.  Also, (by) streams are never garbage-collected."
   [fields & children]
   ; new-fork is a function which gives us a new copy of our children.
   ; table is a reference which maps (field event) to a fork (or list of


### PR DESCRIPTION
Namely, that there isn't any.  Per @aphyr:

> Nope, by streams are not presently GCed. Tried a bunch of strategies but it's real hard to predict when it's legal to GC a stream.