### PR TITLE
Upgrade influxdb-java dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
     [ch.qos.logback/logback-classic "1.1.3"]
     [com.github.juise/logstash-logback-layout "1.0"]
     [net.logstash.logback/logstash-logback-encoder "4.5"]
-    [org.influxdb/influxdb-java "2.4"]
+    [org.influxdb/influxdb-java "2.7"]
     [com.cemerick/pomegranate "0.3.1"
      :exclusions [org.codehaus.plexus/plexus-utils]]
     ; for pomegranate


### PR DESCRIPTION
influxdb-java changelog [here](https://github.com/influxdata/influxdb-java/blob/master/CHANGELOG.md).

Two nice improvements:

```
Significant (~35%) performance improvements for write speed with less memory footprint. PR #330
Drop guava runtime dependency which reduces jar size from 1MB -> 49KB PR #322
```