### PR TITLE
[Need review] Refactoring influxdb

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
     [ch.qos.logback/logback-classic "1.1.3"]
     [com.github.juise/logstash-logback-layout "1.0"]
     [net.logstash.logback/logstash-logback-encoder "4.5"]
-
+    [org.influxdb/influxdb-java "2.4"]
     [com.cemerick/pomegranate "0.3.0"
      :exclusions [org.codehaus.plexus/plexus-utils]]
     ; for pomegranate

--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -1,47 +1,36 @@
 (ns riemann.influxdb
-  "Forwards events to InfluxDB. Supports both 0.8 and 0.9 APIs."
+  "Forwards events to InfluxDB. Supports InfluxDB 0.9 or Higher"
   (:require
-    [capacitor.core :as capacitor]
-    [cheshire.core :as json]
-    [clj-http.client :as http]
-    [clojure.set :as set]
-    [clojure.string :as str]
-    [riemann.common :refer [unix-to-iso8601]]))
+    [clojure.set :as set])
+  (:import
+   (java.util.concurrent TimeUnit)
+   (javax.net.ssl SSLContext X509TrustManager HostnameVerifier)
+   (java.security SecureRandom)
+   (java.security.cert X509Certificate)
+   (org.influxdb InfluxDBFactory InfluxDB$ConsistencyLevel)
+   (org.influxdb.dto BatchPoints Point)))
 
-;; ## Helper Functions
+(defn nil-or-empty-str
+  [s]
+  (or (nil? s) (= "" s)))
 
