### PR TITLE
Refactoring Elasticsearch output

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -41,7 +41,9 @@
                      [sns         :refer [sns-publisher]]
                      [stackdriver :refer [stackdriver]]
                      [prometheus  :refer [prometheus]]
-                     [elasticsearch :refer [elasticsearch]]
+                     [elasticsearch :refer [elasticsearch
+                                            default-bulk-formatter
+                                            elasticsearch-bulk]]
                      [streams     :refer :all]
                      [telegram    :refer [telegram]]
                      [test        :as test :refer [tap io tests]]

--- a/src/riemann/elasticsearch.clj
+++ b/src/riemann/elasticsearch.clj
@@ -22,16 +22,17 @@
 
 (defn- post
   "POST to Elasticsearch."
-  [credentials esindex formatted-event]
-  (let [base-http-options {:body (json/generate-string formatted-event)
-                           :content-type :json
-                           :conn-timeout 5000
-                           :socket-timeout 5000
-                           :throw-entire-message? true}
+  [credentials es-endpoint body http-options]
+  (let [base-http-options (merge {:body body
+                                  :content-type :json
+                                  :conn-timeout 5000
+                                  :socket-timeout 5000
+                                  :throw-entire-message? true}
+                                 http-options)
         http-options (if credentials
                        (assoc base-http-options :basic-auth credentials)
                        base-http-options)]
-    (http/post esindex http-options)))
+    (http/post es-endpoint http-options)))
 
 (defn elasticsearch
   "Returns a function which accepts an event and sends it to
@@ -59,20 +60,120 @@
         [newtags (concat (:tags event) [\"extra-tag\"])]
         (merge event {:tags newtags}))))"
   [opts & maybe-formatter]
-  (let
-    [opts (merge {:es-endpoint "http://127.0.0.1:9200"
-                  :es-index "riemann"
-                  :index-suffix "-yyyy.MM.dd"
-                  :type "event"}
-                 opts)
-     event-formatter (if (first maybe-formatter) (first maybe-formatter) format-event)]
+  (let [opts (merge {:es-endpoint "http://127.0.0.1:9200"
+                     :es-index "riemann"
+                     :index-suffix "-yyyy.MM.dd"
+                     :type "event"}
+                    opts)
+        event-formatter (if (first maybe-formatter) (first maybe-formatter) format-event)]
+    (fn [event]
+      (let [credentials (when (and (:username opts) (:password opts))
+                          [(:username opts) (:password opts)])
+            body (json/generate-string (event-formatter event))
+            es-endpoint (format "%s/%s%s/%s"
+                                (:es-endpoint opts)
+                                (:es-index opts)
+                                (time-format/unparse (time-format/formatter (:index-suffix opts)) (datetime-from-event event))
+                                (:type opts))
+            http-options {}]
+        (post
+         credentials
+         es-endpoint
+         body
+         http-options)))))
 
-    (fn[event] (post
-                 (if (and (:username opts) (:password opts))
-                   [(:username opts) (:password opts)])
-                 (format "%s/%s%s/%s"
-                         (:es-endpoint opts)
-                         (:es-index opts)
-                         (time-format/unparse (time-format/formatter (:index-suffix opts)) (datetime-from-event event))
-                         (:type opts))
-                 (event-formatter event)))))
+(defn gen-request-bulk-body-reduce
+  "Reduction fn used in `gen-request-bulk-body` to generate the body request"
+  [result elem]
+  (str
+   result
+   ;;action and metadata
+   (json/generate-string {(:es-action elem) (:es-metadata elem)}) "\n"
+   ;; source (optional)
+   (when (:es-source elem)
+     (str (json/generate-string (:es-source elem)) "\n"))))
+
+(defn gen-request-bulk-body
+  "Takes a list of events, generates the body request for Elasticsearch"
+  [events]
+  (reduce gen-request-bulk-body-reduce "" events))
+
+(defn default-bulk-formatter
+  "Returns a function which accepts an event and formats it for the Elasticsearch bulk API.
+
+  Options :
+  :es-index        Elasticsearch index name (without suffix).
+  :type            Type to send to index.
+  :es-action       Elasticsearch action, for example \"index\".
+  :index-suffix    Index suffix, for example \"-yyyy.MM.dd\".
+
+  Each event received by the function can also have these keys (which override default options), and an optional `es-id` key."
+  [{:keys [es-index type es-action index-suffix]}]
+  (fn [event]
+    (let [special-keys [:es-index :type :es-action :es-id :index-suffix :time]
+          es-index  (:es-index event es-index)
+          es-type   (:type event type)
+          es-action (:es-action event es-action)
+          es-id     (:es-id event)
+          index-suffix (:index-suffix event index-suffix)
+          timestamp (time-format/unparse
+                     (time-format/formatters :date-time)
+                     (datetime-from-event event))
+          source (-> (apply dissoc event special-keys)
+                     (assoc (keyword "@timestamp") timestamp))
+          metadata (let [m {:_index (str es-index
+                                         (time-format/unparse
+                                          (time-format/formatter index-suffix)
+                                          (datetime-from-event event)))
+                            :_type es-type}]
+                     (if es-id
+                       (assoc m :_id es-id)
+                       m))]
+      {:es-action es-action
+       :es-metadata metadata
+       :es-source source})))
+
+(defn elasticsearch-bulk
+  "Returns a function which accepts an event (or a list of events) and sends it to
+  Elasticsearch using the Bulk API. Custom event formatter can be provided using the `:formatter` key.
+  A formatter is a function which accepts an event.
+  Event time is mandatory.
+
+  Events should have this format :
+
+  {:es-action \"index\"
+   :es-metadata {:_index \"test\"
+                 :_type \"type1\"
+                 :_id \"1\"}
+   :es-source {:field1 \"value1\"}}
+
+  `:es-action` is the action (create, update, index, delete), `:es-metadata` the document metadata, and `es-source` the document source.
+
+  More informations about the Elasticsearch bulk API: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+
+  If a formatter is specified, events will be formatted using it. You can then send events not respecting the previous format if the specified formatter converts them to it.
+
+  Options:
+
+  :es-endpoint     Elasticsearch, default is \"http://127.0.0.1:9200\".
+  :username        Username to authenticate with.
+  :password        Password to authenticate with.
+  :formatter       Fn taking an event and returning it with the ES Bulk API format
+  :http-options    Http options (like proxy). See https://github.com/dakrone/clj-http for option list"
+  [opts]
+  (let [opts (merge {:es-endpoint "http://127.0.0.1:9200"} opts)]
+    (fn [events]
+      (let [events (let [e (if (sequential? events) events (list events))]
+                     (if (:formatter opts)
+                       (map (:formatter opts) e)
+                       e))
+            credentials (when (and (:username opts) (:password opts))
+                          [(:username opts) (:password opts)])
+            body (gen-request-bulk-body events)
+            http-options (merge {:content-type "application/x-ndjson"}
+                                (:http-options opts {}))]
+        (post
+         credentials
+         (str (:es-endpoint opts) "/_bulk")
+         body
+         http-options)))))

--- a/test/riemann/elasticsearch_test.clj
+++ b/test/riemann/elasticsearch_test.clj
@@ -110,3 +110,238 @@
                  :conn-timeout 5000
                  :socket-timeout 5000
                  :throw-entire-message? true}]))))))
