### PR TITLE
Fix #796: line wrap when code line is too long

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -235,6 +235,7 @@ code {
   font: monospace;
   color: #001843;
   background-color: #eee;
+  white-space: pre-wrap;
 }
 code a {
   font-size: inherit;

--- a/quickstart.html
+++ b/quickstart.html
@@ -50,9 +50,10 @@ $ cd riemann-0.2.14
 
 <p>Check the md5sum to verify the tarball:</p>
 
-<code><pre>wget <a href="https://github.com/riemann/riemann/releases/download/0.2.14/riemann-0.2.14.tar.bz2.md5">https://github.com/riemann/riemann/releases/download/0.2.14/riemann-0.2.14.tar.bz2.md5</a>
-md5sum -c riemann-0.2.14.tar.bz2.md5
-</pre></code>
+{% highlight shell_session %}
+$ wget https://github.com/riemann/riemann/releases/download/0.2.14/riemann-0.2.14.tar.bz2.md5
+$ md5sum -c riemann-0.2.14.tar.bz2.md5
+{% endhighlight%}
 
 <p>You can also install Riemann via the Debian or RPM packages, through
       <a href="https://forge.puppetlabs.com/garethr/riemann">Puppet</a>, <a


### PR DESCRIPTION
![wrap](https://user-images.githubusercontent.com/1647008/31862460-44ac5df0-b73e-11e7-813b-9931d33f27ba.png)

Wrap code line to a new line when too long. Note that this breaks vertical alignment and spacing...