### PR TITLE
Extend pushover functionality

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -95,6 +95,7 @@
                    :elasticsearch :elasticsearch
                    :netuitive :netuitive
                    :kafka :kafka
+                   :pushover :pushover
                    :all (fn [_] true)}
 ;;  :javac-options     ["-target" "1.6" "-source" "1.6"]
   :java-source-paths ["src/riemann/"]

--- a/test/riemann/pushover_test.clj
+++ b/test/riemann/pushover_test.clj
@@ -8,18 +8,39 @@
 
 (logging/init)
 
+(defn- my-custom-formatter [event]
+  {:title (str (:state event) " - " (:service event) "@" (:projectid event))
+   :message (str "<b>"(:targetid event) "</b>\n" (:description event))})
+
 (deftest ^:pushover pushover-test
   (with-mock [calls clj-http.client/post]
     (let [pshvr (pushover "token" "user")
+          pshvr-custom (pushover "token" "user" {:formatter my-custom-formatter
+                                                 :html 1})
           time (unix-time)]
 
-      (testing "an event without metric")
-      (pshvr {:host "testhost"
-              :service "testservice"
-              :state "ok"})
-      (is (= (last @calls)
-             ["https://api.pushover.net/1/messages.json"
-              {:form-params {:token "token"
-                             :user "user"
-                             :title "testhost testservice"
-                             :message "testhost testservice is ok ()"}}])))))
+      (testing "an event without metric"
+        (pshvr {:host "testhost"
+                :service "testservice"
+                :state "ok"})
+        (is (= (last @calls)
+               ["https://api.pushover.net/1/messages.json"
+                {:form-params {:token "token"
+                               :user "user"
+                               :title "testhost testservice"
+                               :message "testhost testservice is ok ()"}}])))
+
+      (testing "an event with opts"
+        (pshvr-custom {:host "testhost"
+                       :service "testservice"
+                       :state "critical"
+                       :projectid "myproject"
+                       :targetid "prod"
+                       :description "request rate is critical"})
+        (is (= (last @calls)
+               ["https://api.pushover.net/1/messages.json"
+                {:form-params {:token "token"
+                               :user "user"
+                               :title "critical - testservice@myproject"
+                               :message "<b>prod</b>\nrequest rate is critical"
+                               :html 1}}]))))))


### PR DESCRIPTION
Support
- custom event formatter
- pushover parameters

I did not want to break compatibility so I left the `token` and `user` parameters untouched.