### PR TITLE
Prometheus label / body only support some char.

### DIFF
--- a/src/riemann/prometheus.clj
+++ b/src/riemann/prometheus.clj
@@ -9,10 +9,11 @@
   "A set of event fields in Riemann with special handling logic."
   #{:service :metric :tags :time :ttl})
 
+
 (defn replace-disallowed
   "Replaces all existence of disallowed characters with underscore."
   [field]
-  (str/escape field {\space "_", \. "_", \: "_" \- "_"}))
+   (str/replace (str/replace field #"[^a-zA-Z0-9_]" "_") #"[_]{2,}" "_"))
 
 (defn generate-metricname
   "Generates the metric name as per prometheus specification."
@@ -31,7 +32,7 @@
   "Creates a Prometheus label out of a Riemann event."
   [filtered-event]
   (->> filtered-event
-       (map #(if-not (nil? (second %)) (str "/" (name (first %)) "/" (second %))))
+       (map #(if-not (nil? (second %)) (str "/" (replace-disallowed (name (first %))) "/" (second %))))
        (str/join "")))
 
 (defn filter-event

--- a/src/riemann/prometheus.clj
+++ b/src/riemann/prometheus.clj
@@ -9,11 +9,10 @@
   "A set of event fields in Riemann with special handling logic."
   #{:service :metric :tags :time :ttl})
 
-
 (defn replace-disallowed
   "Replaces all existence of disallowed characters with underscore."
   [field]
-   (str/replace (str/replace field #"[^a-zA-Z0-9_]" "_") #"[_]{2,}" "_"))
+  (str/replace (str/replace field #"[^a-zA-Z0-9_]" "_") #"[_]{2,}" "_"))
 
 (defn generate-metricname
   "Generates the metric name as per prometheus specification."

--- a/test/riemann/prometheus_test.clj
+++ b/test/riemann/prometheus_test.clj
@@ -88,3 +88,25 @@
                :conn-timeout 5000
                :content-type :json
                :throw-entire-message? true}])))))
+
+(deftest ^:prometheus prometheus-test-with-disallow-caractere
+  (with-mock [calls client/post]
+    (let [d (prometheus/prometheus {:host "localhost"
+                                    :exclude-fields #{:service :metric :tags :time :ttl :state}})]
+
+      (testing "an event with a custom field")
+      (d {:host    "testhost"
+          :service "testservice :scheduling (ms)"
+          :metric  42
+          :time    123456789
+          :state   "ok"
+          :tags    ["tag1","tag2"]
+          :client-test  "X-Riemann-Client"})
+      (is (= 1 (count @calls)))
+      (is (= (vec (last @calls))
+             ["http://localhost:9091/metrics/job/riemann/host/testhost/instance/localhost/tags/tag1,tag2/host/testhost/client_test/X-Riemann-Client"
+              {:body "testservice_scheduling_ms_ 42.0\n"
+               :socket-timeout 5000
+               :conn-timeout 5000
+               :content-type :json
+               :throw-entire-message? true}])))))


### PR DESCRIPTION
Prometheus do not allow some character, the first implementation was not enough restrictive and didn't apply to label.

So I made it more restrictive and apply to label as well.

