### PR TITLE
Fix some tests for time micro

### DIFF
--- a/test/riemann/core_test.clj
+++ b/test/riemann/core_test.clj
@@ -239,11 +239,10 @@
                           (query client)
                           deref
                           set)]
-               (is (= r
-                      #{(event {:metric 2, :time 3})
-                        (event {:host "kitten" :tags ["whiskers" "paws"] :time 2})
-                        (event {:host "cat", :service "miao", :time 3})})))
-
+               (is (= r (set (map #(update % :time double)
+                                  #{(event {:metric 2, :time 3})
+                                    (event {:host "kitten" :tags ["whiskers" "paws"] :time 2})
+                                    (event {:host "cat", :service "miao", :time 3})})))))
              (finally
                (close! client)
                (logging/suppress ["riemann.core"

--- a/test/riemann/transport_test.clj
+++ b/test/riemann/transport_test.clj
@@ -114,7 +114,7 @@
           event  (event {:service "hi" :state "ok" :metric 1.23})]
       (try
         (client/send-event client event)
-        (is (= event (deref sink 1000 :timed-out)))
+        (is (= (update event :time double) (deref sink 1000 :timed-out)))
         (finally
           (client/close! client)
           (stop! core))))))


### PR DESCRIPTION
I modified 2 tests in this PR :

- in core_test.clj : the (event) fn in riemann.common returns a new event but cast the :time field in long, example :

```clojure
(event {:time 1.1})
#riemann.codec.Event{:host nil, :service nil, :state nil, :description nil, :metric nil, :tags nil, :time 1, :ttl nil}
```

But now Riemann use double for the :time field. So the test fail. I modified it to cast the event :time field in double, and then transform the result into a set.

- transport_test.clj : same problem, (event) cast the event :time in long.

With this PR, all Riemann tests are passing. Maybe we should modify riemann.common/event in the future to not cast :time into long.
