### PR TITLE
Mock the Riemann index in test mode

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -206,7 +206,7 @@
     (swap! next-core assoc :streams
            (reduce conj (:streams @next-core) things))))
 
-(defn index
+(defn set-index
   "Set the index used by this core. Returns the index."
   [& opts]
   (locking core
@@ -223,6 +223,13 @@
                    index')]
       (swap! next-core assoc :index index')
       index')))
+
+(defmacro index
+  "Set the index used by this core. Returns the index."
+  [& opts]
+  (if test/*testing*
+    `(test/index-stream)
+    `(apply set-index ~opts)))
 
 (defn update-index
   "Updates the given index with all events received. Also publishes to the

--- a/test/riemann/test_test.clj
+++ b/test/riemann/test_test.clj
@@ -1,8 +1,20 @@
 (ns riemann.test-test
   "Who tests the testers?"
-  (:require [riemann.test :refer [tap io with-test-env inject!]]
+  (:require [riemann.test :refer [tap
+                                  io
+                                  with-test-env
+                                  inject!
+                                  query-index
+                                  clear-index
+                                  lookup-index
+                                  expire-index]]
+            [riemann.time.controlled :refer [control-time!
+                                             reset-time!]]
             [clojure.test :refer :all]
             [riemann.streams :refer :all]))
+
+(use-fixtures :once control-time!)
+(use-fixtures :each reset-time!)
 
 (defmacro bound
   "Invokes body in a bound fn. Tests may run without a binding context, which
@@ -49,3 +61,124 @@
                  s (sdo (io (partial deliver downstream)))]
              (inject! [s] [{:time 2 :metric 0}])
              (is (nil? (deref downstream 0 nil)))))))))
+
+(deftest clear-index-test
+  (with-test-env
+    (bound
+      (eval
+        '(do
+           (ns riemann.test-test)
+           (let [s (riemann.config/index)]
+             (inject! [s]
+                      [{:host "foo" :service "a" :time 0 :metric 0 :ttl 60}
+                       {:host "foo" :service "b" :time 1 :metric 1 :ttl 60}
+                       {:host "foo" :service "c" :time 2 :metric 2 :ttl 60}])
+             (is (= (count (query-index "true")) 3))
+             (clear-index)
+             (is (= (count (query-index "true")) 0))))))))
+
+(deftest query-index-test
+  (with-test-env
+    (bound
+      (eval
+        '(do
+           (ns riemann.test-test)
+           (let [s (riemann.config/index)]
+             (inject! [s]
+                      [{:host "foo" :service "a" :time 0 :metric 0 :ttl 60}
+                       {:host "foo" :service "b" :time 1 :metric 1 :ttl 60}
+                       {:host "foo" :service "c" :time 2 :metric 2 :ttl 60}])
+             (is (= (query-index "true")
+                    [{:host "foo" :service "a" :time 0 :metric 0 :ttl 60}
+                     {:host "foo" :service "b" :time 1 :metric 1 :ttl 60}
+                     {:host "foo" :service "c" :time 2 :metric 2 :ttl 60}]))
+             (is (= (query-index "service = \"a\"")
+                    [{:host "foo" :service "a" :time 0 :metric 0 :ttl 60}]))
+             (clear-index)
+             (inject! [s]
+                      [{:host "z" :service "b" :time 1 :metric 0 :ttl 60}
+                       {:host "b" :service "a" :time 2 :metric 1 :ttl 60}
+                       {:host "z" :service "b" :time 3 :metric 1 :ttl 60}
+                       {:host "z" :service "a" :time 5 :metric 1 :ttl 60}
+                       {:host "b" :service "b" :time 2 :metric 1 :ttl 60}
+                       {:host "b" :service "b" :time 3 :metric 1 :ttl 60}])
+             (is (= (query-index "true")
+                    [{:host "b" :service "a" :time 2 :metric 1 :ttl 60}
+                     {:host "b" :service "b" :time 3 :metric 1 :ttl 60}
+                     {:host "z" :service "a" :time 5 :metric 1 :ttl 60}
+                     {:host "z" :service "b" :time 3 :metric 1 :ttl 60}]))))))))
+
+(deftest lookup-index-test
+  (with-test-env
+    (bound
+      (eval
+        '(do
+           (ns riemann.test-test)
+           (let [s (riemann.config/index)]
+             (inject! [s]
+                      [{:host "foo" :service "a" :time 0 :metric 0 :ttl 60}
+                       {:host "foo" :service "b" :time 1 :metric 1 :ttl 60}
+                       {:host "foo" :service "c" :time 2 :metric 2 :ttl 60}])
+             (is (= (count (query-index "true")) 3))
+             (is (= (lookup-index "foo" "a")
+                    {:host "foo" :service "a" :time 0 :metric 0 :ttl 60}))
+             (is (= (lookup-index "foo" "b")
+                    {:host "foo" :service "b" :time 1 :metric 1 :ttl 60}))
+             (is (= (lookup-index "foo" "c")
+                    {:host "foo" :service "c" :time 2 :metric 2 :ttl 60}))))))))
+
+(deftest expire-index-test
+  (with-test-env
+    (bound
+      (eval
+        '(do
+           (ns riemann.test-test)
+           (let [s (riemann.config/index)]
+             (inject! [s]
+                      [{:host "foo" :service "a" :time 0 :metric 0 :ttl 60}
+                       {:host "foo" :service "b" :time 0 :metric 1 :ttl 60}
+                       {:host "foo" :service "c" :time 0 :metric 2 :ttl 60}
+                       {:host "foo" :service "d" :time 61 :metric 3 :ttl 60}])
+             (is (= (count (query-index "true")) 4))
+             (is (= (expire-index)
+                    [{:host "foo" :service "a" :time 61 :state "expired"}
+                     {:host "foo" :service "b" :time 61 :state "expired"}
+                     {:host "foo" :service "c" :time 61 :state "expired"}]))
+             (is (= (count (query-index "true")) 1))
+             (is (= (lookup-index "foo" "d")
+                    {:host "foo" :service "d" :time 61 :metric 3 :ttl 60}))
+             (inject! [s]
+                      [{:host "foo" :service "a" :time 60 :metric 0 :ttl 60}
+                       {:host "foo" :service "b" :time 60 :metric 1 :ttl 60}
+                       {:host "foo" :service "c" :time 60 :metric 2 :ttl 60}
+                       {:host "foo" :service "d" :time 121 :metric 3 :ttl 60}])
+             (is (= (count (query-index "true")) 4))
+             (is (= (expire-index {:keep-keys [:host :service :metric]})
+                    [{:host "foo" :service "a" :metric 0 :time 121 :state "expired"}
+                     {:host "foo" :service "b" :metric 1 :time 121 :state "expired"}
+                     {:host "foo" :service "c" :metric 2 :time 121 :state "expired"}]))))))))
+
+(deftest index-captures-events
+  (with-test-env
+    (bound
+      (eval
+        '(do
+           (ns riemann.test-test)
+           (let [s (riemann.config/index)]
+             (inject! [s]
+                      [{:host "foo" :service "a" :time 0 :metric 0 :ttl 60}
+                       {:host "foo" :service "b" :time 1 :metric 1 :ttl 60}
+                       {:host "foo" :service "c" :time 2 :metric 2 :ttl 60}])
+             (is (= (query-index "true")
+                    [{:host "foo" :service "a" :time 0 :metric 0 :ttl 60}
+                     {:host "foo" :service "b" :time 1 :metric 1 :ttl 60}
+                     {:host "foo" :service "c" :time 2 :metric 2 :ttl 60}]))
+             (inject! [s]
+                      [{:host "foo" :service "a" :time 5 :metric 4 :ttl 60}
+                       {:host "foo" :service "d" :time 1 :metric 1 :ttl 60}])
+             (is (= (query-index "true")
+                    [{:host "foo" :service "a" :time 5 :metric 4 :ttl 60}
+                     {:host "foo" :service "b" :time 1 :metric 1 :ttl 60}
+                     {:host "foo" :service "c" :time 2 :metric 2 :ttl 60}
+                     {:host "foo" :service "d" :time 1 :metric 1 :ttl 60}]))))))))
+


### PR DESCRIPTION
This PR adds the ability to mock the Rieman index in test mode. I saw this feature requested several times on irc/mailing list/issues.

## How

I defined a `^:dynamic *index*` variable in riemann.test. This variable will contains an index in test mode (set by `with-test-env`). The index will be cleared between each `deftest` (you can see it in the `deftest` macro in riemann.test).

I modified `riemann.config/index` (replaced it by a macro). It test mode, it will returns a stream (`riemann.test/index-stream`) which will record events in the test index. Events without time are not indexed (but it will not cause exceptions).

I also added several utility functions in riemann.test :

- lookup-index: "Return an indexed event from the test index"
- clear-index: "Clear the test index."
- query-index: "Return a vec of events, sorted by `:host` and `:service`, from the test index matching the query."
- expire-index: "Return a vec of expired events, sorted by `:host` and `:service`, from the test index, removing each."

You can use this functions in your tests (i will show some examples later). `query-index` and `expire-index` returns sorted vector, so their results can be easily compared with expected results in tests.

I also added `(reset! riemann.config/core {:index *index*})` in `with-test-env`. Streams querying the index (like [the maintenance mode stream](http://riemann.io/howto.html#query-the-index-from-within-a-stream)) should now be testable (it was not the case because there is no core in test mode).

## Commented examples

Test indexed events :

```
(streams
 ;; index all events with hosts = foo
 (where (host "foo")
  (index)))

(tests
 (deftest foo
   (inject! [{:host "foo" :service "a" :metric 0 :time 0 :ttl 30}
             {:host "foo" :service "b" :metric 0 :time 0 :ttl 30}
             {:host "bar" :service "c" :metric 0 :time 0 :ttl 30}
             {:host "foo" :service "c" :metric 0 :time 0 :ttl 30}])
   (is (= (query-index "true")
          ;; use query-index to query the index
          [{:host "foo" :service "a" :metric 0 :time 0 :ttl 30}
           {:host "foo" :service "b" :metric 0 :time 0 :ttl 30}
           {:host "foo" :service "c" :metric 0 :time 0 :ttl 30}]))

   (is (= (lookup-index "foo" "a")
          ;; use lookup-index to retrieve an event by host/service
          {:host "foo" :service "a" :metric 0 :time 0 :ttl 30}))
   ;; advance time to expire events
   (riemann.time.controlled/advance! 31)
   ;; test for expired events
   (is (= (expire-index)
          ;; events are expired
          [{:host "foo" :service "a" :time 31 :state "expired"}
           {:host "foo" :service "b" :time 31 :state "expired"}
           {:host "foo" :service "c" :time 31 :state "expired"}]))
   ;; the index is empty, all events are expired
   (is (= (query-index "true") []))

   ;; inject some new events
   (inject! [{:host "foo" :service "a" :metric 0 :time 30 :ttl 30}
             {:host "foo" :service "b" :metric 0 :time 30 :ttl 30}
             {:host "foo" :service "c" :metric 0 :time 30 :ttl 30}])
   (is (= (query-index "host = \"foo\"")
          ;; query the index for host = foo
          [{:host "foo" :service "a" :metric 0 :time 30 :ttl 30}
           {:host "foo" :service "b" :metric 0 :time 30 :ttl 30}
           {:host "foo" :service "c" :metric 0 :time 30 :ttl 30}]))
   ;; advance time to expire events
   (riemann.time.controlled/advance! 61)

   (is (= (expire-index {:keep-keys [:host :service :metric]})
          ;; use the :keey-keys option like in periodically-expire
          [{:host "foo" :service "a" :metric 0 :time 61 :state "expired"}
           {:host "foo" :service "b" :metric 0 :time 61 :state "expired"}
           {:host "foo" :service "c" :metric 0 :time 61 :state "expired"}]))))
```

Test [the maintenance mode stream](http://riemann.io/howto.html#query-the-index-from-within-a-stream).

```clojure
(defn maintenance-mode?
  "Is Riemann currently in maintenance mode?"
  []
  ; Take an expression representing a query for maintenance mode
  (->> '(and (= :host nil)
             (= :service "maintenance-mode"))
       ; Search the current Riemann core's index for any matching events
       (riemann.index/search (:index @core))
       ; Take the first match
       first
       ; Find its state
       :state
       ; Is it the string "active"?
       (= "active")))

(streams
 (where (host "maintenance")
   ;; index a maintenance event
   (with {:host nil
          :service "maintenance-mode"}
     (index)))
 (where (and (not (host "maintenance"))
             (not (maintenance-mode?)))
   ;; index all events excepts maintenance events
   (tap :maintenance-mode)))

(tests
 (deftest maintenance-test
   (let [result (inject! [{:host "foo" :service "a" :time 0}
                          {:host "bar" :service "a" :time 1}
                          ;; enable maintenance
                          {:host "maintenance" :state "active" :time 2}
                          ;; these events will not be present in the tap
                          {:host "bar" :service "b" :time 3}
                          {:host "bar" :service "c" :time 4}
                          ;; disable maintenance
                          {:host "maintenance" :state "not active" :time 5}
                          {:host "bar" :service "d" :time 6}])]
     (is (= (:maintenance-mode result)
            [{:host "foo" :service "a" :time 0}
             {:host "bar" :service "a" :time 1}
             {:host "bar" :service "d" :time 6}])))))
```

I think it's important that someone give this PR a second look before merging. 
