### PR TITLE
Fix nested escaping of strings

### DIFF
--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -21,7 +21,7 @@
   (clojure.string/join "," (map
     (fn [[key value]]
       (if (instance? String value)
-        (str (replace-disallowed-9 key) "=" (str "\"" (str/escape value {\" "\\\""}) "\""))
+        (str (replace-disallowed-9 key) "=" (pr-str value))
         (str (replace-disallowed-9 key) "=" (clojure.pprint/cl-format nil "~F" value))))
     kv)))
 


### PR DESCRIPTION
## Problem

Current escaping of string values before sending them to influxdb is naive and doesn't work in all situations

## Example

```clj
(println (kv-encode-9 {"description" "or an equivalent \"signed for\" delivery service"}))
;> description="or an equivalent \"signed for\" delivery service"
```
Works fine. But we're sending data structures as strings in the description. So

```clj
(println (kv-encode-9 {"description" (str {:info "or an equivalent \"signed for\" delivery service"})}))
;> description="{:info \"or an equivalent \\"signed for\\" delivery service\"}"
```

When this is sent to influxdb as part of the write-data string it fails because the `\\"foo bar\\"` is not a valid encoding

## Proposed solution

Instead of manually escaping quotes use clojure `pr-str` to print the content into an escaped string

```clj
(defn kv-encode-9* [kv]
  (clojure.string/join "," (map
                             (fn [[key value]]
                               (if (instance? String value)
                                 (str (replace-disallowed-9 key) "=" (pr-str value))
                                 (str (replace-disallowed-9 key) "=" (clojure.pprint/cl-format nil "~F" value))))
                             kv)))
```

```clj
(println (kv-encode-9* {"description" (str {:info "or an equivalent \"signed for\" delivery service"})}))
;> description="{:info \"or an equivalent \\\"signed for\\\" delivery service\"}"
```

This correctly has three `\` to escape the nested quote