### PR TITLE
Updated docs for JDK 8 and 9 and removing JDK 7

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -302,9 +302,9 @@ set :bind, "1.2.3.4"
 <div class="row">
   <div class="sixcol">
     <p>Oracle JDK8 is likely to be the fastest option (and supports the full
-    range of aggressive tuning options with <code>riemann -a</code>), but I
-    test and deploy with JDK 7 and 8, from both Oracle and OpenJDK. You're
-    welcome to give other JVMs a shot, though!</p>
+    range of aggressive tuning options with <code>riemann -a</code>), but we
+    test and deploy with JDK 8, from both Oracle and OpenJDK, and JDK 9 from Oracle.
+    You're welcome to give other JVMs a shot, though!</p>
   </div>
 </div>
 


### PR DESCRIPTION
Related to #846 