### PR TITLE
uses humane-test-output to pretty print test outputs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,8 @@
     [clj-campfire "2.2.0"]
     [clj-nsca "0.0.3"]
     [amazonica "0.3.28" :exclusions [joda-time]]
-    [spootnik/kinsky "0.1.16"]]
+    [spootnik/kinsky "0.1.16"]
+    [pjstadig/humane-test-output "0.8.1"]]
   :plugins [[lein-codox "0.10.2"]
             [lein-difftest "2.0.0"]
             [lein-rpm "0.0.5"

--- a/src/riemann/test.clj
+++ b/src/riemann/test.clj
@@ -189,7 +189,9 @@
            ~'(:require [riemann.test :refer [deftest inject! io tap run-stream lookup]]
                        [riemann.streams :refer :all]
                        [riemann.folds :as folds]
+                       [pjstadig.humane-test-output :as output]
                        [clojure.test :refer [is are]]))
+         (output/activate!)
          ~@body
          (ns ~old-ns))))
 


### PR DESCRIPTION
I just discovered [humane-test-output](https://github.com/pjstadig/humane-test-output).
Before using it :

```
FAIL in (foo-test) (riemann.config:25)
expected: (= (:foo result) [{:host "localhost", :service "foo1", :metric 10}])
  actual: (not (= [{:host "localhost", :service "foo", :metric 10}] [{:host "localhost", :service "foo1", :metric 10}]))
```

after :

```
FAIL in (foo-test) (riemann.config:25)
expected: [{:host "localhost", :service "foo", :metric 10}]
  actual: [{:host "localhost", :service "foo1", :metric 10}]
    diff: - [{:service "foo"}]
          + [{:service "foo1"}]
```

this PR fix #787.