### PR TITLE
Fix typo in the doc string of Instrumented protocol.

### DIFF
--- a/src/riemann/instrumentation.clj
+++ b/src/riemann/instrumentation.clj
@@ -10,7 +10,7 @@
                                       uniform-reservoir]]))
 
 (defprotocol Instrumented
-  "These things can can be asked to report events about their performance and
+  "These things can be asked to report events about their performance and
   health."
   (events [this]
           "Returns a sequence of events describing the current state of the


### PR DESCRIPTION
Fixes the message in the doc string.