### PR TITLE
bump clj-http to 3.5.0 - http-integrations over a sniproxy \o/

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
     ; for pomegranate
     [org.codehaus.plexus/plexus-utils "3.0"]
     [http-kit "2.1.19"]
-    [clj-http "2.0.1"]
+    [clj-http "3.5.0"]
     [cheshire "5.5.0"]
     [clj-librato "0.0.5"]
     [clj-time "0.10.0"]


### PR DESCRIPTION
SNI, clj-http and httpclient:

- https://github.com/dakrone/clj-http/issues/202
- https://issues.apache.org/jira/browse/HTTPCLIENT-1119