### PR TITLE
Fix #796: add scrollbar when code line is too long

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -250,6 +250,7 @@ figure.highlight, code pre {
   padding: 6px;
   font-size: 12px;
   line-height: 16px;
+  overflow: auto;
 }
 
 .cards {

--- a/quickstart.html
+++ b/quickstart.html
@@ -50,9 +50,10 @@ $ cd riemann-0.2.14
 
 <p>Check the md5sum to verify the tarball:</p>
 
-<code><pre>wget <a href="https://github.com/riemann/riemann/releases/download/0.2.14/riemann-0.2.14.tar.bz2.md5">https://github.com/riemann/riemann/releases/download/0.2.14/riemann-0.2.14.tar.bz2.md5</a>
-md5sum -c riemann-0.2.14.tar.bz2.md5
-</pre></code>
+{% highlight shell_session %}
+$ wget https://github.com/riemann/riemann/releases/download/0.2.14/riemann-0.2.14.tar.bz2.md5
+$ md5sum -c riemann-0.2.14.tar.bz2.md5
+{% endhighlight%}
 
 <p>You can also install Riemann via the Debian or RPM packages, through
       <a href="https://forge.puppetlabs.com/garethr/riemann">Puppet</a>, <a


### PR DESCRIPTION
![scrollbar](https://user-images.githubusercontent.com/1647008/31862395-878ecc8a-b73d-11e7-93e7-cb43c07d61bb.png)

Add a scrollbar when the code line is too long