### PR TITLE
Add the "riemann" tag in index instrumentation

### DIFF
--- a/src/riemann/index.clj
+++ b/src/riemann/index.clj
@@ -105,7 +105,9 @@
 
       Instrumented
       (events [this]
-        (let [base {:state "ok" :time (unix-time)}]
+        (let [base {:state "ok"
+                    :time (unix-time)
+                    :tags ["riemann"]}]
           (map (partial merge base)
                [{:service "riemann index size"
                  :metric (.size hm)}])))


### PR DESCRIPTION
The riemann tag was missing.