### PR TITLE
Keep coalesce state between reloads

### DIFF
--- a/src/riemann/bin.clj
+++ b/src/riemann/bin.clj
@@ -40,6 +40,7 @@
       (riemann.config/validate-config @config-file)
       (riemann.time/reset-tasks!)
       (riemann.config/clear!)
+      (riemann.config/clear-stream-state!)
       (riemann.pubsub/sweep! (:pubsub @riemann.config/core))
       (riemann.config/include @config-file)
       (riemann.config/apply!)

--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -291,6 +291,11 @@
   (locking core
     (reset! next-core (core/core))))
 
+(defn clear-stream-state!
+  "Resets the streams states atoms"
+  []
+  (stream-state-transition!))
+
 (defn apply!
   "Applies pending changes to the core. Transitions the current core to the
   next one, and resets the next core."


### PR DESCRIPTION
This PR allows the coalesce stream to keep state between reloads ([#743]([https://github.com/riemann/riemann/issues/743))