### PR TITLE
Add Crabby to Toolbox section of clients.html

### DIFF
--- a/clients.html
+++ b/clients.html
@@ -193,6 +193,13 @@ title: Riemann - Clients
         href="https://collectd.org/wiki/index.php/Plugin:Write_Riemann">Write
         Riemann plugin for collectd</a> submits collectd values as events to
       Riemann.</p>
+      
+      <h2 id="crabby">Crabby</h2>
+      <p><a href="https://github.com/chrissnell/crabby">Crabby</a> is a web page 
+        performance monitor that loads your pages in a real browser (headless 
+        Chrome) and reports various page performance metrics (DNS resolution 
+        time, time-to-first-byte, DOM rendering time, etc.) to Riemann.  
+        It also reports HTTP response codes as state events.</p>
 
       <h2 id="ganglia">Ganglia</h2>
       <p>Ganglia can <a


### PR DESCRIPTION
Crabby is a web performance monitor that can send metrics and HTTP response codes as events to Riemann.