### PR TITLE
coalesce: simplify coalesce state storage

### DIFF
--- a/src/riemann/bin.clj
+++ b/src/riemann/bin.clj
@@ -40,7 +40,6 @@
       (riemann.config/validate-config @config-file)
       (riemann.time/reset-tasks!)
       (riemann.config/clear!)
-      (riemann.config/clear-stream-state!)
       (riemann.pubsub/sweep! (:pubsub @riemann.config/core))
       (riemann.config/include @config-file)
       (riemann.config/apply!)

--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -292,11 +292,6 @@
   (locking core
     (reset! next-core (core/core))))
 
-(defn clear-stream-state!
-  "Resets the streams states atoms"
-  []
-  (stream-state-transition!))
-
 (defn apply!
   "Applies pending changes to the core. Transitions the current core to the
   next one, and resets the next core."


### PR DESCRIPTION
Here's a proposed changed to how coalesce would store state.
This does away with the two atoms, and uses defonce to have a single persistent state atom.
For the odd-case where you might be tempted to change/remove a coalesce, a utility function is provided.