### PR TITLE
Fix the where macro for clojure 1.9

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1720,7 +1720,7 @@
         [true-kids else-kids] (where-partition-clauses children)]
     `(let [true-kids# ~true-kids
            else-kids# ~else-kids]
-       (fn stream [event#]
+       (fn stream# [event#]
          (let [value# (let [~'event event#] ~p)]
            (if value#
              (call-rescue event# true-kids#)


### PR DESCRIPTION
I have this exception when i launch Riemann with clojure 1.9:

```

Exception in thread "main" clojure.lang.ExceptionInfo: Call to clojure.core/fn did not conform to spec:
In: [0] val: riemann.streams/stream fails spec: :clojure.core.specs.alpha/arg-list at: [:args :bs :arity-1 :args] predicate: vector?
In: [0] val: riemann.streams/stream fails spec: :clojure.core.specs.alpha/args+body at: [:args :bs :arity-n] predicate: (cat :args :clojure.core.specs.alpha/arg-list :body (alt :prepost+body (cat :prepost map? :body (+ any?)) :body (* any?)))
:clojure.spec.alpha/spec  #object[clojure.spec.alpha$regex_spec_impl$reify__1200 0x402f8592 "clojure.spec.alpha$regex_spec_impl$reify__1200@402f8592"]
:clojure.spec.alpha/value  (riemann.streams/stream [event__2178__auto__] (clojure.core/let [value__2179__auto__ (clojure.core/let [event event__2178__auto__] (:metric event))] (if value__2179__auto__ (riemann.streams/call-rescue event__2178__auto__ true-kids__2176__auto__) (riemann.streams/call-rescue event__2178__auto__ else-kids__2177__auto__)) value__2179__auto__))
:clojure.spec.alpha/args  (riemann.streams/stream [event__2178__auto__] (clojure.core/let [value__2179__auto__ (clojure.core/let [event event__2178__auto__] (:metric event))] (if value__2179__auto__ (riemann.streams/call-rescue event__2178__auto__ true-kids__2176__auto__) (riemann.streams/call-rescue event__2178__auto__ else-kids__2177__auto__)) value__2179__auto__))
 #:clojure.spec.alpha{:problems ({:path [:args :bs :arity-1 :args], :pred clojure.core/vector?, :val riemann.streams/stream, :via [:clojure.core.specs.alpha/args+body :clojure.core.specs.alpha/arg-list :clojure.core.specs.alpha/arg-list], :in [0]} {:path [:args :bs :arity-n], :pred (clojure.spec.alpha/cat :args :clojure.core.specs.alpha/arg-list :body (clojure.spec.alpha/alt :prepost+body (clojure.spec.alpha/cat :prepost clojure.core/map? :body (clojure.spec.alpha/+ clojure.core/any?)) :body (clojure.spec.alpha/* clojure.core/any?))), :val riemann.streams/stream, :via [:clojure.core.specs.alpha/args+body :clojure.core.specs.alpha/args+body], :in [0]}), :spec #object[clojure.spec.alpha$regex_spec_impl$reify__1200 0x402f8592 "clojure.spec.alpha$regex_spec_impl$reify__1200@402f8592"], :value (riemann.streams/stream [event__2178__auto__] (clojure.core/let [value__2179__auto__ (clojure.core/let [event event__2178__auto__] (:metric event))] (if value__2179__auto__ (riemann.streams/call-rescue event__2178__auto__ true-kids__2176__auto__) (riemann.streams/call-rescue event__2178__auto__ else-kids__2177__auto__)) value__2179__auto__)), :args (riemann.streams/stream [event__2178__auto__] (clojure.core/let [value__2179__auto__ (clojure.core/let [event event__2178__auto__] (:metric event))] (if value__2179__auto__ (riemann.streams/call-rescue event__2178__auto__ true-kids__2176__auto__) (riemann.streams/call-rescue event__2178__auto__ else-kids__2177__auto__)) value__2179__auto__))}, compiling:(riemann/blueflood.clj:79:5)
	at clojure.lang.Compiler.checkSpecs(Compiler.java:6891)
	at clojure.lang.Compiler.macroexpand1(Compiler.java:6907)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:6989)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:6100)
	at clojure.lang.Compiler$LetExpr$Parser.parse(Compiler.java:6420)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7003)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:6991)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:6991)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:6100)
	at clojure.lang.Compiler$LetExpr$Parser.parse(Compiler.java:6420)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7003)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:6991)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:6100)
	at clojure.lang.Compiler$FnMethod.parse(Compiler.java:5460)
	at clojure.lang.Compiler$FnExpr.parse(Compiler.java:4022)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7001)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:6991)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.access$300(Compiler.java:38)
	at clojure.lang.Compiler$DefExpr$Parser.parse(Compiler.java:595)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7003)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler.eval(Compiler.java:7066)
	at clojure.lang.Compiler.load(Compiler.java:7514)
	at clojure.lang.RT.loadResourceScript(RT.java:379)
	at clojure.lang.RT.loadResourceScript(RT.java:370)
	at clojure.lang.RT.load(RT.java:460)
	at clojure.lang.RT.load(RT.java:426)
	at clojure.core$load$fn__6550.invoke(core.clj:6047)
	at clojure.core$load.invokeStatic(core.clj:6046)
	at clojure.core$load.doInvoke(core.clj:6030)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at clojure.core$load_one.invokeStatic(core.clj:5849)
	at clojure.core$load_one.invoke(core.clj:5844)
	at clojure.core$load_lib$fn__6495.invoke(core.clj:5889)
	at clojure.core$load_lib.invokeStatic(core.clj:5888)
	at clojure.core$load_lib.doInvoke(core.clj:5869)
	at clojure.lang.RestFn.applyTo(RestFn.java:142)
	at clojure.core$apply.invokeStatic(core.clj:659)
	at clojure.core$load_libs.invokeStatic(core.clj:5926)
	at clojure.core$load_libs.doInvoke(core.clj:5910)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:661)
	at clojure.core$use.invokeStatic(core.clj:6014)
	at clojure.core$use.doInvoke(core.clj:6014)
	at clojure.lang.RestFn.invoke(RestFn.java:551)
	at riemann.blueflood_test$eval366$loading__6436__auto____367.invoke(blueflood_test.clj:1)
	at riemann.blueflood_test$eval366.invokeStatic(blueflood_test.clj:1)
	at riemann.blueflood_test$eval366.invoke(blueflood_test.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:7062)
	at clojure.lang.Compiler.eval(Compiler.java:7051)
	at clojure.lang.Compiler.load(Compiler.java:7514)
	at clojure.lang.RT.loadResourceScript(RT.java:379)
	at clojure.lang.RT.loadResourceScript(RT.java:370)
	at clojure.lang.RT.load(RT.java:460)
	at clojure.lang.RT.load(RT.java:426)
	at clojure.core$load$fn__6550.invoke(core.clj:6047)
	at clojure.core$load.invokeStatic(core.clj:6046)
	at clojure.core$load.doInvoke(core.clj:6030)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at clojure.core$load_one.invokeStatic(core.clj:5849)
	at clojure.core$load_one.invoke(core.clj:5844)
	at clojure.core$load_lib$fn__6495.invoke(core.clj:5889)
	at clojure.core$load_lib.invokeStatic(core.clj:5888)
	at clojure.core$load_lib.doInvoke(core.clj:5869)
	at clojure.lang.RestFn.applyTo(RestFn.java:142)
	at clojure.core$apply.invokeStatic(core.clj:659)
	at clojure.core$load_libs.invokeStatic(core.clj:5926)
	at clojure.core$load_libs.doInvoke(core.clj:5910)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:659)
	at clojure.core$require.invokeStatic(core.clj:5948)
	at clojure.core$require.doInvoke(core.clj:5948)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:659)
	at clojure.core$apply.invoke(core.clj:652)
	at user$eval233.invokeStatic(form-init464709538604683264.clj:1)
	at user$eval233.invoke(form-init464709538604683264.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:7062)
	at clojure.lang.Compiler.eval(Compiler.java:7052)
	at clojure.lang.Compiler.load(Compiler.java:7514)
	at clojure.lang.Compiler.loadFile(Compiler.java:7452)
	at clojure.main$load_script.invokeStatic(main.clj:278)
	at clojure.main$init_opt.invokeStatic(main.clj:280)
	at clojure.main$init_opt.invoke(main.clj:280)
	at clojure.main$initialize.invokeStatic(main.clj:311)
	at clojure.main$null_opt.invokeStatic(main.clj:345)
	at clojure.main$null_opt.invoke(main.clj:342)
	at clojure.main$main.invokeStatic(main.clj:424)
	at clojure.main$main.doInvoke(main.clj:387)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:702)
	at clojure.main.main(main.java:37)
