### PR TITLE
Add sflatten stream

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -182,6 +182,13 @@
     (doseq [e (f event)]
       (call-rescue e children))))
 
+(defn sflatten
+  "Streaming flatten. Calls children with each event in events. Events should be a sequence."
+  [& children]
+  (fn stream [events]
+    (doseq [e events]
+      (call-rescue e children))))
+
 (defn sreduce
   "Streaming reduce. Two forms:
 

--- a/test/riemann/streams_test.clj
+++ b/test/riemann/streams_test.clj
@@ -48,6 +48,10 @@
     (test-stream (smapcat #(vector % %)) [0 1 2 3]
                  [0 0 1 1 2 2 3 3])))
 
+(deftest sflatten-test
+  (test-stream (sflatten) [[0 1 2 3] [4 5 6 7]]
+               [0 1 2 3 4 5 6 7]))
+
 (deftest sdo-test
   (let [vals1   (atom [])
         vals2   (atom [])


### PR DESCRIPTION
When i started using Riemann, i quickly needed a stream to convert seq of events to individual events. This is what this stream does, and i think it can be useful to others. Example :

```clojure
(streams
  (fixed-time-window 10
    (sflatten
      #(info %))))
```