### PR TITLE
Clarify throttle doc-string

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1059,9 +1059,10 @@
            bottom-stream))))
 
 (defn throttle
-  "Passes on at most n events every dt seconds. If more than n events arrive in
-  a dt-second fixed window, drops remaining events. Imposes no additional
-  latency; events are either passed on immediately or dropped."
+  "Passes on at most n events, or vectors of events, every dt seconds. If more
+  than n events (or vectors) arrive in a dt-second fixed window, drops
+  remaining events. Imposes no additional latency; events are either passed on
+  immediately or dropped."
   [n dt & children]
   (part-time-simple
     dt


### PR DESCRIPTION
It wasn't clear to me how throttle would handle vectors of events (for instance the output from moving-time-window). I've tried to clarify the doc-string.