Caused by: clojure.lang.ExceptionInfo: Call to clojure.core/fn did not conform to spec:
In: [0] val: riemann.streams/stream fails spec: :clojure.core.specs.alpha/arg-list at: [:args :bs :arity-1 :args] predicate: vector?
In: [0] val: riemann.streams/stream fails spec: :clojure.core.specs.alpha/args+body at: [:args :bs :arity-n] predicate: (cat :args :clojure.core.specs.alpha/arg-list :body (alt :prepost+body (cat :prepost map? :body (+ any?)) :body (* any?)))
:clojure.spec.alpha/spec  #object[clojure.spec.alpha$regex_spec_impl$reify__1200 0x402f8592 "clojure.spec.alpha$regex_spec_impl$reify__1200@402f8592"]
:clojure.spec.alpha/value  (riemann.streams/stream [event__2178__auto__] (clojure.core/let [value__2179__auto__ (clojure.core/let [event event__2178__auto__] (:metric event))] (if value__2179__auto__ (riemann.streams/call-rescue event__2178__auto__ true-kids__2176__auto__) (riemann.streams/call-rescue event__2178__auto__ else-kids__2177__auto__)) value__2179__auto__))
:clojure.spec.alpha/args  (riemann.streams/stream [event__2178__auto__] (clojure.core/let [value__2179__auto__ (clojure.core/let [event event__2178__auto__] (:metric event))] (if value__2179__auto__ (riemann.streams/call-rescue event__2178__auto__ true-kids__2176__auto__) (riemann.streams/call-rescue event__2178__auto__ else-kids__2177__auto__)) value__2179__auto__))
 {:clojure.spec.alpha/problems ({:path [:args :bs :arity-1 :args], :pred clojure.core/vector?, :val riemann.streams/stream, :via [:clojure.core.specs.alpha/args+body :clojure.core.specs.alpha/arg-list :clojure.core.specs.alpha/arg-list], :in [0]} {:path [:args :bs :arity-n], :pred (clojure.spec.alpha/cat :args :clojure.core.specs.alpha/arg-list :body (clojure.spec.alpha/alt :prepost+body (clojure.spec.alpha/cat :prepost clojure.core/map? :body (clojure.spec.alpha/+ clojure.core/any?)) :body (clojure.spec.alpha/* clojure.core/any?))), :val riemann.streams/stream, :via [:clojure.core.specs.alpha/args+body :clojure.core.specs.alpha/args+body], :in [0]}), :clojure.spec.alpha/spec #object[clojure.spec.alpha$regex_spec_impl$reify__1200 0x402f8592 "clojure.spec.alpha$regex_spec_impl$reify__1200@402f8592"], :clojure.spec.alpha/value (riemann.streams/stream [event__2178__auto__] (clojure.core/let [value__2179__auto__ (clojure.core/let [event event__2178__auto__] (:metric event))] (if value__2179__auto__ (riemann.streams/call-rescue event__2178__auto__ true-kids__2176__auto__) (riemann.streams/call-rescue event__2178__auto__ else-kids__2177__auto__)) value__2179__auto__)), :clojure.spec.alpha/args (riemann.streams/stream [event__2178__auto__] (clojure.core/let [value__2179__auto__ (clojure.core/let [event event__2178__auto__] (:metric event))] (if value__2179__auto__ (riemann.streams/call-rescue event__2178__auto__ true-kids__2176__auto__) (riemann.streams/call-rescue event__2178__auto__ else-kids__2177__auto__)) value__2179__auto__))}
	at clojure.core$ex_info.invokeStatic(core.clj:4744)
	at clojure.core$ex_info.invoke(core.clj:4744)
	at clojure.spec.alpha$macroexpand_check.invokeStatic(alpha.clj:696)
	at clojure.spec.alpha$macroexpand_check.invoke(alpha.clj:688)
	at clojure.lang.AFn.applyToHelper(AFn.java:156)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at clojure.lang.Var.applyTo(Var.java:702)
	at clojure.lang.Compiler.checkSpecs(Compiler.java:6889)
	... 103 more
Tests failed.
```

The problem was in the where macro, (fn stream) was fully qualified.