+
+(deftest ^:elasticsearch gen-request-bulk-body-reduce-test
+  (is (= "{\"index\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"1\"}}\n{\"field1\":\"value1\"}\n"
+         (gen-request-bulk-body-reduce "" {:es-action "index"
+                              :es-metadata {:_index "test"
+                                            :_type "type1"
+                                            :_id "1"}
+                              :es-source {:field1 "value1"}})))
+  (is (= "{\"delete\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"2\"}}\n"
+         (gen-request-bulk-body-reduce "" {:es-action "delete"
+                              :es-metadata {:_index "test"
+                                            :_type "type1"
+                                            :_id "2"}}))))
+
+(deftest ^:elasticsearch gen-request-bulk-body-test
+  (is (= "{\"index\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"1\"}}\n{\"field1\":\"value1\"}\n"
+         (gen-request-bulk-body [{:es-action "index"
+                          :es-metadata {:_index "test"
+                                        :_type "type1"
+                                        :_id "1"}
+                          :es-source {:field1 "value1"}}])))
+  (is (= "{\"index\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"1\"}}\n{\"field1\":\"value1\"}\n{\"delete\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"2\"}}\n"
+         (gen-request-bulk-body [{:es-action "index"
+                          :es-metadata {:_index "test"
+                                        :_type "type1"
+                                        :_id "1"}
+                          :es-source {:field1 "value1"}}
+                         {:es-action "delete"
+                          :es-metadata {:_index "test"
+                                        :_type "type1"
+                                        :_id "2"}}])))
+    (is (= "{\"index\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"1\"}}\n{\"field1\":\"value1\"}\n{\"delete\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"2\"}}\n{\"index\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"1\"}}\n{\"field1\":\"value1\"}\n"
+         (gen-request-bulk-body [{:es-action "index"
+                          :es-metadata {:_index "test"
+                                        :_type "type1"
+                                        :_id "1"}
+                          :es-source {:field1 "value1"}}
+                         {:es-action "delete"
+                          :es-metadata {:_index "test"
+                                        :_type "type1"
+                                        :_id "2"}}
+                         {:es-action "index"
+                          :es-metadata {:_index "test"
+                                        :_type "type1"
+                                        :_id "1"}
+                          :es-source {:field1 "value1"}}]))))
+
+(deftest ^:elasticsearch elasticsearch-bulk-test
+  (with-mock [calls clj-http.client/post]
+    (testing "without auth"
+      (let [elastic (elasticsearch-bulk {})]
+        (elastic {:es-action "index"
+                  :es-metadata {:_index "test"
+                                :_type "type1"
+                                :_id "1"}
+                  :es-source {:field1 "value1"}})
+        (is (= (last @calls)
+               ["http://127.0.0.1:9200/_bulk"
+                {:body "{\"index\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"1\"}}\n{\"field1\":\"value1\"}\n"
+                 :content-type "application/x-ndjson"
+                 :conn-timeout 5000
+                 :socket-timeout 5000
+                 :throw-entire-message? true}]))
+        (elastic [{:es-action "index"
+                   :es-metadata {:_index "test"
+                                 :_type "type1"
+                                 :_id "1"}
+                   :es-source {:field1 "value1"}}
+                  {:es-action "delete"
+                   :es-metadata {:_index "test"
+                                 :_type "type1"
+                                 :_id "2"}}
+                  {:es-action "index"
+                   :es-metadata {:_index "test"
+                                 :_type "type1"
+                                 :_id "1"}
+                   :es-source {:field1 "value1"}}])
+        (is (= (last @calls)
+               ["http://127.0.0.1:9200/_bulk"
+                {:body "{\"index\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"1\"}}\n{\"field1\":\"value1\"}\n{\"delete\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"2\"}}\n{\"index\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"1\"}}\n{\"field1\":\"value1\"}\n"
+                 :content-type "application/x-ndjson"
+                 :conn-timeout 5000
+                 :socket-timeout 5000
+                 :throw-entire-message? true}]))))
+    (testing "with auth"
+      (let [elastic (elasticsearch-bulk {:username "elastic"
+                                         :password "changeme"})]
+        (elastic {:es-action "index"
+                  :es-metadata {:_index "test"
+                                :_type "type1"
+                                :_id "1"}
+                  :es-source {:field1 "value1"}})
+        (is (= (last @calls)
+               ["http://127.0.0.1:9200/_bulk"
+                {:body "{\"index\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"1\"}}\n{\"field1\":\"value1\"}\n"
+                 :content-type "application/x-ndjson"
+                 :conn-timeout 5000
+                 :socket-timeout 5000
+                 :basic-auth ["elastic" "changeme"]
+                 :throw-entire-message? true}]))))
+    (testing "with formatter"
+      (let [formatter (default-bulk-formatter {:es-index "riemann"
+                                               :type "foo"
+                                               :es-action "index"
+                                               :index-suffix "-yyyy.MM.dd"})
+            elastic (elasticsearch-bulk {:username "elastic"
+                                         :password "changeme"
+                                         :formatter formatter
+                                         :http-options {:conn-timeout 1000}
+                                         :es-endpoint "http://127.0.0.1:9300"})]
+        (elastic {:host "foo"
+                  :metric 10
+                  :time 1491567382
+                  :tags ["t1"]
+                  :es-id "3"
+                  :ttl 30})
+        (is (= (last @calls)
+               ["http://127.0.0.1:9300/_bulk"
+                {:body "{\"index\":{\"_index\":\"riemann-2017.04.07\",\"_type\":\"foo\",\"_id\":\"3\"}}\n{\"host\":\"foo\",\"metric\":10,\"tags\":[\"t1\"],\"ttl\":30,\"@timestamp\":\"2017-04-07T12:16:22.000Z\"}\n"
+                 :content-type "application/x-ndjson"
+                 :conn-timeout 1000
+                 :socket-timeout 5000
+                 :basic-auth ["elastic" "changeme"]
+                 :throw-entire-message? true}]))))))
+
+(deftest ^:elasticsearch default-bulk-formatter-test
+  (let [formatter (default-bulk-formatter {:es-index "riemann"
+                                           :type "foo"
+                                           :es-action "index"
+                                           :index-suffix "-yyyy.MM.dd"})]
+    (is (= (formatter {:host "foo"
+                       :metric 10
+                       :service "bar"
+                       :tags ["t1"]
+                       :ttl 30
+                       :time 1491567382
+                       :foo "bar"})
+           {:es-action "index"
+            :es-metadata {:_index "riemann-2017.04.07"
+                          :_type "foo"}
+            :es-source {:host "foo"
+                        :metric 10
+                        :service "bar"
+                        :tags ["t1"]
+                        :ttl 30
+                        :foo "bar"
+                        (keyword "@timestamp") "2017-04-07T12:16:22.000Z"
+                        }}))
+    (is (= (formatter {:host "foo"
+                       :metric 10
+                       :service "bar"
+                       :tags ["t1"]
+                       :ttl 30
+                       :es-id "10"
+                       :es-index "test"
+                       :type "bar"
+                       :es-action "create"
+                       :index-suffix "-yyyy.MM"
+                       :time 1491567382
+                       :foo "bar"})
+           {:es-action "create"
+            :es-metadata {:_index "test-2017.04"
+                          :_type "bar"
+                          :_id "10"}
+            :es-source {:host "foo"
+                        :metric 10
+                        :service "bar"
+                        :tags ["t1"]
+                        :ttl 30
+                        :foo "bar"
+                        (keyword "@timestamp") "2017-04-07T12:16:22.000Z"
+                        }}))))
+
+(deftest ^:integration ^:elasticsearch elasticsearch-bulk-integration-test
+  (testing "Without formatter"
+    (let [elastic (elasticsearch-bulk {:username "elastic"
+                                       :password "changeme"})]
+      (elastic {:es-action "index"
+                :es-metadata {:_index "test"
+                              :_type "type1"
+                              :_id "1"}
+                :es-source {:field1 "value1"}})
+      (elastic {:es-action "index"
+                :es-metadata {:_index "test"
+                              :_type "type1"
+                              :_id "2"}
+                :es-source {:field1 "value2"}})
+      (elastic {:es-action "index"
+                :es-metadata {:_index "test"
+                              :_type "type2"}
+                :es-source {:field1 "value3"}})
+      (elastic {:es-action "update"
+                :es-metadata {:_index "test"
+                              :_type "type1"
+                              :_id "1"}
+                :es-source {:doc {:field1 "new_value"}}})
+      (elastic {:es-action "create"
+                :es-metadata {:_index "test"
+                              :_type "type1"
+                              :_id "5"}
+                :es-source {:field4 "value4"}})
+      (elastic {:es-action "create"
+                :es-metadata {:_index "test"
+                              :_type "type2"
+                              :_id "6"}
+                :es-source {:field4 "value4"}})
+      (elastic {:es-action "delete"
+                :es-metadata {:_index "test"
+                              :_type "type1"
+                              :_id "1"}})))
+  (testing "Using default formatter"
+    (let [formatter (default-bulk-formatter {:es-index "riemann"
+                                             :type "foo"
+                                             :es-action "index"
+                                             :index-suffix "-yyyy.MM.dd"})
+          elastic (elasticsearch-bulk {:username "elastic"
+                                       :password "changeme"
+                                       :formatter formatter})]
+      (elastic {:host "fooformatter"
+                :metric 10
+                :service "bar"
+                :tags ["t1"]
+                :ttl 30
+                :time 1491567382
+                :foo "bar"}))))
+
+(deftest ^:integration ^:elasticsearch elasticsearch-integration-test
+  (let [elastic (elasticsearch {:username "elastic"
+                                :password "changeme"})]
+    (elastic {:host "foo"
+              :service "bar"
+              :metric "100"
+              :time (riemann.time/unix-time)
+              :state "critical"
+              :tags ["t1" "t2"]})))


