### PR TITLE
Add a try/catch where events are expired

### DIFF
--- a/test/riemann/index_test.clj
+++ b/test/riemann/index_test.clj
@@ -50,20 +50,28 @@
                   #{{:host 2 :service "meow" :time 0}}))))
 
 (deftest nhbm-expire
-         (let [i (wrap-index (index))]
-           (i {:host 1 :ttl 0 :time  (dec (unix-time))})
-           (i {:host 2 :ttl 10 :time (unix-time)})
-           (i {:host 3 :ttl 20 :time (- (unix-time) 21)})
-           ; Default TTLs
-           (i {:host 4 :ttl nil :time (unix-time)})
-           (i {:host 5 :ttl nil :time (- (unix-time) default-ttl 1)})
+  (testing "Without exception"
+    (let [i (wrap-index (index))]
+      (i {:host 1 :ttl 0 :time  (dec (unix-time))})
+      (i {:host 2 :ttl 10 :time (unix-time)})
+      (i {:host 3 :ttl 20 :time (- (unix-time) 21)})
+                                        ; Default TTLs
+      (i {:host 4 :ttl nil :time (unix-time)})
+      (i {:host 5 :ttl nil :time (- (unix-time) default-ttl 1)})
 
-           (let [expired (expire i)]
-             (is (= (set (map :host expired))
-                    #{1 3 5})))
+      (let [expired (expire i)]
+        (is (= (set (map :host expired))
+               #{1 3 5})))
 
-           (is (= (set (map :host i))
-                  #{2 4}))))
+      (is (= (set (map :host i))
+             #{2 4}))))
+  (testing "With exception"
+    (let [i (wrap-index (index))]
+      (i {:host 1 :ttl "0" :time (unix-time)})
+      (let [expired (expire i)]
+        (is (= (set (map :host expired))
+               #{}))
+        (is (= (lookup i 1 nil) nil))))))
 
 (deftest nbhm-read-index
          (let [i (wrap-index (index))]


### PR DESCRIPTION
Fix #850 

If a malformed event is indexed, and cause an exception during its expiration, the events in the index will never expire (the reaper thread is killed).

This commit adds a try/catch to catch the exception, log an error message, and remove the malformed event from the index.