### PR TITLE
add kafka as input option

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -18,7 +18,7 @@
                      [hipchat     :refer [hipchat]]
                      [index       :as index]
                      [influxdb    :refer [influxdb]]
-                     [kafka       :refer [kafka]]
+                     [kafka       :as kafka :refer [kafka]]
                      [kairosdb    :refer [kairosdb]]
                      [keenio      :refer [keenio]]
                      [librato     :refer [librato-metrics]]
@@ -173,6 +173,31 @@
   (sse-server {:port 5556})"
   [& opts]
   (service! (sse/sse-server (kwargs-or-map opts))))
+
+(defn kafka-consumer
+  "Add a new kafka consumer with opts to the default core.
+
+  (kafka-consumer {:consumer.config {:bootstrap.servers \"localhost:9092\"
+                                     :group.id \"riemann\"}
+                   :topics [\"riemann\"]})
+ 
+  Options:
+   
+  For a full list of :consumer.config options see the kafka consumer docs.
+  NOTE: The :enable.auto.commit option is ignored and defaults to true.
+
+  :consumer.config      Consumer configuration 
+    :bootstrap.servers  Bootstrap configuration, default is \"localhost:9092\"
+    :group.id           Consumer group id, default is \"riemann\"
+  :topics               Topics to consume from, default is [\"riemann\"]
+  :key.deserializer     Key deserializer function, defaults to the 
+                        keyword-deserializer.
+  :value.deserializer   Value deserializer function, defaults to 
+                        json-deserializer.
+  :poll.timeout.ms      Polling timeout, default is 100."
+
+  [& opts]
+  (service! (kafka/kafka-consumer (kwargs-or-map opts))))
 
 (defn streams
   "Add any number of streams to the default core."

--- a/src/riemann/kafka.clj
+++ b/src/riemann/kafka.clj
@@ -1,6 +1,11 @@
 (ns riemann.kafka
-  "Forwards events to Kafka."
-  (:require [kinsky.client :as client]))
+  "Receives events from and forwards events to Kafka."
+  (:require [kinsky.client :as client]
+            [cheshire.core :as json])
+  (:use [riemann.common        :only [event]]
+        [riemann.core          :only [stream!]]
+        [riemann.service       :only [Service ServiceEquiv]]
+        [clojure.tools.logging :only [info error]]))
 
 (defn kafka
   "Returns a function that is invoked with a topic name and an optional message key and returns a stream. That stream is a function which takes an event or a sequence of events and sends them to Kafka.
@@ -36,3 +41,73 @@
          (let [[topic message-key] args]
            (client/send!
              producer topic message-key event)))))))
+
+(defn json-deserializer
+  "Deserialize JSON. Let bad payload not break the consumption."
+  []
+  (client/deserializer
+    (fn [_ payload]
+      (when payload
+        (try
+          (json/parse-string (String. payload "UTF-8") true)
+        (catch Exception e
+          (error e "Could not decode message")))))))
+
+(defn start-kafka-thread
+  "Start a kafka thread which will pop messages off the queue as long
+  as running? is true"
+  [running? core opts]
+  (let [opts (merge {:consumer.config {:bootstrap.servers "localhost:9092"
+                                       :group.id "riemann"}
+                     :topics ["riemann"]
+                     :key.deserializer client/keyword-deserializer
+                     :value.deserializer json-deserializer
+                     :poll.timeout.ms 100}
+                    opts)
+        consumer (client/consumer (dissoc (:consumer.config opts) :enable.auto.commit)
+                                  (:key.deserializer opts)
+                                  (:value.deserializer opts))
+        topics (flatten (:topics opts))]
+    (future
+      (try
+        (info "Subscribing to " topics "...")
+        (client/subscribe! consumer topics)
+        (while running?
+          (let [msgs (client/poll! consumer (:poll.timeout.ms opts))
+                msgs-by-topic (get msgs :by-topic)]
+            (doseq [records msgs-by-topic
+                    record (last records)]
+              (let [event (event (get record :value))]
+                (stream! @core event)))))
+        (catch Exception e
+          (error e "Interrupted consumption"))
+        (finally 
+          (client/close! consumer))))))
+
+(defn kafka-consumer
+  "Yield a kafka consumption service"
+  [opts]
+  (let [running? (atom true)
+        core     (atom nil)]
+    (reify
+      clojure.lang.ILookup
+      (valAt [this k not-found]
+        (or (.valAt this k) not-found))
+      (valAt [this k]
+        (info "Looking up: " k)
+        (when (= (name k) "opts") opts))
+      ServiceEquiv
+      (equiv? [this other]
+        (= opts (:opts other)))
+      Service
+      (conflict? [this other]
+        (= opts (:opts other)))
+      (start! [this]
+        (info "Starting kafka consumer")
+        (start-kafka-thread running? core opts))
+      (reload! [this new-core]
+        (info "Reload called, setting new core value")
+        (reset! core new-core))
+      (stop! [this]
+        (reset! running? false)
+        (info "Stopping kafka consumer")))))


### PR DESCRIPTION
Addresses issue #767 

I ported a lot of code from https://github.com/pyr/riemann-kafka. As I'm not that familiar with the riemann internals, I'm not sure why the `clojure.lang.ILookup` implementation in the `kafka-consumer` function is needed (or maybe it's not anymore)? 

Tested with kafka 0.10.0.1