### PR DESCRIPTION
Fixes #791

The current Elasticsearch output does not change.

I added a new steam `elasticsearch-bulk` to support Elasticsearch bulk API.

Stream options are:

```
:es-endpoint     Elasticsearch, default is \"http://127.0.0.1:9200\".
:username        Username to authenticate with.
:password        Password to authenticate with.
:formatter       Fn taking an event and returning it with the ES Bulk API format
:http-options    Http options (like proxy). See https://github.com/dakrone/clj-http for option list
```
The stream must receive events with this format:

```clojure
  {:es-action "index"
   :es-metadata {:_index "test"
                 :_type "type1"
                 :_id "1"}
   :es-source {:field1 "value1"}}
```
(note : It's exactly the format expected by ES bulk API, except for the `es-action` key : https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html)

Or you can use the :formatter parameter to pass a function that will convert events from the Riemann format to the Elasticsearch format.

I have added a generic formatter (`default-bulk-formatter`), which should be sufficient for most use cases:

```
(defn default-bulk-formatter
  "Returns a function which accepts an event and format it for the Elasticsearch bulk API.

  Options :
  :es-index        Elasticsearch index name (without suffix).
  :type            Type to send to index.
  :es-action       Elasticsearch action, for example \"index\".
  :index-suffix    Index-suffix, for example \"-yyyy.MM.dd\".

  Each event received by the function can also have these keys (which override default options), and a optional `es-id` key."
```

For example:

```clojure
    (let [formatter (default-bulk-formatter {:es-index "riemann"
                                             :type "foo"
                                             :es-action "index"
                                             :index-suffix "-yyyy.MM.dd"})
          elastic (elasticsearch-bulk {:username "elastic"
                                       :password "changeme"
                                       :formatter formatter})]
      (elastic {:host "fooformatter"
                :metric 10
                :service "bar"
                :tags ["t1"]
                :ttl 30
                :time 1491567382
                :foo "bar"}))
```
You will have in Elasticsearch:

```json
{
  "_index": "riemann-2017.04.07",
  "_type": "foo",
  "_id": "AVtIjyj5EApgwWFtAOGj",
  "_score": 1,
  "_source": {
    "host": "fooformatter",
    "metric": 10,
    "service": "bar",
    "tags": [
      "t1"
    ],
    "ttl": 30,
    "foo": "bar",
    "@timestamp": "2017-04-07T12:16:22.000Z"
  },
  "fields": {
    "@timestamp": [
      1491567382000
    ]
  }
}
```

With this stream and this formatter, you can specify per event id, index, type, action (create, update...). It's also easy to write your own formatter if you need it.

I tested this PR using Elsaticsearch 5.3 and 2.4.

I want @boernd and @faxm0dem reviews on this PR before merging (and i also want to make more tests).