### PR TITLE
Fix fraction divisor in generating events example

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -2238,7 +2238,7 @@ rate
 (fixed-time-window 60
   (smap (fn [events]
           (let [errors   (filter (comp #{"warning" "critical"} :state) events)
-                fraction (/ (count errors) events)]
+                fraction (/ (count errors) (count events))]
             ; Build a new event using a map of fields and values.
             (event {:service "error percent"
                     :metric fraction})))


### PR DESCRIPTION
The fraction operation was using "events" as a divisor. "Events" is a
collection, so this patch replace it by the number of events, in order
to get the percentage of events.