### PR TITLE
fix websocket listening address

### DIFF
--- a/src/riemann/transport/websockets.clj
+++ b/src/riemann/transport/websockets.clj
@@ -183,7 +183,7 @@
           (locking this
             (when-not @server
               (reset! server (http/run-server (ws-handler core stats)
-                                              {:host host
+                                              {:ip host
                                                :port port}))
               (info "Websockets server" host port "online"))))
 


### PR DESCRIPTION
fix #721.
the :host option for ws-server was ignored. It is because http-kit uses the :ip keyword for the host.