### PR TITLE
Add "riemann" tag to Instrumented transports and services

### DIFF
--- a/src/riemann/service.clj
+++ b/src/riemann/service.clj
@@ -220,34 +220,42 @@
             s (partial str "riemann executor " (clojure.core/name name) " ")]
         [{:service (s "accepted rate")
           :metric  (/ daccepted dtime)
+          :tags    ["riemann"]
           :state   "ok"
           :time    time}
          {:service (s "completed rate")
           :metric  (/ dcompleted dtime)
+          :tags    ["riemann"]
           :state   "ok"
           :time    time}
          {:service (s "rejected rate")
           :metric  (/ drejected dtime)
+          :tags    ["riemann"]
           :state   (if (pos? drejected) "warning" "ok")
           :time    time}
          {:service (s "queue capacity")
           :metric  queue-capacity
+          :tags    ["riemann"]
           :state   "ok"
           :time    time}
          {:service (s "queue size")
           :metric  queue-size
+          :tags    ["riemann"]
           :state   queue-used-state
           :time    time}
          {:service (s "queue used")
           :metric  queue-used
+          :tags    ["riemann"]
           :state   queue-used-state
           :time    time}
          {:service (s "threads active")
           :metric  threads-active
+          :tags    ["riemann"]
           :state   "ok"
           :time    time}
          {:service (s "threads alive")
           :metric  (.getPoolSize executor)
+          :tags    ["riemann"]
           :state   "ok"
           :time    time}]))))
 

--- a/src/riemann/transport.clj
+++ b/src/riemann/transport.clj
@@ -152,11 +152,12 @@
 
     (reify Instrumented
       (events [this]
-        (let [base {:state "ok" :time (unix-time)}]
+        (let [base {:state "ok"
+                    :tags  ["riemann"]
+                    :time  (unix-time)}]
                    (map (partial merge base)
                         [{:service (str svc "threads active")
-                          :metric (.. executor executorCount)}]))
-        ))))
+                          :metric (.. executor executorCount)}]))))))
 
 (defn handle
   "Handles a msg with the given core."

--- a/src/riemann/transport/sse.clj
+++ b/src/riemann/transport/sse.clj
@@ -111,6 +111,7 @@
           ;; Take snapshots of our current stats.
           (let [svc (str "riemann server sse " host ":" port)
                 base {:time (unix-time)
+                      :tags ["riemann"]
                       :state "ok"}
                 out (metrics/snapshot! (:out stats))
                 in  (metrics/snapshot! (:in stats))]

--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -182,6 +182,7 @@
           (let [svc  (str "riemann server tcp " host ":" port)
                 in   (metrics/snapshot! stats)
                 base {:state "ok"
+                      :tags ["riemann"]
                       :time (:time in)}]
             (map (partial merge base)
                  (concat [{:service (str svc " conns")

--- a/src/riemann/transport/udp.clj
+++ b/src/riemann/transport/udp.clj
@@ -133,6 +133,7 @@
           (let [svc  (str "riemann server udp " host ":" port)
                 in   (metrics/snapshot! stats)
                 base {:state "ok"
+                      :tags ["riemann"]
                       :time (:time in)}]
             (map (partial merge base)
                  (concat [{:service (str svc " in rate")

--- a/src/riemann/transport/websockets.clj
+++ b/src/riemann/transport/websockets.clj
@@ -198,6 +198,7 @@
           ; Take snapshots of our current stats.
           (let [svc (str "riemann server ws " host ":" port)
                 base {:time (unix-time)
+                      :tags ["riemann"]
                       :state "ok"}
                 out (metrics/snapshot! (:out stats))
                 in  (metrics/snapshot! (:in stats))]

--- a/test/riemann/service_test.clj
+++ b/test/riemann/service_test.clj
@@ -68,8 +68,8 @@
            (is (= [:start-2 :core] (send :start-2)))
 
            ; Should shut down cleanly
-           (let [f (future 
-                     (Thread/sleep 50) 
+           (let [f (future
+                     (Thread/sleep 50)
                      (.put in :stop))]
              (stop! s)
              @f)
@@ -155,34 +155,42 @@
              (is (= (instrumentation/events s)
                     [{:service "riemann executor cat accepted rate"
                       :metric 3/5
+                      :tags ["riemann"]
                       :state "ok"
                       :time 5}
                      {:service "riemann executor cat completed rate"
                       :metric 3/5
+                      :tags ["riemann"]
                       :state "ok"
                       :time 5}
                      {:service "riemann executor cat rejected rate"
                       :metric 0
+                      :tags ["riemann"]
                       :state "ok"
                       :time 5}
                      {:service "riemann executor cat queue capacity"
                       :metric 2
+                      :tags ["riemann"]
                       :state "ok"
                       :time 5}
                      {:service "riemann executor cat queue size"
                       :metric 0
+                      :tags ["riemann"]
                       :state "ok"
                       :time 5}
                      {:service "riemann executor cat queue used"
                       :metric 0
+                      :tags ["riemann"]
                       :state "ok"
                       :time 5}
                      {:service "riemann executor cat threads active"
                       :metric 0
+                      :tags ["riemann"]
                       :state "ok"
                       :time 5}
                      {:service "riemann executor cat threads alive"
                       :metric 1
+                      :tags ["riemann"]
                       :state "ok"
                       :time 5}]))
 


### PR DESCRIPTION
Actually, core instrumentation produces events (rate and latency) with the "riemann" tag, but transports and services instrumentation do not.
This PR adds the "riemann" tag to instrumented transports and services.