### PR TITLE
Netuitive Payload Size Reduction

### DIFF
--- a/src/riemann/netuitive.clj
+++ b/src/riemann/netuitive.clj
@@ -77,5 +77,6 @@
     (fn [event]
       (let [events (if (sequential? event) event [event])
             post-data (mapv #(generate-event % opts) events)
-            json-data (generate-string post-data)]
+            reduced-data (map (apply partial reduce combine-elements []) (partition-by :id (sort-by :id post-data)))
+            json-data (generate-string reduced-data)]
         (post-datapoint (:api-key opts) (:url opts gateway-url) json-data)))))

--- a/src/riemann/netuitive.clj
+++ b/src/riemann/netuitive.clj
@@ -34,11 +34,11 @@
    "Combine two elements"
    [element1 element2]
    {:id (:id element1)
-     :name (:name element1)
-     :type (:type element1)
-     :metrics (map (partial apply merge) (partition-by :id (sort-by :id (concat (:metrics element1) (:metrics element2)))))
-     :samples (concat (:samples element1) (:samples element2))
-     :tags (map (partial apply merge) (partition-by :name (sort-by :name (concat (:tags element1) (:tags element2)))))})
+    :name (:name element1)
+    :type (:type element1)
+    :metrics (map (partial apply merge) (partition-by :id (sort-by :id (concat (:metrics element1) (:metrics element2)))))
+    :samples (concat (:samples element1) (:samples element2))
+    :tags (map (partial apply merge) (partition-by :name (sort-by :name (concat (:tags element1) (:tags element2)))))})
 
 (defn generate-event
    "Structure for ingest to Netuitive as JSON"

--- a/src/riemann/netuitive.clj
+++ b/src/riemann/netuitive.clj
@@ -72,9 +72,10 @@
   [opts]
   (let [opts (merge {:api-key "netuitive-api-key"} opts)]
     (fn [event]
-      (let [events (if (sequential? event) event [event])
-            non-null (filter #(not (nil? (:metric %))) events)
-            post-data (mapv #(generate-event % opts) non-null)
-            reduced-data (map (apply partial reduce combine-elements []) (partition-by :id (sort-by :id post-data)))
-            json-data (generate-string reduced-data)]
+      (let [json-data (->> (if (sequential? event) event [event])
+                           (filter :metric)
+                           (map #(generate-event % opts))
+                           (partition-by :id)
+                           (map #(reduce combine-elements %))
+                           (generate-string))]
         (post-datapoint (:api-key opts) (:url opts gateway-url) json-data)))))

--- a/src/riemann/netuitive.clj
+++ b/src/riemann/netuitive.clj
@@ -33,12 +33,9 @@
 (defn combine-elements
    "Combine two elements"
    [element1 element2]
-   {:id (:id element1)
-    :name (:name element1)
-    :type (:type element1)
-    :metrics (map (partial apply merge) (partition-by :id (sort-by :id (concat (:metrics element1) (:metrics element2)))))
-    :samples (concat (:samples element1) (:samples element2))
-    :tags (map (partial apply merge) (partition-by :name (sort-by :name (concat (:tags element1) (:tags element2)))))})
+   (assoc element1 :metrics (clojure.set/union (:metrics element1) (:metrics element2))
+                   :samples (concat (:samples element1) (:samples element2))
+                   :tags    (clojure.set/union (:tags element1) (:tags element2))))
 
 (defn generate-event
    "Structure for ingest to Netuitive as JSON"
@@ -48,11 +45,11 @@
        {:id (str type ":" (:host event))
         :name (:host event)
         :type type
-        :metrics [{:id metric-id}]
+        :metrics (set [{:id metric-id}])
         :samples [{:metricId metric-id
                    :timestamp (parsetime (:time event))
                    :val (:metric event)}]
-        :tags (mapv generate-tag (:tags event))}))
+        :tags (set (map generate-tag (:tags event)))}))
 
 (defn netuitive
   "Return a function which accepts either single events or batches of

--- a/src/riemann/netuitive.clj
+++ b/src/riemann/netuitive.clj
@@ -76,7 +76,8 @@
   (let [opts (merge {:api-key "netuitive-api-key"} opts)]
     (fn [event]
       (let [events (if (sequential? event) event [event])
-            post-data (mapv #(generate-event % opts) events)
+            non-null (filter #(not (nil? (:metric %))) events)
+            post-data (mapv #(generate-event % opts) non-null)
             reduced-data (map (apply partial reduce combine-elements []) (partition-by :id (sort-by :id post-data)))
             json-data (generate-string reduced-data)]
         (post-datapoint (:api-key opts) (:url opts gateway-url) json-data)))))

--- a/src/riemann/netuitive.clj
+++ b/src/riemann/netuitive.clj
@@ -30,6 +30,16 @@
    [tag]
    {:name tag :value :true})
 
+(defn combine-elements
+   "Combine two elements"
+   [element1 element2]
+   {:id (:id element1)
+     :name (:name element1)
+     :type (:type element1)
+     :metrics (map (partial apply merge) (partition-by :id (sort-by :id (concat (:metrics element1) (:metrics element2)))))
+     :samples (concat (:samples element1) (:samples element2))
+     :tags (map (partial apply merge) (partition-by :name (sort-by :name (concat (:tags element1) (:tags element2)))))})
+
 (defn generate-event
    "Structure for ingest to Netuitive as JSON"
    [event opts]

--- a/test/riemann/netuitive_test.clj
+++ b/test/riemann/netuitive_test.clj
@@ -9,12 +9,12 @@
    (is (= (:type (generate-event test-event {})) "Riemann"))
    (is (= (:id (generate-event test-event {})) "Riemann:riemann.local"))
    (is (= (:name (generate-event test-event {})) "riemann.local"))
-   (is (= (:metrics (generate-event test-event {})) [{:id "netuitive.test"}]))
+   (is (= (:metrics (generate-event test-event {})) #{{:id "netuitive.test"}}))
    (is (= (:metricId (first (:samples (generate-event test-event {}))) "netuitive.test")))
    (is (= (:val (first (:samples (generate-event test-event {}))) 2)))
-   (is (= (:name (second (:tags (generate-event test-event {})))) "netuitive"))
+   (is (= (:name (first (:tags (generate-event test-event {})))) "netuitive"))
    (is (= (:name (generate-tag "tagname") "tagname")))
-   (is (= (:name (first (:tags (generate-event test-event {}))) "riemann")))
+   (is (= (:name (second (:tags (generate-event test-event {}))) "riemann")))
    (is (= (:type (generate-event test-event {:type "SERVER"})) "SERVER"))
    (is (= (netuitive-metric-name test-event) "netuitive.test"))
 
@@ -22,12 +22,12 @@
    (is (= (:id (combine-elements (generate-event test-event {}) (generate-event other-event {}))) "Riemann:riemann.local"))
    (is (= (:type (combine-elements (generate-event test-event {}) (generate-event other-event {}))) "Riemann"))
 
-   (is (= (:metrics (combine-elements (generate-event test-event {}) (generate-event test-event {}))) [{:id "netuitive.test"}]))
-   (is (= (:tags (combine-elements (generate-event test-event {}) (generate-event test-event {}))) [{:name "netuitive", :value :true} {:name "riemann", :value :true}]))
+   (is (= (:metrics (combine-elements (generate-event test-event {}) (generate-event test-event {}))) #{{:id "netuitive.test"}}))
+   (is (= (:tags (combine-elements (generate-event test-event {}) (generate-event test-event {}))) #{{:name "netuitive", :value :true} {:name "riemann", :value :true}}))
    (is (= (count (:samples (combine-elements (generate-event test-event {}) (generate-event test-event {})))) 2))
 
-   (is (= (:metrics (combine-elements (generate-event test-event {}) (generate-event other-event {}))) [{:id "netuitive.other"} {:id "netuitive.test"}]))
-   (is (= (:tags (combine-elements (generate-event test-event {}) (generate-event other-event {}))) [{:name "netuitive", :value :true} {:name "other", :value :true} {:name "riemann", :value :true}]))
+   (is (= (:metrics (combine-elements (generate-event test-event {}) (generate-event other-event {}))) #{{:id "netuitive.other"} {:id "netuitive.test"}}))
+   (is (= (:tags (combine-elements (generate-event test-event {}) (generate-event other-event {}))) #{{:name "netuitive", :value :true} {:name "other", :value :true} {:name "riemann", :value :true}}))
    (is (= (count (:samples (combine-elements (generate-event test-event {}) (generate-event other-event {})))) 2)))
 
 (deftest ^:integration ^:netuitive netuitive-test

--- a/test/riemann/netuitive_test.clj
+++ b/test/riemann/netuitive_test.clj
@@ -3,6 +3,7 @@
         clojure.test))
 
 (def test-event {:host "riemann.local" :service "netuitive test" :state "ok" :description "Successful test" :metric 2 :time (/ (System/currentTimeMillis) 1000) :tags ["riemann" "netuitive"]})
+(def other-event {:host "riemann.other" :service "netuitive test" :state "ok" :description "Successful test" :metric 2 :time (/ (System/currentTimeMillis) 1000) :tags ["riemann" "netuitive"]})
 
 (deftest ^:netuitive netuitive-unit-tests
    (is (= (:type (generate-event test-event {})) "Riemann"))
@@ -15,7 +16,11 @@
    (is (= (:name (generate-tag "tagname") "tagname")))
    (is (= (:name (first (:tags (generate-event test-event {}))) "riemann")))
    (is (= (:type (generate-event test-event {:type "SERVER"})) "SERVER"))
-   (is (= (netuitive-metric-name test-event) "netuitive.test")))
+   (is (= (netuitive-metric-name test-event) "netuitive.test"))
+   (is (= (count (:metrics (combine-elements (generate-event test-event {}) (generate-event test-event {})))) 1))
+   (is (= (count (:samples (combine-elements (generate-event test-event {}) (generate-event test-event {})))) 2))
+   (is (= (count (:tags (combine-elements (generate-event test-event {}) (generate-event test-event {})))) 2))
+   (is (= (count (combine-elements (generate-event test-event {}) (generate-event other-event {})))) 2))
 
 (deftest ^:integration ^:netuitive netuitive-test
    (let [k (netuitive {:api-key "netuitive-test-key" :url "https://api.app.netuitive.com/ingest/"})]

--- a/test/riemann/netuitive_test.clj
+++ b/test/riemann/netuitive_test.clj
@@ -3,7 +3,7 @@
         clojure.test))
 
 (def test-event {:host "riemann.local" :service "netuitive test" :state "ok" :description "Successful test" :metric 2 :time (/ (System/currentTimeMillis) 1000) :tags ["riemann" "netuitive"]})
-(def other-event {:host "riemann.other" :service "netuitive test" :state "ok" :description "Successful test" :metric 2 :time (/ (System/currentTimeMillis) 1000) :tags ["riemann" "netuitive"]})
+(def other-event {:host "riemann.local" :service "netuitive other" :state "ok" :description "Successful test" :metric 5 :time (/ (System/currentTimeMillis) 1000) :tags ["other"]})
 
 (deftest ^:netuitive netuitive-unit-tests
    (is (= (:type (generate-event test-event {})) "Riemann"))
@@ -17,10 +17,18 @@
    (is (= (:name (first (:tags (generate-event test-event {}))) "riemann")))
    (is (= (:type (generate-event test-event {:type "SERVER"})) "SERVER"))
    (is (= (netuitive-metric-name test-event) "netuitive.test"))
-   (is (= (count (:metrics (combine-elements (generate-event test-event {}) (generate-event test-event {})))) 1))
+
+   (is (= (:name (combine-elements (generate-event test-event {}) (generate-event other-event {}))) "riemann.local"))
+   (is (= (:id (combine-elements (generate-event test-event {}) (generate-event other-event {}))) "Riemann:riemann.local"))
+   (is (= (:type (combine-elements (generate-event test-event {}) (generate-event other-event {}))) "Riemann"))
+
+   (is (= (:metrics (combine-elements (generate-event test-event {}) (generate-event test-event {}))) [{:id "netuitive.test"}]))
+   (is (= (:tags (combine-elements (generate-event test-event {}) (generate-event test-event {}))) [{:name "netuitive", :value :true} {:name "riemann", :value :true}]))
    (is (= (count (:samples (combine-elements (generate-event test-event {}) (generate-event test-event {})))) 2))
-   (is (= (count (:tags (combine-elements (generate-event test-event {}) (generate-event test-event {})))) 2))
-   (is (= (count (combine-elements (generate-event test-event {}) (generate-event other-event {})))) 2))
+
+   (is (= (:metrics (combine-elements (generate-event test-event {}) (generate-event other-event {}))) [{:id "netuitive.other"} {:id "netuitive.test"}]))
+   (is (= (:tags (combine-elements (generate-event test-event {}) (generate-event other-event {}))) [{:name "netuitive", :value :true} {:name "other", :value :true} {:name "riemann", :value :true}]))
+   (is (= (count (:samples (combine-elements (generate-event test-event {}) (generate-event other-event {})))) 2)))
 
 (deftest ^:integration ^:netuitive netuitive-test
    (let [k (netuitive {:api-key "netuitive-test-key" :url "https://api.app.netuitive.com/ingest/"})]


### PR DESCRIPTION
Netuitive accepts REST payloads containing arrays of elements, but we prefer having a smaller number of larger payloads. The current implementation sends element payloads with a single metric and a single sample which are very inefficient.

This PR batches element payloads so a typical REST payload will have a few unique elements, a few metrics each, and a lot of samples. The PR also filters out events with a sample value of `nil` because those are ignored anyways. The resulting data in Netuitive will be identical, this just more efficiently transfers the data.