### PR TITLE
Catch AssertionError in stream.clj and time.clj

### DIFF
--- a/src/riemann/common.clj
+++ b/src/riemann/common.clj
@@ -146,7 +146,7 @@
 (defn exception->event
   "Creates an event from an Exception."
   ([exception] (exception->event exception nil))
-  ([^Exception e original]
+  ([^Throwable e original]
    (map->Event {:time (unix-time)
                 :service "riemann exception"
                 :state "error"

--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -70,6 +70,10 @@
          (catch Exception e#
            (if-let [ex-stream# *exception-stream*]
              (ex-stream# (exception->event e# ~event))
+             (warn e# (str child# " threw"))))
+         (catch AssertionError e#
+           (if-let [ex-stream# *exception-stream*]
+             (ex-stream# (exception->event e# ~event))
              (warn e# (str child# " threw"))))))
      ; TODO: Why return true?
      true))

--- a/src/riemann/time.clj
+++ b/src/riemann/time.clj
@@ -152,7 +152,9 @@
             ; Run task
             (try
               (run task)
-              (catch Exception t
+              (catch Exception e
+                (warn e "running task threw"))
+              (catch AssertionError t
                 (warn t "running task threw")))
             (when-let [task' (succ task)]
               ; Schedule the next task.
@@ -165,7 +167,9 @@
         (do
           ; No task available; park for a bit and try again.
           (LockSupport/parkNanos (ceil (* 1000000000 park-interval)))))
-      (catch Exception t
+      (catch Exception e
+        (warn e "riemann.time task threw"))
+      (catch AssertionError t
         (warn t "riemann.time task threw")))))
 
 (defn stop!


### PR DESCRIPTION
I added `catch AssertionError` where arbitrary code can run.