### PR TITLE
Adds Netty Kqueue support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,7 @@
     [com.draines/postal "2.0.2"]
     [com.amazonaws/aws-java-sdk "1.11.116" :exclusions [joda-time]]
     [interval-metrics "1.0.0"]
-    [io.netty/netty-all "4.1.11.Final"]
+    [io.netty/netty-all "4.1.15.Final"]
     [clj-antlr "0.2.2"]
     [riemann-clojure-client "0.4.5"]
     [less-awful-ssl "1.0.1"]

--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,7 @@
     [com.draines/postal "2.0.2"]
     [com.amazonaws/aws-java-sdk "1.11.116" :exclusions [joda-time]]
     [interval-metrics "1.0.0"]
-    [io.netty/netty-all "4.1.4.Final"]
+    [io.netty/netty-all "4.1.11.Final"]
     [clj-antlr "0.2.2"]
     [riemann-clojure-client "0.4.5"]
     [less-awful-ssl "1.0.1"]

--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -84,11 +84,14 @@
          (.equals (System/getProperty "netty.epoll.enabled" "true") "true"))
        {:event-loop-group-fn #(EpollEventLoopGroup.)
          :channel EpollServerSocketChannel}
-    (or (and (.contains (. System getProperty "os.name") "mac") (.contains (. System getProperty "os.arch") "x86_64"))
-        (and (.contains (. System getProperty "os.name") "freebsd") (.contains (. System getProperty "os.arch") "amd64"))
-      (and (.equals (System/getProperty "netty.kqueue.enabled" "true") "true")))
-        {:event-loop-group-fn #(KQueueEventLoopGroup.)
-          :channel KQueueServerSocketChannel}
+    (and
+      (or (and (.contains (. System getProperty "os.name") "mac")
+               (.contains (. System getProperty "os.arch") "x86_64"))
+          (and (.contains (. System getProperty "os.name") "freebsd")
+               (.contains (. System getProperty "os.arch") "amd64")))
+      (.equals (System/getProperty "netty.kqueue.enabled" "true") "true"))
+       {:event-loop-group-fn #(KQueueEventLoopGroup.)
+         :channel KQueueServerSocketChannel}
     :else 
        {:event-loop-group-fn #(NioEventLoopGroup.)
           :channel NioServerSocketChannel}))

--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -19,6 +19,7 @@
                                    LengthFieldPrepender]
            [io.netty.handler.ssl SslHandler]
            [io.netty.channel.epoll EpollEventLoopGroup EpollServerSocketChannel]
+           [io.netty.channel.kqueue KQueueEventLoopGroup KQueueServerSocketChannel]
            [io.netty.channel.nio NioEventLoopGroup]
            [io.netty.channel.socket.nio NioServerSocketChannel])
   (:require [less.awful.ssl :as ssl]
@@ -145,10 +146,8 @@
                     (.group boss-group worker-group)
                     (.channel (:channel netty-implementation))
                     (.option ChannelOption/SO_REUSEADDR true)
-                    (.option ChannelOption/TCP_NODELAY true)
                     (.option ChannelOption/SO_BACKLOG so-backlog)
                     (.childOption ChannelOption/SO_REUSEADDR true)
-                    (.childOption ChannelOption/TCP_NODELAY true)
                     (.childOption ChannelOption/SO_KEEPALIVE true)
                     (.childHandler initializer))
 


### PR DESCRIPTION
* Updated netty to 4.1.15.Final to get kqueue support.
* Removed TCP_NODELAY as it on by default and causes a warning in the
tests.
* Adds netty Kqueue to the tcp transport.
* Updates switch to check for:
  a. If "linux" and "amd64" and "netty.epoll.enabled" then use epoll.
  b. if "mac" and "x86_64" and "netty.kqueue.enabled" then use kqueue.
  c. if "freebsd" and "amd64" and "netty.kqueue.enabled" then use
     kqueue.
  d. If none of the above default to NIO.

Fixed #851 