### PR TITLE
Stringfy anything except numbers to influxdb

### DIFF
--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -20,9 +20,9 @@
 (defn kv-encode-9 [kv]
   (clojure.string/join "," (map
     (fn [[key value]]
-      (if (instance? String value)
-        (str (replace-disallowed-9 key) "=" (str "\"" (str/escape value {\" "\\\""}) "\""))
-        (str (replace-disallowed-9 key) "=" (clojure.pprint/cl-format nil "~F" value))))
+      (if (number? value)
+        (str (replace-disallowed-9 key) "=" (clojure.pprint/cl-format nil "~F" value))
+        (str (replace-disallowed-9 key) "=" (str "\"" (str/escape (str value) {\" "\\\""}) "\""))))
     kv)))
 
 (defn lineprotocol-encode-9 [event]


### PR DESCRIPTION
Previously anything that was not a string was formatted as a ~F
this would break for anything that is not a number

We were trying to send a clojure map to influx as it happened to be in one of our custom fields so we got the following:

```
WARN [2016-08-04 14:01:02,977] pool-1-thread-1 - riemann.streams - riemann.influxdb$influxdb_9$stream__9428@cae44ec threw
java.lang.ClassCastException: clojure.lang.PersistentArrayMap cannot be cast to java.lang.Number
    at clojure.lang.Numbers.isNeg(Numbers.java:100)
    at clojure.pprint$fixed_float.invokeStatic(cl_format.clj:676)
    at clojure.pprint$fixed_float.invoke(cl_format.clj:672)
    at clojure.lang.AFn.applyToHelper(AFn.java:160)
    at clojure.lang.AFn.applyTo(AFn.java:144)
    at clojure.core$apply.invokeStatic(core.clj:646)
    at clojure.pprint$execute_format$fn__9038.invoke(cl_format.clj:1907)
    at clojure.lang.AFn.applyToHelper(AFn.java:156)
    at clojure.lang.AFn.applyTo(AFn.java:144)
    at clojure.core$apply.invokeStatic(core.clj:646)
    at clojure.pprint$map_passing_context.invokeStatic(utilities.clj:30)
    at clojure.pprint$execute_format.invokeStatic(cl_format.clj:1879)
    at clojure.pprint$execute_format.invoke(cl_format.clj:1879)
    at clojure.pprint$execute_format$fn__9036.invoke(cl_format.clj:1893)
    at clojure.pprint$execute_format.invokeStatic(cl_format.clj:1892)
    at clojure.pprint$execute_format.invoke(cl_format.clj:1879)
    at clojure.pprint$cl_format.invokeStatic(cl_format.clj:64)
    at clojure.pprint$cl_format.doInvoke(cl_format.clj:27)
    at clojure.lang.RestFn.invoke(RestFn.java:442)
    at riemann.influxdb$kv_encode_9$fn__9379.invoke(influxdb.clj:25)
    at clojure.core$map$fn__4785.invoke(core.clj:2646)
    at clojure.lang.LazySeq.sval(LazySeq.java:40)
    at clojure.lang.LazySeq.seq(LazySeq.java:49)
    at clojure.lang.Cons.next(Cons.java:39)
    at clojure.lang.RT.next(RT.java:688)
    at clojure.core$next__4341.invokeStatic(core.clj:64)
    at clojure.string$join.invokeStatic(string.clj:191)
    at clojure.string$join.invoke(string.clj:180)
    at riemann.influxdb$kv_encode_9.invokeStatic(influxdb.clj:21)
    at riemann.influxdb$kv_encode_9.invoke(influxdb.clj:20)
    at riemann.influxdb$lineprotocol_encode_9.invokeStatic(influxdb.clj:29)
    at riemann.influxdb$lineprotocol_encode_9.invoke(influxdb.clj:28)
    at clojure.core$map$fn__4785.invoke(core.clj:2644)
    at clojure.lang.LazySeq.sval(LazySeq.java:40)
    at clojure.lang.LazySeq.seq(LazySeq.java:49)
    at clojure.lang.LazySeq.first(LazySeq.java:71)
    at clojure.lang.RT.first(RT.java:667)
    at clojure.core$first__4339.invokeStatic(core.clj:55)
    at clojure.string$join.invokeStatic(string.clj:180)
    at clojure.string$join.invoke(string.clj:180)
    at riemann.influxdb$influxdb_9$stream__9428.invoke(influxdb.clj:181)
    at riemann.streams$execute_on$stream__6765$runner__6766$fn__6771.invoke(streams.clj:268)
    at riemann.streams$execute_on$stream__6765$runner__6766.invoke(streams.clj:268)
    at clojure.lang.AFn.applyToHelper(AFn.java:152)
    at clojure.lang.AFn.applyTo(AFn.java:144)
    at clojure.core$apply.invokeStatic(core.clj:646)
    at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1881)
    at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1881)
    at clojure.lang.RestFn.invoke(RestFn.java:425)
    at clojure.lang.AFn.applyToHelper(AFn.java:156)
    at clojure.lang.RestFn.applyTo(RestFn.java:132)
    at clojure.core$apply.invokeStatic(core.clj:650)
    at clojure.core$bound_fn_STAR_$fn__4671.doInvoke(core.clj:1911)
    at clojure.lang.RestFn.invoke(RestFn.java:397)
    at clojure.lang.AFn.run(AFn.java:22)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```

This PR doesn't change the overall behaviour but ensures that any value will at worst get turned into a string instead of throwing an exception and not appearing in influx.
