### PR TITLE
Slack : cast event :tags into vector

### DIFF
--- a/src/riemann/slack.clj
+++ b/src/riemann/slack.clj
@@ -35,7 +35,7 @@
                      "State:   " (or (:state events) "-") "\n"
                      "Description:   " (or (:description events) "-") "\n"
                      "Metric:   " (or (:metric events) "-") "\n"
-                     "Tags:   " (or (:tags events) "-") "\n"))
+                     "Tags:   " (into [] (:tags events)) "\n"))
        :short true}]}]})
 
 
@@ -64,7 +64,7 @@
        :value (slack-escape (or (:description events) "-"))
        :short true}
       {:title "Tags",
-       :value (slack-escape (or (str (:tags events)) "-"))
+       :value (slack-escape (str (into [] (:tags events))))
        :short true}]}]})
 
 


### PR DESCRIPTION
With this conf :

```clojure
(streams
 (tag "foo"
   slacker))
```

I have in slack :

```
Host:   host
Service:   riemann server tcp 0.0.0.0:5555 in latency 0.5
State:   ok
Description:   -
Metric:   -
Tags:   clojure.lang.LazySeq@18ce5
```
It is because the `tag` stream produces a LazySeq in :tags. This PR cast the :tags value into vector in the slack formatters.