### PR TITLE
Add Pagerduty v2 API support

### DIFF
--- a/src/riemann/pagerduty.clj
+++ b/src/riemann/pagerduty.clj
@@ -1,17 +1,24 @@
 (ns riemann.pagerduty
   "Forwards events to Pagerduty"
-  (:require [clj-http.client :as client])
-  (:require [cheshire.core :as json]))
+  (:require [clj-http.client :as client]
+            [cheshire.core :as json]
+            [clj-time.format :as f]
+            [clj-time.coerce :as coerce]))
 
-(def ^:private event-url
+(def ^:private event-url-v1
   "https://events.pagerduty.com/generic/2010-04-15/create_event.json")
+
+(def ^:private event-url-v2
+  "https://events.pagerduty.com/v2/enqueue")
+
+(def timestamp-formatter (f/formatters :date-time))
 
 (defn- post
   "POST to the PagerDuty events API."
-  [request options]
-  (client/post event-url
+  [request-body url options]
+  (client/post url
                (merge
-                {:body (json/generate-string request)
+                {:body (json/generate-string request-body)
                  :socket-timeout 5000
                  :conn-timeout 5000
                  :content-type :json
@@ -19,8 +26,8 @@
                  :throw-entire-message? true}
                 options)))
 
-(defn format-event
-  "Formats an event for PagerDuty"
+(defn format-event-v1
+  "Formats an event for PagerDuty v1 API"
   [event]
   {:incident_key (str (:host event) " " (:service event))
    :description (str (:host event) " "
@@ -29,35 +36,101 @@
                      (:metric event) ")")
    :details event})
 
-(defn send-event
-  "Sends an event to PD. event-type is one of :trigger, :acknowledge,
+(defn format-event-v2
+  "Formats an event for PagerDuty v2 API"
+  [event]
+  {:summary (str (:host event) " - "
+                 (:service event) " is "
+                 (:state event) " ("
+                 (:metric event) ")")
+   :source (:host event)
+   :severity (:state event)
+   :timestamp (->> (or (:time event) (long (riemann.time/unix-time)))
+                   (coerce/from-long)
+                   (f/unparse timestamp-formatter))
+   :custom_details event})
+
+(defn request-body-v2
+  "Generate PD v2 API request body. event-action is one of :trigger, :acknowledge,
+  :resolve"
+  [service-key event-action formatter event]
+  (merge
+   {:routing_key service-key
+    :event_action event-action
+    :payload (formatter event)}
+   (if-let [dedup-key (:dedup-key event)]
+     {:dedup_key dedup-key}
+     {})))
+
+(defn request-body-v1
+  "Generate PD v1 API request body. event-type is one of :trigger, :acknowledge,
   :resolve"
   [service-key event-type formatter event]
   (merge
-    {:service_key service-key, :event_type event-type} (formatter event)))
+   {:service_key service-key
+    :event_type event-type}
+   (formatter event)))
+
+(defn send-event
+  "Send an event to Pagerduty."
+  [event-type config event]
+  (let [[request-body event-url formatter] (if (= :v2 (:version config))
+                                             [request-body-v2
+                                              event-url-v2
+                                              format-event-v2]
+                                             [request-body-v1
+                                              event-url-v1
+                                              format-event-v1])]
+    (post (request-body (:service-key config)
+                        event-type
+                        (or (:formatter config) formatter)
+                        event)
+          event-url
+          (:options config))))
 
 (defn pagerduty
-  "Creates a PagerDuty adapter. Takes your PD service key, and returns a map of
-  functions which trigger, acknowledge, and resolve events. By default, event
-  service will be used as the incident key. The PD description will be the service,
-  state, and metric. The full event will be attached as the details.
+  "Creates a PagerDuty adapter.
+  By default, use the pagerduty v1 API. You can use the v2 API by setting the
+  `:version` option to `:v2`.
 
-  You can override this by specifying a formatter. The formatter must be a function that accepts an event and emits a hash.
+  Returns a map of functions which trigger, acknowledge, and resolve events.
 
-  You can also pass more http options (like proxy) using the `:options` key.
+  General options:
+
+  `:service-key`         Pagerduty service key (also called integration key
+  or routing key)
+  `:formatter`           Formatter for the pagerduty event. You can override
+  the default formatter. The formatter must be a function that accepts an event
+  and emits a hash. (optional)
+  `:options`             Extra HTTP options. (optional)
+  `:version`             set to `:v2` to use Pagerduty v2 API. (optional)
+
+  v1 API:
+
+  By default, event host and service will be used as the incident key. The PD
+  description will be the host, service, state, and metric. The full event will be
+  attached as the details.
+
+  v2 API:
+
+  By default, event host will be used as the source. The PD summary will be the
+  host, service, state, and metric. The severity is the state. The full event will
+  be attached as the details.
+
+  Each event can also contains a `:dedup-key` key to handle alert de-duplication.
+
+  Example, using the v1 API with a custom formatter:
 
   (defn pd-format-event
     [event]
     {:incident_key 'Incident key', :description 'Incident Description',
      :details 'Incident details'})
 
-  The :formatter is an optional argument.
-
   (let [pd (pagerduty { :service-key \"my-service-key\" :formatter pd-format-event})]
     (changed-state
       (where (state \"ok\") (:resolve pd))
       (where (state \"critical\") (:trigger pd))))"
-  [{:keys [service-key formatter options] :or {formatter format-event options {}}}]
-  {:trigger     (fn [e] (post (send-event service-key :trigger formatter e) options))
-   :acknowledge (fn [e] (post (send-event service-key :acknowledge formatter e) options))
-   :resolve     (fn [e] (post (send-event service-key :resolve formatter e) options))})
+  [config]
+  {:trigger     (fn [e] (send-event :trigger config e))
+   :acknowledge (fn [e] (send-event :acknowledge config e))
+   :resolve     (fn [e] (send-event :resolve config e))})

--- a/test/riemann/pagerduty_test.clj
+++ b/test/riemann/pagerduty_test.clj
@@ -3,11 +3,99 @@
             [clj-http.client :as client]
             [riemann.test-utils :refer [with-mock]]
             [cheshire.core :as json]
+            [riemann.time :refer :all]
+            [riemann.time.controlled :refer :all]
             [clojure.test :refer :all]))
 
-(deftest ^:pagerduty send-event-test
+(use-fixtures :once control-time!)
+(use-fixtures :each reset-time!)
+
+(deftest ^:pagerduty format-event-v1-test
+  (let [event {:host "riemann.io"
+               :service "req_per_sec"
+               :state "critical"
+               :metric 100}]
+    (is (= {:incident_key "riemann.io req_per_sec"
+            :description "riemann.io req_per_sec is critical (100)"
+            :details event}
+           (pg/format-event-v1 event)))))
+
+(deftest ^:pagerduty format-event-v2-test
+  (let [event {:host "riemann.io"
+               :service "req_per_sec"
+               :state "critical"
+               :metric 100}]
+    (testing "with time"
+      (is (= {:summary "riemann.io - req_per_sec is critical (100)"
+              :source "riemann.io"
+              :severity "critical"
+              :custom_details (assoc event :time 100)
+              :timestamp "1970-01-01T00:00:00.100Z"}
+             (pg/format-event-v2 (assoc event :time 100)))))
+    (testing "without time"
+      (is (= {:summary "riemann.io - req_per_sec is critical (100)"
+              :source "riemann.io"
+              :timestamp "1970-01-01T00:00:00.000Z"
+              :custom_details event
+              :severity "critical"}
+             (pg/format-event-v2 event))))))
+
+(deftest request-body-v1-test
+  (let [service-key "fookey"
+        event {:host "riemann.io"
+               :service "req_per_sec"
+               :state "critical"
+               :metric 100}
+        formatter pg/format-event-v1
+        event-type :trigger]
+    (is (= {:service_key "fookey"
+            :event_type :trigger
+            :incident_key "riemann.io req_per_sec"
+            :description "riemann.io req_per_sec is critical (100)"
+            :details event}
+           (pg/request-body-v1 service-key
+                               event-type
+                               formatter
+                               event)))))
+
+(deftest request-body-v2-test
+  (let [service-key "fookey"
+        action :trigger
+        formatter pg/format-event-v2
+        event {:host "riemann.io"
+               :service "req_per_sec"
+               :state "critical"
+               :time 100
+               :metric 100}]
+    (testing "without :dedup-key"
+      (is (= {:routing_key service-key
+              :event_action action
+              :payload {:summary "riemann.io - req_per_sec is critical (100)"
+                        :source "riemann.io"
+                        :severity "critical"
+                        :timestamp "1970-01-01T00:00:00.100Z"
+                        :custom_details event}}
+             (pg/request-body-v2 service-key
+                                 action
+                                 formatter
+                                 event))))
+    (testing "with :dedup-key"
+      (is (= {:routing_key service-key
+              :event_action action
+              :payload {:summary "riemann.io - req_per_sec is critical (100)"
+                        :source "riemann.io"
+                        :severity "critical"
+                        :timestamp "1970-01-01T00:00:00.100Z"
+                        :custom_details (assoc event :dedup-key "riemann-alert")}
+              :dedup_key "riemann-alert"}
+             (pg/request-body-v2 service-key
+                                 action
+                                 formatter
+                                 (assoc event :dedup-key "riemann-alert")))))))
+
+(deftest ^:pagerduty pagerduty-v1-test
   (with-mock [calls client/post]
-    (testing "default paerduty stream"
+    (testing "default pagerduty stream"
       (let [s (pg/pagerduty {:service-key "foobarkey"})
             event {:host "foo" :service "bar" :state "critical"}]
         ((:trigger s) event)
@@ -15,7 +103,7 @@
                ["https://events.pagerduty.com/generic/2010-04-15/create_event.json"
                 {:body (json/generate-string (merge {:service_key "foobarkey"
                                                      :event_type :trigger}
-                                                    (pg/format-event event)))
+                                                    (pg/format-event-v1 event)))
                  :socket-timeout 5000
                  :conn-timeout 5000
                  :content-type :json
@@ -27,7 +115,7 @@
                ["https://events.pagerduty.com/generic/2010-04-15/create_event.json"
                 {:body (json/generate-string (merge {:service_key "foobarkey"
                                                      :event_type :acknowledge}
-                                                    (pg/format-event event)))
+                                                    (pg/format-event-v1 event)))
                  :socket-timeout 5000
                  :conn-timeout 5000
                  :content-type :json
@@ -39,7 +127,7 @@
                ["https://events.pagerduty.com/generic/2010-04-15/create_event.json"
                 {:body (json/generate-string (merge {:service_key "foobarkey"
                                                      :event_type :resolve}
-                                                    (pg/format-event event)))
+                                                    (pg/format-event-v1 event)))
                  :socket-timeout 5000
                  :conn-timeout 5000
                  :content-type :json
@@ -59,6 +147,76 @@
                 {:body (json/generate-string (merge {:service_key "foobarkey"
                                                      :event_type :resolve}
                                                     (formatter event)))
+                 :socket-timeout 5000
+                 :conn-timeout 5000
+                 :content-type :json
+                 :accept :json
+                 :proxy-host "127.0.0.1"
+                 :proxy-port 8080
+                 :throw-entire-message? true}]))
+        (reset! calls [])))))
+
+(deftest ^:pagerduty pagerduty-v2-test
+  (with-mock [calls client/post]
+    (testing "default pagerduty stream"
+      (let [service-key "foobarkey"
+            s (pg/pagerduty {:service-key service-key :version :v2})
+            event {:host "foo" :service "bar" :state "critical"}]
+        ((:trigger s) event)
+        (is (= (into [] (first @calls))
+               ["https://events.pagerduty.com/v2/enqueue"
+                {:body (json/generate-string {:routing_key service-key
+                                              :event_action :trigger
+                                              :payload
+                                              (pg/format-event-v2 event)})
+                 :socket-timeout 5000
+                 :conn-timeout 5000
+                 :content-type :json
+                 :accept :json
+                 :throw-entire-message? true}]))
+        (reset! calls [])
+        ((:acknowledge s) event)
+        (is (= (into [] (first @calls))
+               ["https://events.pagerduty.com/v2/enqueue"
+                {:body (json/generate-string {:routing_key service-key
+                                              :event_action :acknowledge
+                                              :payload
+                                              (pg/format-event-v2 event)})
+                 :socket-timeout 5000
+                 :conn-timeout 5000
+                 :content-type :json
+                 :accept :json
+                 :throw-entire-message? true}]))
+        (reset! calls [])
+        ((:resolve s) event)
+        (is (= (into [] (first @calls))
+               ["https://events.pagerduty.com/v2/enqueue"
+                {:body (json/generate-string {:routing_key service-key
+                                              :event_action :resolve
+                                              :payload
+                                              (pg/format-event-v2 event)})
+                 :socket-timeout 5000
+                 :conn-timeout 5000
+                 :content-type :json
+                 :accept :json
+                 :throw-entire-message? true}]))
+        (reset! calls [])))
+    (testing "override formatter and options parameters"
+      (let [service-key "foobarkey"
+            formatter (fn [event] (:foo (str event)))
+            s (pg/pagerduty {:service-key service-key
+                             :formatter formatter
+                             :version :v2
+                             :options {:proxy-host "127.0.0.1"
+                                       :proxy-port 8080}})
+            event {:host "foo" :service "bar" :state "critical"}]
+        ((:resolve s) event)
+        (is (= (into [] (first @calls))
+               ["https://events.pagerduty.com/v2/enqueue"
+                {:body (json/generate-string {:routing_key "foobarkey"
+                                              :event_action :resolve
+                                              :payload
+                                              (formatter event)})
                  :socket-timeout 5000
                  :conn-timeout 5000
                  :content-type :json


### PR DESCRIPTION
By default, the pagerduty stream uses the v1 API (so no breaking change), but the v2 API can be used by setting the `:version` option to `:v2`.

You can find more informations about the v2 API [here](https://v2.developer.pagerduty.com/docs/events-api-v2).

When you use the v2 API, each event can also have a `:dedup-key` field. It will be used by Pagerduty for alert de-duplication (cf v2 api documentation).

cc @openglx ;)