### PR TITLE
Refactoring the telegram output

### DIFF
--- a/test/riemann/telegram_test.clj
+++ b/test/riemann/telegram_test.clj
@@ -1,7 +1,8 @@
 (ns riemann.telegram-test
-  (:use riemann.telegram
-        clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:require [clojure.test :refer :all]
+            [riemann.telegram :refer :all]
+            [riemann.logging :as logging]
+            [riemann.test-utils :refer [with-mock]]))
 
 (def api-token (System/getenv "TELEGRAM_API_TOKEN"))
 (def chat-id (System/getenv "TELEGRAM_CHAT_ID"))
@@ -14,16 +15,16 @@
 
 (logging/init)
 
-(deftest ^:telegram ^:integration single_event
-  (let [tg (telegram {:token api-token :chat_id chat-id})]
+(deftest ^:telegram ^:integration single-event
+  (let [tg (telegram {:token api-token :chat-id chat-id})]
     (tg {:host "localhost"
          :service "telegram single"
          :description "Testing single event"
          :metric 42
          :state "ok"})))
 
-(deftest ^:telegram ^:integration multiple_events
-  (let [tg (telegram {:token api-token :chat_id chat-id})]
+(deftest ^:telegram ^:integration multiple-events
+  (let [tg (telegram {:token api-token :chat-id chat-id})]
     (tg [{:host "localhost"
           :service "telegram multiple"
           :description "Testing multiple events"
@@ -35,10 +36,71 @@
           :metric 44
           :state "ok"}])))
 
-(deftest ^:telegram ^:integration html_event
-  (let [tg (telegram {:token api-token :chat_id chat-id :parse_mode "html"})]
+(deftest ^:telegram ^:integration html-event
+  (let [tg (telegram {:token api-token :chat-id chat-id :parse-mode "HTML"})]
     (tg {:host "localhost"
          :service "telegram html parse mode test"
          :description "Testing <b>html</b> formatted <code>event</code>"
          :metric 45
          :state "ok"})))
+
+(deftest ^:telegram telegram-test
+  (with-mock [calls clj-http.client/post]
+    (testing "default options"
+      (let [s (telegram {:token "1234"
+                         :telegram-options {:chat_id "4321"}})
+            e {:host "localhost"
+               :service "bar"
+               :description "desc"
+               :metric 45
+               :state "ok"}]
+        (s e)
+        (is (= 1 (count @calls)))
+        (let [[url {:keys [form-params]}]
+              (last @calls)]
+          (is (= url "https://api.telegram.org/bot1234/sendMessage"))
+          (is (= form-params {:chat_id "4321"
+                              :parse_mode "Markdown"
+                              :text (markdown-parse-mode e)})))))
+    (testing "http options and more telegram options"
+      (let [s (telegram {:token "1234"
+                         :http-options {:proxy-host "127.0.0.1"
+                                        :proxy-port 8080}
+                         :telegram-options {:chat_id "4321"
+                                            :disable_notification true
+                                            :parse_mode "HTML"}})
+            e {:host "localhost"
+               :service "bar"
+               :description "desc"
+               :metric 45
+               :state "ok"}]
+        (s e)
+        (is (= 2 (count @calls)))
+        (let [[url {:keys [form-params] :as req}]
+              (last @calls)]
+          (is (= url "https://api.telegram.org/bot1234/sendMessage"))
+          (is (= (:proxy-host req) "127.0.0.1"))
+          (is (= (:proxy-port req) 8080))
+          (is (= form-params {:chat_id "4321"
+                              :disable_notification true
+                              :parse_mode "HTML"
+                              :text (html-parse-mode e)})))))
+    (testing "custom formatter"
+      (let [formatter #(:host %)
+            s (telegram {:token "1234"
+                         :message-formatter formatter
+                         :telegram-options {:chat_id "4321"}})
+            e {:host "localhost"
+               :service "bar"
+               :description "desc"
+               :metric 45
+               :state "ok"}]
+        (s e)
+        (is (= 3 (count @calls)))
+        (let [[url {:keys [form-params]}]
+              (last @calls)]
+          (is (= url "https://api.telegram.org/bot1234/sendMessage"))
+          (is (= form-params {:chat_id "4321"
+                              :parse_mode "Markdown"
+                              :text "localhost"})))))))
+


### PR DESCRIPTION
- Breaking change: refactoring stream options. 

Before: 

```clojure
(streams
   (telegram {:token token
              :chat_id chat_id}))
```

Now : 

```clojure
(streams
    (telegram {:token token
               :telegram-options {:chat_id chat-id}}))
```

The `:telegram-options` key can contains all telegram [sendMessage](https://core.telegram.org/bots/api#sendmessage) options.

- New option: `:http-options` for http options like proxy
- New option: `:message-formatter` a function accepting an event and returning a string.
- I also simplified the code and added some tests.

I need to test this PR using a telegram account before merging ;)