+;; specific influxdb-deprecated code
 (def special-fields
   "A set of event fields in Riemann with special handling logic."
-  #{:host :service :time :metric :tags :ttl})
+  #{:host :service :time :metric :tags :ttl :precision :tag-fields})
 
-(defn replace-disallowed-9 [field]
-  (str/escape field {\space "\\ ", \= "\\=", \, "\\,"}))
-
-(defn kv-encode-9 [kv]
-  (clojure.string/join "," (map
-    (fn [[key value]]
-      (if (instance? String value)
-        (str (replace-disallowed-9 key) "=" (pr-str value))
-        (str (replace-disallowed-9 key) "=" (clojure.pprint/cl-format nil "~F" value))))
-    kv)))
-
-(defn lineprotocol-encode-9 [event]
-  (let [encoded_fields (kv-encode-9 (get event "fields"))
-        encoded_tags   (clojure.string/join "," (map
-                         (fn [[tag value]] (str (replace-disallowed-9 tag) "=" (replace-disallowed-9 value)))
-                         (get event "tags")))]
-    (str (str/escape (get event "measurement") {\space "\\ ", \, "\\,"}) "," encoded_tags " " encoded_fields " " (get event "time"))))
-
+;; specific influxdb-deprecated code
 (defn event-tags
   "Generates a map of InfluxDB tags from a Riemann event. Any fields in the
   event which are named in `tag-fields` will be converted to a string key/value
   entry in the tag map."
   [tag-fields event]
   (->> (select-keys event tag-fields)
-       (remove (fn [[k v]] (or (nil? v) (= "" v))))
+       (remove (fn [[k v]] (nil-or-empty-str v)))
        (map #(vector (name (key %)) (str (val %))))
        (into {})))
 
+;; specific influxdb-deprecated code
 (defn event-fields
   "Generates a map of InfluxDB fields from a Riemann event. The event's
   `metric` is converted to the `value` field, and any additional event fields
@@ -51,175 +40,246 @@
   (let [ignored-fields (set/union special-fields tag-fields)]
     (-> event
         (->> (remove (comp ignored-fields key))
-             (remove (fn [[k v]] (or (nil? v) (= "" v))))
+             (remove (fn [[k v]] (nil-or-empty-str v)))
              (map #(vector (name (key %)) (val %)))
              (into {}))
         (assoc "value" (:metric event)))))
 
-;; ## InfluxDB 0.8
+(defn get-trust-manager
+  "Returns an array with an instance of `X509TrustManager`
+  Used for trust all certs in the influxdb `insecure` mode."
+  []
+  (let [trust-manager (proxy [X509TrustManager] []
+                        (checkServerTrusted [_ _])
+                        (checkClientTrusted [_ _] )
+                        (getAcceptedIssuers [] (make-array X509Certificate 0)))]
+    (into-array (list trust-manager))))
 
-(defn event->point-8
-  "Transform a Riemann event to an InfluxDB point, or nil if the event is
-  missing a metric or service."
-  [event]
-  (when (and (:metric event) (:service event))
-    (merge
-      {:name (:service event)
-       :host (or (:host event) "")
-       :time (:time event)
-       :value (:metric event)}
-      (apply dissoc event special-fields))))
+(defn get-ssl-factory
+  "Get an instance of `javax.net.ssl.SSLSocketFactory`"
+  []
+  (let [ssl-context (SSLContext/getInstance "TLS")]
+    (.init ssl-context nil (get-trust-manager) (new SecureRandom))
+    (.getSocketFactory ssl-context)))
 
-(defn events->points-8
-  "Takes a series fn that finds the series for a given event, and a sequence of
-  events, and emits a map of series names to vectors of points for that series."
-  [series-fn events]
-  (persistent!
-    (reduce (fn [m event]
-              (let [series (or (series-fn event) "riemann-events")
-                    point  (event->point-8 event)]
-                (if point
-                  (assoc! m series (conj (get m series []) point))
-                  m)))
-            (transient {})
-            events)))
+(defn get-hostname-verifier
+  "Get an instance of `javax.net.ssl.HostnameVerifier`"
+  []
+  (let [verifier (proxy [HostnameVerifier] []
+                   (verify [_ _] true))]
+    verifier))
 
-(defn influxdb-8
-  "Returns a function which accepts an event, or sequence of events, and sends
-  it to InfluxDB. Compatible with the 0.8.x series.
+(defn get-builder
+  "Returns a new okhttp3.OkHttpClient$Builder"
+  [{:keys [timeout insecure]}]
+  (let [builder (new okhttp3.OkHttpClient$Builder)]
+    (when insecure
+      (.sslSocketFactory builder (get-ssl-factory))
+      (.hostnameVerifier builder (get-hostname-verifier)))
+    (doto builder
+      (.readTimeout timeout TimeUnit/MILLISECONDS)
+      (.writeTimeout timeout TimeUnit/MILLISECONDS)
+      (.connectTimeout timeout TimeUnit/MILLISECONDS))))
 
-  ; For giving series name as the concatenation of :host and :service fields
-  ; with dot separator.
+(defn get-client
+  "Returns an `org.influxdb.InfluxDB` instance"
+  [{:keys [scheme host port username password] :as opts}]
+  (let [url (str scheme "://" host ":" port)]
+    (InfluxDBFactory/connect url username password (get-builder opts))))
 
-  (influxdb-8 {:host   \"play.influxdb.org\"
-               :port   8086
-               :series #(str (:host %) \".\" (:service %))})
+(defn get-batchpoint
+  "Returns a `org.influxdb.dto.BatchPoints` instance"
+  [{:keys [tags db retention consistency]}]
+  (let [builder (doto (BatchPoints/database db)
+                      (.consistency (InfluxDB$ConsistencyLevel/valueOf consistency)))]
+    (when retention (.retentionPolicy builder retention))
+    (doseq [[k v] tags] (.tag builder (name k) (str v)))
+    (.build builder)))
 
-  0.8 Options:
+(defn get-time-unit
+  "returns a value from the TimeUnit enum depending of the `precision` parameters.
+  The `precision` parameter is a keyword whose possibles values are `:seconds`, `:milliseconds` and `:microseconds`.
+  Returns `TimeUnit/SECONDS` by default"
+  [precision]
+  (cond
+    (= precision :milliseconds) TimeUnit/MILLISECONDS
+    (= precision :microseconds) TimeUnit/MICROSECONDS
+    (= precision :seconds) TimeUnit/SECONDS
+    true TimeUnit/SECONDS))
 
-  :name           Name of the metric which is same as the series name.
+(defn convert-time
+  "Converts the `time-event` parameter (which is time second) in a new time unit specified by the `precision` parameter. It also converts the time to long.
+  The `precision` parameter is a keyword whose possibles values are `:seconds`, `:milliseconds` and `:microseconds`.
+  Returns time in seconds by default"
+  [time-event precision]
+  (cond
+    (= precision :milliseconds) (long (* 1000 time-event))
+    (= precision :microseconds) (long (* 1000000 time-event))
+    (= precision :seconds) (long time-event)
+    true (long time-event)))
 
-  :series         Function which takes an event and returns the InfluxDB series
-                  name to use. Defaults to :service. If this function returns
-                  nil, series names default to \"riemann-events\"."
-  [opts]
-  (let [opts (merge {:username "root"
-                     :password "root"
-                     :series :service}
-                    opts)
-        series (:series opts)
-        client (capacitor/make-client opts)]
+(defn ratio?->double
+  "if n if a ratio, converts it to double. Returns n otherwise"
+  [n]
+  (if (ratio? n)
+    (double n)
+    n))
 
-    (fn stream [events]
-      (let [events (if (sequential? events) events (list events))
-            points (events->points-8 series events)]
-        (when-not (empty? points)
-          (doseq [[series points] points]
-            (capacitor/post-points client series "s" points)))))))
-
-;; ## InfluxDB 0.9
-
+;; specific influxdb-deprecated code
 (defn event->point-9
-  "Converts a Riemann event into an InfluxDB point if it has a time, service,
-  and metric."
-  [tag-fields event]
+  "Converts a Riemann event into an InfluxDB Point (an instance of `org.influxdb.dto.Point`.
+  The first parameter is the event. The `:precision` key of the event is used to converts the event `time` into the correct time unit (default seconds).
+  The second parameter is the option map passed to the influxdb stream."
+  [event opts]
   (when (and (:time event) (:service event) (:metric event))
-    {"measurement" (:service event)
-     "time" (long (:time event))
-     "tags" (event-tags tag-fields event)
-     "fields" (event-fields tag-fields event)}))
+    (let [precision (:precision event (:precision opts))
+          builder (doto (Point/measurement (:service event))
+                        (.time (convert-time (:time event) precision) (get-time-unit precision)))
+          tag-fields (set/union (:tag-fields opts) (:tag-fields event))
+          tags   (event-tags tag-fields event)
+          fields (event-fields tag-fields event)]
+      (doseq [[k v] tags] (.tag builder k v))
+      (doseq [[k v] fields] (.field builder k (ratio?->double v)))
+      (.build builder))))
 
-(defn events->points-9
-  "Converts a collection of Riemann events into InfluxDB points. Events which
-  map to nil are removed from the final collection.  Also filter out NaNs that
-  influxdb can't deal with currently."
-  [tag-fields events]
-  (filter (fn [p]
-    (not-any?
-      (fn [v] (and (instance? Number (val v)) (Double/isNaN (val v))))
-      (get p "fields")))
-    (keep (partial event->point-9 tag-fields) events)))
+(defn event->point
+  "Converts a Riemann event into an InfluxDB Point (an instance of `org.influxdb.dto.Point`.
+  The first parameter is the event.
+  The `:precision` event key is used to converts the event `time` into the correct time unit (default seconds).
+  The `:measurement` event key is the influxdb measurement.
+  The `:influxdb-tags` event key contains all the Influxdb tags.
+  The `:influxdb-fields` event key contains all the Influxdb fields.
+  The second parameter is the option map passed to the influxdb stream."
+  [event opts]
+  (when (and (:time event) (:measurement event))
+    (let [precision (:precision event (:precision opts)) ;; use seconds default
+          builder (doto (Point/measurement (:measurement event))
+                        (.time (convert-time (:time event) precision) (get-time-unit precision)))
+          tags   (:influxdb-tags event)
+          fields (:influxdb-fields event)]
+      (doseq [[k v] tags] (when-not (nil-or-empty-str v) (.tag builder (name k) (str v))))
+      (doseq [[k v] fields] (when-not (nil-or-empty-str v) (.field builder (name k) (ratio?->double v))))
+      (.build builder))))
 
-(defn influxdb-9
+(def default-opts
+  "Default influxdb options"
+  {:db "riemann"
+   :scheme "http"
+   :version :deprecated
+   :host "localhost"
+   :username "root"
+   :precision :seconds
+   :port 8086
+   :tags {}
+   :tag-fields #{:host}
+   :consistency "ONE"
+   :timeout 5000
+   :insecure false})
+
+(defn write-batch-point
+  "Write to influxdb the `batch-point` using the `connection`"
+  [connection batch-point]
+  (.write connection batch-point))
+
+(defn get-batchpoints
+  "Create a `org.influxdb.dto.BatchPoints` for each element in the `event` list.
+  `event` is a list where each element is a list of events.
+  Each element contains events with the same `:db`, `:retention` and `:consistency` keys.
+  These options are used to create the BatchPoints.
+  `opts` are the global influxdb stream options."
+  [opts events]
+  (map
+   (fn [events]
+     (when (not-empty events)
+       (let [event (first events)
+             opts (merge opts ;; we can have per event :db :retention :consistency
+                         (select-keys event [:db :retention :consistency]))
+             batch-point (get-batchpoint opts)
+             _ (doseq [event events] (.point batch-point (event->point event opts)))]
+         batch-point)))
+   events))
+
+(defn partition-events
+  "`events` is a list of events
+  partition `events` depending of the `db`, `retention` and `consistency` keys
+  returns a list, each element being a list of events (the result of the partitioning)."
+  [events]
+  (->> (if (sequential? events) events (list events))
+       (group-by #(select-keys % [:db :retention :consistency]))
+       (vals)))
+
+(defn influxdb-new-stream
   "Returns a function which accepts an event, or sequence of events, and writes
-  them to InfluxDB. Compatible with the 0.9.x series.
-  (influxdb-9 {:host \"influxdb.example.com\"
-               :db \"my_db\"
-               :retention \"raw\"
-               :tag-fields #{:host :sys :env}})
-  0.9 Options:
-  `:retention`      Name of retention policy to use. (optional)
-  `:tag-fields`     A set of event fields to map into InfluxDB series tags.
-                    (default: `#{:host}`)
-  `:tags`           A common map of tags to apply to all points. (optional)
-  `:timeout`        HTTP timeout in milliseconds. (default: `5000`)"
+  them to InfluxDB.
+
+  streams receive an event or a list of events. Each event can have these keys :
+  `:measurement`     The influxdb measurement.
+  `:influxdb-tags`   A map of influxdb tags. Exemple : `{:foo \"bar\"}`
+  `:influxdb-fields` A map of influxdb fields. Exemple : `{:bar \"baz\"}`
+  `:precision`       The time precision. Possibles values are `:seconds`, `:milliseconds` and `:microseconds` (default `:seconds`). The event `time` will be converted.
+  `:db`              Name of the database to write to. (optional)
+  `:retention`       Name of retention policy to use. (optional)
+  `:consistency`     The InfluxDB consistency level (default: `\"ONE\"`). Possibles values are ALL, ANY, ONE, QUORUM."
   [opts]
-  (let [write-url
-        (str (cond->
-          (format "%s://%s:%s/write?db=%s&precision=s" (:scheme opts) (:host opts) (:port opts) (:db opts))
-          (:retention opts)
-            (str "&rp=" (:retention opts))))
-
-        http-opts
-        (cond->
-          {:socket-timeout (:timeout opts 5000) ; ms
-           :conn-timeout   (:timeout opts 5000) ; ms
-           :content-type   "text/plain"
-           :insecure? (:insecure opts false)}
-          (:username opts)
-            (assoc :basic-auth [(:username opts)
-                                (:password opts)]))
-
-        tag-fields
-        (:tag-fields opts #{:host})]
-    (fn stream
+  (let [opts (merge default-opts opts)
+        connection (get-client opts)]
+    (fn streams
       [events]
-      (let [events (if (sequential? events) events (list events))
-            points (events->points-9 tag-fields events)]
-        (http/post write-url
-          (assoc http-opts :body (->> points
-            (map lineprotocol-encode-9)
-            (clojure.string/join "\n"))))))))
+      (let [events-partition (partition-events events)
+            batch-points (get-batchpoints opts events-partition)]
+        (doseq [batch-point batch-points] (write-batch-point connection batch-point))
+        batch-points))))
 
-;; ## Stream Construction
+(defn influxdb-deprecated
+  "Returns a function which accepts an event, or sequence of events, and writes
+  them to InfluxDB.
+
+  influxdb-deprecated specifics options :
+  `:tag-fields`     A set of event fields to map into InfluxDB series tags.
+                    (default: `#{:host}`).
+
+  Each event can have these keys :
+  `:tag-fields`     A set of event fields to map into InfluxDB series tags..
+  `:precision`       The time precision. Possibles values are `:seconds`, `:milliseconds` and `:microseconds` (default `:seconds`). The event `time` will be converted."
+  [opts]
+  (let [opts (merge default-opts opts)
+        connection (get-client opts)]
+    (fn streams
+      [events]
+      (let [events (->> (if (sequential? events) events (list events))
+                        (keep #(event->point-9 % opts)))
+            batch-point (get-batchpoint opts)
+            _ (doseq [event events] (.point batch-point event))]
+        (write-batch-point connection batch-point)
+        batch-point))))
 
 (defn influxdb
   "Returns a function which accepts an event, or sequence of events, and writes
   them to InfluxDB as a batch of measurement points. For performance, you should
   wrap this stream with `batch` or an asynchronous queue.
-
+  Support InfluxdbDB 0.9 and higher.
   (influxdb {:host \"influxdb.example.com\"
              :db \"my_db\"
              :user \"riemann\"
              :password \"secret\"})
-
   General Options:
-
-  `:version`        Version of InfluxDB client to use. Should be one of `:0.8`
-                    or `:0.9`. (default: `:0.8`)
-
   `:db`             Name of the database to write to. (default: `\"riemann\"`)
-
+  `:version`        Version of InfluxDB client to use. (default: `\":deprecated\"`)
   `:scheme`         URL scheme for endpoint. (default: `\"http\"`)
-
   `:host`           Hostname to write points to. (default: `\"localhost\"`)
-
   `:port`           API port number. (default: `8086`)
-
-  `:username`       Database user to authenticate as. (optional)
-
+  `:username`       Database user to authenticate as. (default: `\"root\"`)
   `:password`       Password to authenticate with. (optional)
-
+  `:tags`           A common map of tags to apply to all points. (optional)
+  `:retention`      Name of retention policy to use. (optional)
+  `:timeout`        HTTP timeout in milliseconds. (default: `5000`)
+  `:consistency`    The InfluxDB consistency level (default: `\"ONE\"`). Possibles values are ALL, ANY, ONE, QUORUM.
   `:insecure`       If scheme is https and certficate is self-signed. (optional)
+  `:precision`      The time precision. Possibles values are `:seconds`, `:milliseconds` and `:microseconds` (default `:seconds`). The event `time` will be converted.
 
-  See `influxdb-8` and `influxdb-9` for version-specific options."
+  See `influxdb-deprecated` and `influxdb-new-stream` for version-specific options."
   [opts]
-  (let [opts (merge {:version :0.8
-                     :db "riemann"
-                     :scheme "http"
-                     :host "localhost"
-                     :port 8086}
-                    opts)]
-    (case (:version opts)
-      :0.8 (influxdb-8 opts)
-      :0.9 (influxdb-9 opts))))
+  (let [opts (merge default-opts opts)]
+    (if (= :new-stream (:version opts))
+      (influxdb-new-stream opts)
+      (influxdb-deprecated opts))))

--- a/test/riemann/influxdb_test.clj
+++ b/test/riemann/influxdb_test.clj
@@ -1,144 +1,910 @@
 (ns riemann.influxdb-test
   (:require
-    [clojure.test :refer :all]
-    [riemann.influxdb :as influxdb]
-    [riemann.logging :as logging]
-    [riemann.time :refer [unix-time]]))
+   [clojure.test :refer :all]
+   [riemann.influxdb :as influxdb]
+   [riemann.logging :as logging]
+   [riemann.test-utils :refer [with-mock]]
+   [riemann.time :refer [unix-time]])
+  (:import
+   (java.util.concurrent TimeUnit)
+   (org.influxdb InfluxDBFactory InfluxDB$ConsistencyLevel)
+   (org.influxdb.dto BatchPoints Point)))
 
 (logging/init)
 
-; Would the next person working on influxdb kindly update these tests to use
-; riemann.test-utils/with-mock? Would be nice to have something besides just
-; integration tests. --Kyle, Sep 2015 :)
+(defn ^java.lang.reflect.Field get-field
+  "Return Field object"
+  [^Class class ^String field-name]
+  (let [f (.getDeclaredField class field-name)]
+    (.setAccessible f true)
+    f))
 
-(deftest ^:influxdb-8 ^:integration influxdb-test-8
-  (let [k (influxdb/influxdb {:block-start true})]
-    (k {:host "riemann.local"
-        :service "influxdb test"
-        :state "ok"
-        :description "all clear, uh, situation normal"
-        :metric -2
-        :time (unix-time)}))
+(def measurement (get-field Point "measurement"))
+(def time-field (get-field Point "time"))
+(def tags (get-field Point "tags"))
+(def fields (get-field Point "fields"))
+(def precision (get-field Point "precision"))
 
-  (let [k (influxdb/influxdb {:block-start true})]
-    (k {:service "influxdb test"
-        :state "ok"
-        :description "all clear, uh, situation normal"
-        :metric 3.14159
-        :time (unix-time)}))
+;; a database named "riemann_test" should exists for integration tests
 
-  (let [k (influxdb/influxdb {:block-start true})]
-    (k {:host "no-service.riemann.local"
-        :state "ok"
-        :description "Missing service, not transmitted"
-        :metric 4
-        :time (unix-time)})))
+(deftest ^:influxdb influxdb-test-mock
+  (with-mock [calls influxdb/write-batch-point]
+    (testing "deprecated influxdb stream"
+      (let [k (influxdb/influxdb
+               {:host (or (System/getenv "INFLUXDB_HOST") "localhost")
+                :db "riemann_test"})
+            t (unix-time)]
+        (k {:host "riemann.local"
+            :service "influxdb test"
+            :state "ok"
+            :description "all clear"
+            :metric -2
+            :time t})
+        (is (= 1 (count @calls)))
+        (let  [batch-point (second (first @calls))
+               points (.getPoints batch-point)
+               point (first points)]
+          (is (= (.getDatabase batch-point) "riemann_test"))
+          (is (= (.getRetentionPolicy batch-point) nil))
+          (is (= (.getConsistency batch-point) InfluxDB$ConsistencyLevel/ONE))
+          (is (= TimeUnit/SECONDS (.get precision point)))
+          (is (= (into {} (.getTags batch-point)) {}))
+          (is (= 1 (count points)))
+          (is (= {"value" -2.0
+                  "state" "ok"
+                  "description" "all clear"} (into {} (.get fields point))))
+          (is (= "influxdb-test") (.get measurement point))
+          (is (= {"host" "riemann.local"} (into {} (.get tags point))))
+          (is (=  (long t) (.get time-field point))))
+        (k [{:host "riemann.local"
+             :service "influxdb test"
+             :state "ok"
+             :description "all clear"
+             :metric -2
+             :time t}
+            {:host "riemann.local2"
+             :service "influxdb test2"
+             :state "ok"
+             :description "not clear"
+             :metric -3
+             :foobar "foobaz"
+             :time (+ t 1)}
+            {:host "riemann.local2"
+             :service "influxdb test2"
+             :state "ok"
+             :description "not clear"
+             :metric -3
+             :foobar "foobaz"
+             "rofl" "mao" ;; test with string key
+             "hello" "goodbye"
+             :tag-fields #{:foobar "hello"}
+             :precision :microseconds
+             :time 1000}])
+        (is (= 2 (count @calls)))
+        (let  [batch-point (second (second @calls))
+               points (.getPoints batch-point)
+               point1 (first points)
+               point2 (second points)
+               point3 (last points)]
+          (is (= (.getDatabase batch-point) "riemann_test"))
+          (is (= (.getRetentionPolicy batch-point) nil))
+          (is (= (.getConsistency batch-point) InfluxDB$ConsistencyLevel/ONE))
+          (is (= (into {} (.getTags batch-point)) {}))
+          (is (= TimeUnit/SECONDS (.get precision point1)))
+          (is (= 3 (count points)))
+          (is (= {"value" -2.0
+                  "state" "ok"
+                  "description" "all clear"} (into {} (.get fields point1))))
+          (is (= "influxdb-test") (.get measurement point1))
+          (is (= {"host" "riemann.local"} (into {} (.get tags point1))))
+          (is (=  (long t) (.get time-field point1)))
+          ;; second point
+          (is (= {"value" -3.0
+                  "state" "ok"
+                  "description" "not clear"
+                  "foobar" "foobaz"} (into {} (.get fields point2))))
+          (is (= "influxdb-test2") (.get measurement point2))
+          (is (= TimeUnit/SECONDS (.get precision point2)))
+          (is (= {"host" "riemann.local2"} (into {} (.get tags point2))))
+          (is (=  (+ 1 (long t)) (.get time-field point2)))
+          ;; third point
+          (is (= {"value" -3.0
+                  "state" "ok"
+                  "rofl" "mao"
+                  "description" "not clear"} (into {} (.get fields point3))))
+          (is (= "influxdb-test2") (.get measurement point3))
+          (is (= {"host" "riemann.local2"
+                  "hello" "goodbye"
+                  "foobar" "foobaz"} (into {} (.get tags point3))))
+          (is (= TimeUnit/MICROSECONDS (.get precision point3)))
+          (is (= 1000000000 (.get time-field point3))))))
+    (reset! calls [])
+    (testing "deprecated influx stream with default opts"
+      (let [k (influxdb/influxdb
+               {:host "aphyr.com"
+                :version :deprecated
+                :db "foodb"
+                :port 9999
+                :username "user"
+                :password "password"
+                :precision :milliseconds
+                :tag-fields #{:host :baz}
+                :tags {"foo" "bar"}
+                :retention "autogen"
+                :timeout 10000
+                :consistency "ALL"})]
+        (k {:host "riemann.local"
+            :service "influxdb test"
+            :state "ok"
+            :description "all clear"
+            :precision :microseconds
+            :foobar "hello"
+            :baz "bar"
+            :tag-fields #{:foobar}
+            :metric -2
+            :time 1000})
+        (is (= 1 (count @calls)))
+        (let  [batch-point (second (first @calls))
+               points (.getPoints batch-point)
+               point (first points)]
+          (is (= 1 (count points)))
+          (is (= (.getDatabase batch-point) "foodb"))
+          (is (= (.getRetentionPolicy batch-point) "autogen"))
+          (is (= (.getConsistency batch-point) InfluxDB$ConsistencyLevel/ALL))
+          (is (= TimeUnit/MICROSECONDS (.get precision point)))
+          (is (= (into {} (.getTags batch-point)) {"foo" "bar"}))
+          (is (= {"value" -2.0
+                  "state" "ok"
+                  "description" "all clear"} (into {} (.get fields point))))
+          (is (= "influxdb-test") (.get measurement point))
+          (is (= {"host" "riemann.local"
+                  "foobar" "hello"
+                  "foo" "bar"
+                  "baz" "bar"}
+                 (into {} (.get tags point))))
+          (is (=  1000000000 (.get time-field point))))))
+    (reset! calls [])
+    (testing "new influxdb stream"
+      (let [k (influxdb/influxdb
+               {:host (or (System/getenv "INFLUXDB_HOST") "localhost")
+                :version :new-stream})]
+        (k {:time 1428366765
+            :influxdb-tags {:foo "bar"
+                            :bar "baz"}
+            :db "riemann_test"
+            :measurement "measurement"
+            :influxdb-fields {:alice "bob"}})
+        (is (= 1 (count @calls)))
+        (let  [batch-point (second (first @calls))
+               points (.getPoints batch-point)
+               point (first points)]
+          (is (= (.getDatabase batch-point) "riemann_test"))
+          (is (= (.getRetentionPolicy batch-point) nil))
+          (is (= (.getConsistency batch-point) InfluxDB$ConsistencyLevel/ONE))
+          (is (= (into {} (.getTags batch-point)) {}))
+          (is (= 1 (count points)))
+          (is (= {"alice" "bob"} (into {} (.get fields point))))
+          (is (= "measurement") (.get measurement point))
+          (is (= {"foo" "bar"
+                  "bar" "baz"} (into {} (.get tags point))))
+          (is (= 1428366765 (.get time-field point))))
+        (reset! calls [])
+        ;; send events with differents db/retention/consistency
+        (k [{:time 1428366765
+             :influxdb-tags {:foo "bar"
+                              :bar "baz"}
+             :db "riemann_test"
+             :measurement "measurement"
+             :influxdb-fields {:alice "bob"}}
+            {:time 1428366766
+             :influxdb-tags {:foo "bar"
+                             :bar "baz"}
+             :db "riemann_test_2"
+             :measurement "measurement2"
+             :retention "autogen"
+             :precision :microseconds
+             :influxdb-fields {:alice "bob"}}
+            {:time 1428366767
+             :influxdb-tags {:foo "foo"
+                             :bar "bar"}
+             :db "riemann_test"
+             :measurement "measurement"
+             :consistency "ALL"
+             :influxdb-fields {:alice "bob"
+                               :hello "goodbye"}}
+            {:time 1428366768
+             :influxdb-tags {:foo "foo"
+                             "one" "two"
+                             :bar "bar"}
+             :db "riemann_test"
+             :measurement "measurement2"
+             :precision :microseconds
+             :consistency "ALL"
+             :influxdb-fields {:alice 1
+                               "haha" "huhu"
+                               :hello 2}}])
+        ;; 3 calls because 3 batch points (see influxb/partition-events)
+        (is (= 3 (count @calls)))
+        ;; first call
+        (let  [batch-point (second (first @calls))
+               points (.getPoints batch-point)
+               point (first points)]
+          (is (= 1 (count points)))
+          (is (= (.getDatabase batch-point) "riemann_test"))
+          (is (= (.getRetentionPolicy batch-point) nil))
+          (is (= (.getConsistency batch-point) InfluxDB$ConsistencyLevel/ONE))
+          (is (= (into {} (.getTags batch-point)) {}))
+          (is (= 1 (count points)))
+          (is (= TimeUnit/SECONDS (.get precision point)))
+          (is (= {"alice" "bob"} (into {} (.get fields point))))
+          (is (= "measurement") (.get measurement point))
+          (is (= {"foo" "bar"
+                  "bar" "baz"} (into {} (.get tags point))))
+          (is (= 1428366765 (.get time-field point))))
+        ;; second call
+        (let  [batch-point (second (second @calls))
+               points (.getPoints batch-point)
+               point (first points)]
+          (is (= 1 (count points)))
+          (is (= (.getDatabase batch-point) "riemann_test_2"))
+          (is (= (.getRetentionPolicy batch-point) "autogen"))
+          (is (= TimeUnit/MICROSECONDS (.get precision point)))
+          (is (= (.getConsistency batch-point) InfluxDB$ConsistencyLevel/ONE))
+          (is (= (into {} (.getTags batch-point)) {}))
+          (is (= 1 (count points)))
+          (is (= {"alice" "bob"} (into {} (.get fields point))))
+          (is (= "measurement2") (.get measurement point))
+          (is (= {"foo" "bar"
+                  "bar" "baz"} (into {} (.get tags point))))
+          (is (= 1428366766000000 (.get time-field point))))
+        ;; third call
+        (let  [batch-point (second (last @calls))
+               points (.getPoints batch-point)
+               point1 (first points)
+               point2 (second points)]
+          (is (= 2 (count points)))
+          (is (= (.getDatabase batch-point) "riemann_test"))
+          (is (= (.getRetentionPolicy batch-point) nil))
+          (is (= (.getConsistency batch-point) InfluxDB$ConsistencyLevel/ALL))
+          (is (= (into {} (.getTags batch-point)) {}))
+          ;; point 1
+          (is (= TimeUnit/SECONDS (.get precision point1)))
+          (is (= {"alice" "bob" "hello" "goodbye"} (into {} (.get fields point1))))
+          (is (= "measurement") (.get measurement point1))
+          (is (= {"foo" "foo"
+                  "bar" "bar"} (into {} (.get tags point1))))
+          (is (= 1428366767 (.get time-field point1)))
+          ;; point 2
+          (is (= TimeUnit/MICROSECONDS (.get precision point2)))
+          (is (= {"alice" 1.0 "hello" 2.0 "haha" "huhu"} (into {} (.get fields point2))))
+          (is (= "measurement2") (.get measurement point2))
+          (is (= {"foo" "foo"
+                  "one" "two"
+                  "bar" "bar"} (into {} (.get tags point2))))
+          (is (= 1428366768000000 (.get time-field point2))))))
+    (reset! calls [])
+    (testing "new influxdb stream with default opts"
+      (let [k (influxdb/influxdb
+               {:host "aphyr.com"
+                :version :new-stream
+                :db "foodb"
+                :port 9999
+                :username "user"
+                :password "password"
+                :precision :milliseconds
+                :tags {"hello" "goodbye" :test1 "test1"}
+                :retention "autogen"
+                :timeout 10000
+                :consistency "ALL"})]
+        (k {:time 1428366765
+            :influxdb-tags {:foo "bar"
+                            :bar "baz"}
+            :measurement "example"
+            :influxdb-fields {:alice "bob"}})
+        (is (= 1 (count @calls)))
+        (let  [batch-point (second (first @calls))
+               points (.getPoints batch-point)
+               point (first points)]
+          (is (= (.getDatabase batch-point) "foodb"))
+          (is (= (.getRetentionPolicy batch-point) "autogen"))
+          (is (= (.getConsistency batch-point) InfluxDB$ConsistencyLevel/ALL))
+          (is (= (into {} (.getTags batch-point)) {"hello" "goodbye"
+                                                   "test1" "test1"}))
+          (is (= 1 (count points)))
+          (is (= {"alice" "bob"} (into {} (.get fields point))))
+          (is (= "example") (.get measurement point))
+          (is (= {"foo" "bar"
+                  "test1" "test1"
+                  "hello" "goodbye"
+                  "bar" "baz"} (into {} (.get tags point))))
+          (is (= 1428366765000 (.get time-field point))))
+        (reset! calls [])
+        (k {:time 1428366765
+            :influxdb-tags {:foo "bar"
+                            :bar "baz"}
+            :db "newdb"
+            :precision :microseconds
+            :retention "foobar"
+            :consistency "ONE"
+            :measurement "example"
+            :influxdb-fields {:alice "bob"}})
+        (is (= 1 (count @calls)))
+        (let  [batch-point (second (first @calls))
+               points (.getPoints batch-point)
+               point (first points)]
+          (is (= 1 (count points)))
+          (is (= (.getDatabase batch-point) "newdb"))
+          (is (= (.getRetentionPolicy batch-point) "foobar"))
+          (is (= (.getConsistency batch-point) InfluxDB$ConsistencyLevel/ONE))
+          (is (= (into {} (.getTags batch-point)) {"hello" "goodbye"
+                                                   "test1" "test1"}))
+          (is (= {"alice" "bob"} (into {} (.get fields point))))
+          (is (= "example") (.get measurement point))
+          (is (= {"foo" "bar"
+                  "test1" "test1"
+                  "hello" "goodbye"
+                  "bar" "baz"} (into {} (.get tags point))))
+          (is (= 1428366765000000 (.get time-field point))))))))
 
+(deftest ^:influxdb ^:integration influxdb-test
+  (testing "deprecated influxdb stream"
+    (let [k (influxdb/influxdb
+             {:host (or (System/getenv "INFLUXDB_HOST") "localhost")
+              :db "riemann_test"})]
+      (k {:host "riemann.local"
+          :service "influxdb test"
+          :state "ok"
+          :description "all clear, uh, situation normal"
+          :metric -2
+          :time (unix-time)})
+      (k {:service "influxdb test"
+          :state "ok"
+          :description "all clear, uh, situation normal"
+          :metric 3.14159
+          :time (unix-time)})
+      (k {:host "no-service.riemann.local"
+          :state "ok"
+          :description "Missing service, not transmitted"
+          :metric 4
+          :time (unix-time)})
+      (k {:host 20
+          :service "influx "
+          :state "ok"
+          :description "all clear, uh, situation normal"
+          :foo 10
+          :metric -2
+          :time (unix-time)})))
 
-(deftest ^:influxdb-9 ^:integration influxdb-test-9
-  (let [k (influxdb/influxdb
-            {:version :0.9
-             :host (System/getenv "INFLUXDB_HOST")
-             :db "riemann_test"})]
-    (k {:host "riemann.local"
-        :service "influxdb test"
-        :state "ok"
-        :description "all clear, uh, situation normal"
-        :metric -2
-        :time (unix-time)})
-    (k {:service "influxdb test"
-        :state "ok"
-        :description "all clear, uh, situation normal"
-        :metric 3.14159
-        :time (unix-time)})
-    (k {:host "no-service.riemann.local"
-        :state "ok"
-        :description "Missing service, not transmitted"
-        :metric 4
-        :time (unix-time)})))
+  (testing "new influxdb stream"
+    (let [k (influxdb/influxdb
+             {:host (or (System/getenv "INFLUXDB_HOST") "localhost")
+              :version :new-stream})]
+      (k {:time 1428366765
+          :influxdb-tags {:foo "bar"
+                          :bar "baz"}
+          :precision :milliseconds
+          :db "riemann_test"
+          :measurement "measurement"
+          :influxdb-fields {:alice "bob"}})
+      (k {:time 21893979/1000000
+          :influxdb-tags {:foo "bar"
+                          :bar "baz"}
+          :db "riemann_test"
+          :measurement "measurement1"
+          :influxdb-fields {:alice 1
+                            :bob "hu"}})
+      (k {:time 1428366765
+          :influxdb-tags {:foo "bar"
+                          :bar "baz"}
+          :precision :milliseconds
+          :db "riemann_test"
+          :measurement "measurement"
+          :influxdb-fields {:ratio 21893979/1000000}})
+      (k {:time 1428366765
+          :influxdb-tags {:foo "bar"
+                          :bar "baz"}
+          :precision :seconds
+          :db "riemann_test"
+          :consistency "ALL"
+          :retention "autogen"
+          :measurement "measurement"
+          :influxdb-fields {:alice "bob"}})
+      (k {:time 1428366765
+          :influxdb-tags {:foo "bar"
+                          :bar "baz"
+                          :baz 10}
+          :precision :milliseconds
+          :db "riemann_test"
+          :measurement "measurement"
+          :influxdb-fields {:alice "bob"
+                            :bob 20}}))))
 
+(deftest event-fields-test
+  (is (= (influxdb/event-fields
+          #{}
+          {:host "host-01"
+           :service "test service"
+           :time 1428366765
+           :metric 42.08})
+         {"value" 42.08}))
+  (is (= (influxdb/event-fields
+          #{}
+          {:host "host-01"
+           :service "test service"
+           :time 1428366765
+           :metric 42.08
+           :hello "hello"})
+         {"value" 42.08 "hello" "hello"}))
+  (is (= (influxdb/event-fields
+          #{:hello}
+          {:host "host-01"
+           :service "test service"
+           :time 1428366765
+           :metric 42.08
+           :hello "hello"})
+         {"value" 42.08}))
+  (is (= (influxdb/event-fields
+          #{:hello}
+          {:host "host-01"
+           :service "test service"
+           :time 1428366765
+           :metric 42.08
+           :hello "hello"
+           :foo "bar"})
+         {"value" 42.08
+          "foo" "bar"})))
+
+(deftest event-tags-test
+  (is (= (influxdb/event-tags
+          #{}
+          {:host "host-01"
+           :service "test service"
+           :time 1428366765
+           :metric 42.08})
+         {}))
+  (is (= (influxdb/event-tags
+          #{:host}
+          {:host "host-01"
+           :service "test service"
+           :time 1428366765
+           :metric 42.08})
+         {"host" "host-01"}))
+  (is (= (influxdb/event-tags
+          #{:host :hello}
+          {:host "host-01"
+           :service "test service"
+           :time 1428366765
+           :hello "hello"
+           :metric 42.08})
+         {"host" "host-01"
+          "hello" "hello"}))
+  (is (= (influxdb/event-tags
+          #{:host :hello}
+          {:host "host-01"
+           :service "test service"
+           :time 1428366765
+           :foo "bar"
+           :hello "hello"
+           :metric 42.08})
+         {"host" "host-01"
+          "hello" "hello"})))
+
+(deftest get-time-unit-test
+  (is (= TimeUnit/SECONDS (influxdb/get-time-unit :seconds)))
+  (is (= TimeUnit/MILLISECONDS (influxdb/get-time-unit :milliseconds)))
+  (is (= TimeUnit/MICROSECONDS (influxdb/get-time-unit :microseconds)))
+  (is (= TimeUnit/SECONDS (influxdb/get-time-unit :default))
+      "Default value is SECONDS"))
+
+(deftest convert-time-test
+  (is (= 1 (influxdb/convert-time 1 :seconds))
+      "seconds -> seconds")
+  (is (= 1000 (influxdb/convert-time 1 :milliseconds))
+      "seconds -> milliseconds")
+  (is (= 1000000 (influxdb/convert-time 1 :microseconds))
+      "seconds -> microseconds")
+  (is (= 1 (influxdb/convert-time 1 :default))
+      "seconds -> seconds (default)"))
+
+(deftest point-conversion-deprecated
+  (is (nil? (influxdb/event->point-9 {:service "foo test" :time 1} {:tag-fields #{}}))
+      "Event with no metric is converted to nil")
+  (testing "Minimal event is converted to point fields"
+    (let [point (influxdb/event->point-9 {:host "host-01"
+                                          :service "test service"
+                                          :time 1428366765
+                                          :metric 42.08}
+                                         {:tag-fields #{:host}
+                                          :precision :seconds})]
+      (is (= "test service" (.get measurement point)))
+      (is (= TimeUnit/SECONDS (.get precision point)))
+      (is (= 1428366765 (.get time-field point)))
+      (is (= {"host" "host-01"} (into {} (.get tags point))))
+      (is (= {"value" 42.08} (into {} (.get fields point))))))
+
+  (testing "Event is converted with time in milliseconds"
+    (let [point (influxdb/event->point-9 {:host "host-01"
+                                          :service "test service"
+                                          :time 1428366765
+                                          :precision :milliseconds
+                                          :metric 42.08}
+                                         {:tag-fields #{:host}
+                                          :precision :seconds})]
+      (is (= "test service" (.get measurement point)))
+      (is (= 1428366765000 (.get time-field point)))
+      (is (= TimeUnit/MILLISECONDS (.get precision point)))
+      (is (= {"host" "host-01"} (into {} (.get tags point))))
+      (is (= {"value" 42.08} (into {} (.get fields point))))))
+
+  (testing "Event is converted with time in microseconds"
+    (let [point (influxdb/event->point-9 {:host "host-01"
+                                          :service "test service"
+                                          :time 1428366765
+                                          :metric 42.08}
+                                         {:tag-fields #{:host}
+                                          :precision :microseconds})]
+      (is (= "test service" (.get measurement point)))
+      (is (= 1428366765000000 (.get time-field point)))
+      (is (= TimeUnit/MICROSECONDS (.get precision point)))
+      (is (= {"host" "host-01"} (into {} (.get tags point))))
+      (is (= {"value" 42.08} (into {} (.get fields point))))))
+
+  (testing "Event with ratio field"
+    (let [point (influxdb/event->point-9 {:host "host-01"
+                                          :service "test service"
+                                          :time 1428366765
+                                          :metric 21893979/1000000}
+                                         {:tag-fields #{:host}
+                                          :precision :microseconds})]
+      (is (= "test service" (.get measurement point)))
+      (is (= 1428366765000000 (.get time-field point)))
+      (is (= TimeUnit/MICROSECONDS (.get precision point)))
+      (is (= {"host" "host-01"} (into {} (.get tags point))))
+      (is (= {"value" (double 21893979/1000000)} (into {} (.get fields point))))))
+
+  (testing "Event is converted with time in microseconds"
+    (let [point (influxdb/event->point-9 {:host "host-01"
+                                          :service "test service"
+                                          :time 1428366765
+                                          :precision :microseconds
+                                          :metric 42.08}
+                                         {:tag-fields #{:host}
+                                          :precision :seconds})]
+      (is (= "test service" (.get measurement point)))
+      (is (= 1428366765000000 (.get time-field point)))
+      (is (= TimeUnit/MICROSECONDS (.get precision point)))
+      (is (= {"host" "host-01"} (into {} (.get tags point))))
+      (is (= {"value" 42.08} (into {} (.get fields point))))))
+
+  (testing "Full event is converted to point fields"
+    (let [point (influxdb/event->point-9 {:host "www-dev-app-01.sfo1.example.com"
+                                          :service "service_api_req_latency"
+                                          :time 1428354941
+                                          :metric 0.8025
+                                          :state "ok"
+                                          :description "A text description!"
+                                          :ttl 60
+                                          :tags ["one" "two" "red"]
+                                          :sys "www"
+                                          :env "dev"
+                                          :role "app"
+                                          :loc "sfo1"
+                                          :foo "frobble"}
+                                         {:tag-fields #{:host :sys :env :role :loc}
+                                          :precision :milliseconds})]
+      (is (= "service_api_req_latency" (.get measurement point)))
+      (is (= 1428354941000 (.get time-field point)))
+      (is (= TimeUnit/MILLISECONDS (.get precision point)))
+      (is (= {"host" "www-dev-app-01.sfo1.example.com"
+              "sys" "www"
+              "env" "dev"
+              "role" "app"
+              "loc" "sfo1"}
+             (into {} (.get tags point))))
+      (is (= {"value" 0.8025
+              "description" "A text description!"
+              "state" "ok"
+              "foo" "frobble"}
+             (into {} (.get fields point))))))
+
+  (testing ":sys and :loc tags and removed because nil or empty str. Same for :bar and :hello fields"
+    (let [point (influxdb/event->point-9 {:host "www-dev-app-01.sfo1.example.com"
+                                          :service "service_api_req_latency"
+                                          :time 1428354941
+                                          :metric 0.8025
+                                          :state "ok"
+                                          :description "A text description!"
+                                          :ttl 60
+                                          :tags ["one" "two" "red"]
+                                          :sys nil
+                                          :env "dev"
+                                          :role "app"
+                                          :loc ""
+                                          :foo "frobble"
+                                          :bar nil
+                                          :hello ""}
+                                         {:tag-fields #{:host :sys :env :role :loc}})]
+      (is (= "service_api_req_latency" (.get measurement point)))
+      (is (= 1428354941 (.get time-field point)))
+      (is (= TimeUnit/SECONDS (.get precision point)))
+      (is (= {"host" "www-dev-app-01.sfo1.example.com"
+              "role" "app"
+              "env" "dev"}
+             (into {} (.get tags point))))
+      (is (= {"value" 0.8025
+              "description" "A text description!"
+              "state" "ok"
+              "foo" "frobble"}
+             (into {} (.get fields point))))))
+
+  (testing "event :tag-fields"
+    (let [point (influxdb/event->point-9 {:host "host-01"
+                                          :service "test service"
+                                          :time 1428366765
+                                          :precision :milliseconds
+                                          :metric 42.08
+                                          :env "dev"
+                                          :tag-fields #{:env}}
+                                         {:tag-fields #{:host}})]
+      (is (= "test service" (.get measurement point)))
+      (is (= 1428366765000 (.get time-field point)))
+      (is (= {"host" "host-01" "env" "dev"} (into {} (.get tags point))))
+      (is (= {"value" 42.08} (into {} (.get fields point)))))))
 
 (deftest point-conversion
-  (is (nil? (influxdb/event->point-9 #{} {:service "foo test", :time 1}))
-      "Event with no metric is converted to nil")
-  (is (= {"measurement" "test service"
-          "time" 1428366765
-          "tags" {"host" "host-01"}
-          "fields" {"value" 42.08}}
-         (influxdb/event->point-9
-           #{:host}
-           {:host "host-01"
-            :service "test service"
-            :time 1428366765
-            :metric 42.08}))
-      "Minimal event is converted to point fields")
-  (is (= {"measurement" "service_api_req_latency"
-          "time" 1428354941
-          "tags" {"host" "www-dev-app-01.sfo1.example.com"
-                  "sys" "www"
-                  "env" "dev"
-                  "role" "app"
-                  "loc" "sfo1"}
-          "fields" {"value" 0.8025
-                    "description" "A text description!"
-                    "state" "ok"
-                    "foo" "frobble"}}
-         (influxdb/event->point-9
-           #{:host :sys :env :role :loc}
-           {:host "www-dev-app-01.sfo1.example.com"
-            :service "service_api_req_latency"
-            :time 1428354941
-            :metric 0.8025
-            :state "ok"
-            :description "A text description!"
-            :ttl 60
-            :tags ["one" "two" "red"]
-            :sys "www"
-            :env "dev"
-            :role "app"
-            :loc "sfo1"
-            :foo "frobble"}))
-      "Full event is converted to point fields")
-  (is (empty? (influxdb/events->points-9 #{} [{:service "foo test"}]))
-      "Nil points are filtered from result")
-  (is (= {"measurement" "service_api_req_latency"
-          "time" 1428354941
-          "tags" {"host" "www-dev-app-01.sfo1.example.com"
-                  "role" "app"
-                  "env" "dev"}
-          "fields" {"value" 0.8025
-                    "description" "A text description!"
-                    "state" "ok"
-                    "foo" "frobble"}}
-         (influxdb/event->point-9
-           #{:host :sys :env :role :loc}
-           {:host "www-dev-app-01.sfo1.example.com"
-            :service "service_api_req_latency"
-            :time 1428354941
-            :metric 0.8025
-            :state "ok"
-            :description "A text description!"
-            :ttl 60
-            :tags ["one" "two" "red"]
-            :sys nil
-            :env "dev"
-            :role "app"
-            :loc ""
-            :foo "frobble"
-            :bar nil
-            :hello ""}))
-      ":sys and :loc tags and removed because nil or empty str. Same for :bar and :hello fields"))
+  (is (nil? (influxdb/event->point {:service "foo test" :time 1} {:precision :seconds}))
+      "Event with no measurement is converted to nil")
 
+  (testing "Event :metric ratio"
+    (let [point (influxdb/event->point {:time 1428366765
+                                        :influxdb-tags {:foo "bar"
+                                                        :bar "baz"}
+                                        :precision :milliseconds
+                                        :measurement "measurement"
+                                        :influxdb-fields {:alice 21893979/1000000}}
+                                       {:precision :seconds})]
+      (is (= "measurement" (.get measurement point)))
+      (is (= 1428366765000 (.get time-field point)))
+      (is (= TimeUnit/MILLISECONDS (.get precision point)))
+      (is (= {"foo" "bar" "bar" "baz"} (into {} (.get tags point))))
+      (is (= {"alice" (double 21893979/1000000)} (into {} (.get fields point))))))
 
-(deftest line-protocol
-  (is (= "some\\ service,host=ugly\"host\\=name,another=ta\\,g value=0.123456789,a_tag=\"a value\" 1442548067"
-         (influxdb/lineprotocol-encode-9
-           {"measurement" "some service"
-            "time"        1442548067000/1000
-            "tags"
-              {"host"     "ugly\"host=name"
-               "another"  "ta,g"}
-            "fields"
-              {"value"    0.123456789
-               "a_tag"    "a value"}}))
-    "Point field is converted to line encoding"))
+  (testing "Minimal event is converted to point fields"
+    (let [point (influxdb/event->point {:time 1428366765
+                                        :influxdb-tags {:foo "bar"
+                                                        :bar "baz"}
+                                        :measurement "measurement"
+                                        :influxdb-fields {:alice "bob"}}
+                                       {:precision :seconds})]
+      (is (= "measurement" (.get measurement point)))
+      (is (= TimeUnit/SECONDS (.get precision point)))
+      (is (= 1428366765 (.get time-field point)))
+      (is (= {"alice" "bob"} (into {} (.get fields point))))))
+
+  (testing "Event is converted with time in milliseconds"
+    (let [point (influxdb/event->point {:time 1428366765
+                                        :influxdb-tags {:foo "bar"
+                                                        :bar "baz"}
+                                        :precision :milliseconds
+                                        :measurement "measurement"
+                                        :influxdb-fields {:alice "bob"}}
+                                       {:precision :seconds})]
+      (is (= "measurement" (.get measurement point)))
+      (is (= 1428366765000 (.get time-field point)))
+      (is (= TimeUnit/MILLISECONDS (.get precision point)))
+      (is (= {"foo" "bar" "bar" "baz"} (into {} (.get tags point))))
+      (is (= {"alice" "bob"} (into {} (.get fields point))))))
+
+  (testing "Event is converted with time in microseconds"
+    (let [point (influxdb/event->point {:time 1428366765
+                                        :influxdb-tags {:foo "bar"
+                                                        :bar "baz"}
+                                        :precision :microseconds
+                                        :measurement "measurement"
+                                        :influxdb-fields {:alice "bob"}}
+                                       {:precision :seconds})]
+      (is (= "measurement" (.get measurement point)))
+      (is (= 1428366765000000 (.get time-field point)))
+      (is (= TimeUnit/MICROSECONDS (.get precision point)))
+      (is (= {"foo" "bar" "bar" "baz"} (into {} (.get tags point))))
+      (is (= {"alice" "bob"} (into {} (.get fields point))))))
+
+  (testing "Event is converted with time in microseconds"
+    (let [point (influxdb/event->point {:time 1428366765
+                                        :influxdb-tags {:foo "bar"
+                                                        :bar "baz"}
+                                        :measurement "measurement"
+                                        :influxdb-fields {:alice "bob"}}
+                                       {:precision :microseconds})]
+      (is (= "measurement" (.get measurement point)))
+      (is (= 1428366765000000 (.get time-field point)))
+      (is (= TimeUnit/MICROSECONDS (.get precision point)))
+      (is (= {"foo" "bar" "bar" "baz"} (into {} (.get tags point))))
+      (is (= {"alice" "bob"} (into {} (.get fields point))))))
+
+  (testing ":sys and :loc tags are removed because nil or empty str. Same for :bar and :hello fields"
+    (let [point (influxdb/event->point {:time 1428366765
+                                        :influxdb-tags {:foo "bar"
+                                                        :bar "baz"
+                                                        :sys ""
+                                                        :loc nil}
+                                        :precision :milliseconds
+                                        :measurement "measurement"
+                                        :influxdb-fields {:alice "bob"
+                                                          :bar nil
+                                                          :hello ""}}
+                                       {:precision :seconds})]
+      (is (= "measurement" (.get measurement point)))
+      (is (= 1428366765000 (.get time-field point)))
+      (is (= TimeUnit/MILLISECONDS (.get precision point)))
+      (is (= {"foo" "bar" "bar" "baz"} (into {} (.get tags point))))
+      (is (= {"alice" "bob"} (into {} (.get fields point)))))))
+
+(deftest get-batchpoint-test
+  (testing "No tags, no retention"
+    (let [batch-point (influxdb/get-batchpoint {:tags {}
+                                                :db "riemann_test"
+                                                :retention nil
+                                                :consistency "ALL"})]
+      (is (= (.getDatabase batch-point) "riemann_test"))
+      (is (= (.getRetentionPolicy batch-point) nil))
+      (is (= (.getConsistency batch-point) InfluxDB$ConsistencyLevel/ALL))
+      (is (= (into {} (.getTags batch-point)) {}))))
+  (testing "With tags, no retention"
+    (let [batch-point (influxdb/get-batchpoint {:tags {:foo "bar"
+                                                       :bar "baz"}
+                                                :db "riemann_test"
+                                                :retention nil
+                                                :consistency "ONE"})]
+      (is (= (.getDatabase batch-point) "riemann_test"))
+      (is (= (.getRetentionPolicy batch-point) nil))
+      (is (= (.getConsistency batch-point) InfluxDB$ConsistencyLevel/ONE))
+      (is (= (into {} (.getTags batch-point)) {"foo" "bar" "bar" "baz"}))))
+  (testing "With tags, with retention"
+    (let [batch-point (influxdb/get-batchpoint {:tags {:foo "bar"
+                                                       :bar "baz"}
+                                                :db "riemann_test"
+                                                :retention "hello"
+                                                :consistency "ONE"})]
+      (is (= (.getDatabase batch-point) "riemann_test"))
+      (is (= (.getRetentionPolicy batch-point) "hello"))
+      (is (= (.getConsistency batch-point) InfluxDB$ConsistencyLevel/ONE))
+      (is (= (into {} (.getTags batch-point)) {"foo" "bar" "bar" "baz"})))))
+
+(deftest get-batchpoints-test
+  (testing "partition by db"
+    (let [partition [[{:time 1428366765
+                       :influxdb-tags {:foo "bar"}
+                       :measurement "measurement"
+                       :db "db1"
+                       :influxdb-fields {:alice "bob"}}
+                      {:time 1428366768
+                       :influxdb-tags {:foo "bar"}
+                       :db "db1"
+                       :measurement "measurement"
+                       :influxdb-fields {:alice "bob"}}]
+                     [{:time 1428366766
+                       :influxdb-tags {:foo "bar"}
+                       :measurement "measurement"
+                       :db "db2"
+                       :influxdb-fields {:alice "bob"}}
+                      {:time 1428366767
+                       :influxdb-tags {:foo "bar"}
+                       :db "db2"
+                       :measurement "measurement"
+                       :influxdb-fields {:alice "bob"}}]]
+          [b1 b2 :as batch-points] (influxdb/get-batchpoints {:consistency "ALL"} partition)]
+      (is (= (count batch-points) 2))
+      (is (= (.getDatabase b1) "db1"))
+      (is (= (.getRetentionPolicy b1) nil))
+      (is (= (.getConsistency b1) InfluxDB$ConsistencyLevel/ALL))
+      (is (= (into {} (.getTags b1)) {}))
+      (is (= (.getDatabase b2) "db2"))
+      (is (= (.getRetentionPolicy b2) nil))
+      (is (= (.getConsistency b2) InfluxDB$ConsistencyLevel/ALL))
+      (is (= (into {} (.getTags b2)) {}))))
+  (testing "partition by db, consistency, retention"
+    (let [partition [[{:time 1428366765
+                       :influxdb-tags {:foo "bar"}
+                       :measurement "measurement"
+                       :db "db1"
+                       :consistency "ALL"
+                       :influxdb-fields {:alice "bob"}}
+                      {:time 1428366768
+                       :influxdb-tags {:foo "bar"}
+                       :db "db1"
+                       :consistency "ALL"
+                       :measurement "measurement"
+                       :influxdb-fields {:alice "bob"}}]
+                     [{:time 1428366765
+                       :influxdb-tags {:foo "bar"}
+                       :measurement "measurement"
+                       :db "db1"
+                       :influxdb-fields {:alice "bob"}}]
+                     [{:time 1428366766
+                       :influxdb-tags {:foo "bar"}
+                       :measurement "measurement"
+                       :db "db2"
+                       :influxdb-fields {:alice "bob"}}
+                      {:time 1428366767
+                       :influxdb-tags {:foo "bar"}
+                       :db "db2"
+                       :measurement "measurement"
+                       :influxdb-fields {:alice "bob"}}]
+                     [{:time 1428366766
+                       :influxdb-tags {:foo "bar"}
+                       :measurement "measurement"
+                       :db "db2"
+                       :retention "hello"
+                       :influxdb-fields {:alice "bob"}}]]
+          [b1 b2 b3 b4 :as batch-points] (influxdb/get-batchpoints {:consistency "ONE"} partition)]
+      (is (= (count batch-points) 4))
+      (is (= (.getDatabase b1) "db1"))
+      (is (= (.getRetentionPolicy b1) nil))
+      (is (= (.getConsistency b1) InfluxDB$ConsistencyLevel/ALL))
+      (is (= (into {} (.getTags b1)) {}))
+      (is (= (.getDatabase b2) "db1"))
+      (is (= (.getRetentionPolicy b2) nil))
+      (is (= (.getConsistency b2) InfluxDB$ConsistencyLevel/ONE))
+      (is (= (into {} (.getTags b2)) {}))
+      (is (= (.getDatabase b3) "db2"))
+      (is (= (.getRetentionPolicy b3) nil))
+      (is (= (.getConsistency b3) InfluxDB$ConsistencyLevel/ONE))
+      (is (= (into {} (.getTags b3)) {}))
+      (is (= (.getDatabase b4) "db2"))
+      (is (= (.getRetentionPolicy b4) "hello"))
+      (is (= (.getConsistency b4) InfluxDB$ConsistencyLevel/ONE))
+      (is (= (into {} (.getTags b4)) {})))))
+
+(deftest partition-events-test
+  (let [[p1 p2 p3 p4 :as result] (influxdb/partition-events [{:db "db1"
+                                                              :consistency "ALL"}
+                                                             {:db "db1"}
+                                                             {:db "db2"}
+                                                             {:db "db2"}
+                                                             {:db "db1"
+                                                              :consistency "ALL"
+                                                              :foo "bar"}
+                                                             {:measurement "measurement"
+                                                              :db "db2"
+                                                              :retention "hello"}])]
+    (is (= (count result) 4))
+    (is (= (count p1) 2))
+    (is (= (first p1) {:db "db1" :consistency "ALL"}))
+    (is (= (second p1) {:db "db1" :consistency "ALL" :foo "bar"}))
+    (is (= (count p2) 1))
+    (is (= (first p2) {:db "db1"}))
+    (is (= (first p3) {:db "db2"}))
+    (is (= (second p3) {:db "db2"}))
+    (is (= (count p3) 2))
+    (is (= (first p4) {:db "db2" :measurement "measurement" :retention "hello"}))
+    (is (= (count p4) 1)))
+
+  (let [[p1 p2 p3 p4 p5 :as result] (influxdb/partition-events [{}
+                                                                {:consistency "ALL"}
+                                                                {:consistency "ONE"}
+                                                                {:db "db1"}
+                                                                {:retention "foo"}
+                                                                {:foo "bar"}
+                                                                {:retention "foo"
+                                                                 :bar "baz"}])]
+    (is (= (count result) 5))
+    (is (= (count p1) 2))
+    (is (= (first p1) {}))
+    (is (= (second p1) {:foo "bar"}))
+    (is (= (count p2) 1))
+    (is (= (first p2) {:consistency "ALL"}))
+    (is (= (count p3) 1))
+    (is (= (first p3) {:consistency "ONE"}))
+    (is (= (count p4) 1))
+    (is (= (first p4) {:db "db1"}))
+    (is (= (count p5) 2))
+    (is (= (first p5) {:retention "foo"}))
+    (is (= (second p5) {:retention "foo"
+                        :bar "baz"}))))
+
+(deftest ratio?->double-test
+  (is (= (influxdb/ratio?->double 21893979/1000000) (double 21893979/1000000)))
+  (is (= (influxdb/ratio?->double 3) 3))
+  (is (= (influxdb/ratio?->double 3.1) 3.1))
+  (is (= (influxdb/ratio?->double "foo") "foo")))


### PR DESCRIPTION
#739 
This is a major refactoring of the InfluxDB code.  The goal is to support all influxdb  options. I have wrapped the officiel influxdb java client. I await your opinions on this (is this change a good idea, possibles improvements in the code...). Normally, the change is transparent for the user (same options).

## Breaking change : 

- this code does not support InfluxDB < 0.9 (like the official java client). Is it acceptable ?

## Improvements :
- Support InfluxDB consistency levels.
- Support differents time units (micros, millis and seconds, automatic conversion) with a :precision keyword on the event.

The :insecure connection mode is actually untested. Otherwise, all tests are passing. 

