### PR TITLE
Mock a core in test mode, refactoring reaper

### DIFF
--- a/src/riemann/bin.clj
+++ b/src/riemann/bin.clj
@@ -129,7 +129,8 @@
               (test/with-test-env
                 (set-config-file! config)
                 (riemann.config/include @config-file)
-                (binding [test/*streams* (:streams @config/next-core)]
+                (reset! riemann.config/core @riemann.config/next-core)
+                (binding [test/*core* @config/core]
                   (let [test-name-pattern (if test-name (re-pattern test-name) #".*-test")
                         results (run-tests test-name-pattern)]
                     (if (and (zero? (:error results))

--- a/src/riemann/kafka.clj
+++ b/src/riemann/kafka.clj
@@ -1,7 +1,8 @@
 (ns riemann.kafka
   "Receives events from and forwards events to Kafka."
   (:require [kinsky.client :as client]
-            [cheshire.core :as json])
+            [cheshire.core :as json]
+            [riemann.test :as test])
   (:use [riemann.common        :only [event]]
         [riemann.core          :only [stream!]]
         [riemann.service       :only [Service ServiceEquiv]]
@@ -103,8 +104,9 @@
       (conflict? [this other]
         (= opts (:opts other)))
       (start! [this]
-        (info "Starting kafka consumer")
-        (start-kafka-thread running? core opts))
+        (when-not test/*testing*
+          (do (info "Starting kafka consumer")
+              (start-kafka-thread running? core opts))))
       (reload! [this new-core]
         (info "Reload called, setting new core value")
         (reset! core new-core))

--- a/src/riemann/test.clj
+++ b/src/riemann/test.clj
@@ -7,6 +7,8 @@
   received."
   (:require [riemann.time.controlled :as time.controlled]
             [riemann.time :as time]
+            [riemann.index :as index]
+            [riemann.service :as service]
             [riemann.streams :as streams]
             [clojure.test :as test]))
 
@@ -24,10 +26,8 @@
   "An atom to a map of tap names to information about the taps; e.g. file and
   line number, for preventing collisions." nil)
 
-(def ^:dynamic *streams*
-  "The current sequence of streams. This is global so test writers can simply
-  call (inject! events) without looking up the streams from their core every
-  time."
+(def ^:dynamic *core*
+  "The core used in test mode"
   nil)
 
 (defn tap-stream
@@ -128,27 +128,22 @@
   riemann.time.controlled is global. Streams may be omitted, in which case
   inject! applies events to the *streams* dynamic var."
   ([events]
-   (inject! *streams* events))
+   (inject! (:streams *core*) events))
   ([streams events]
-   (binding [*results* (fresh-results @*taps*)]
-     ; Set up time
-     (time.controlled/with-controlled-time!
-       (time.controlled/reset-time!)
+   ;; Apply events
+   (doseq [e events]
+     (when-let [t (:time e)]
+       (time.controlled/advance! t))
 
-       ;; Apply events
-       (doseq [e events]
-         (when-let [t (:time e)]
-           (time.controlled/advance! t))
+     (doseq [stream streams]
+       (stream e)))
+     ;; Return captured events
 
-         (doseq [stream streams]
-           (stream e)))
-
-       ;; Return captured events
-       (->> *results*
-            (reduce (fn [results [tap-name results-atom]]
-                      (assoc! results tap-name @results-atom))
-                    (transient {}))
-            persistent!)))))
+   (->> *results*
+        (reduce (fn [results [tap-name results-atom]]
+                  (assoc! results tap-name @results-atom))
+                (transient {}))
+        persistent!)))
 
 (defn lookup
   "Lookup an event by host/service in a vector of tapped events returned by
@@ -173,10 +168,14 @@
   [name & body]
   `(test/deftest ~name
      (binding [*results* (fresh-results @*taps*)]
-       (time.controlled/with-controlled-time!
-         (time.controlled/reset-time!)
-
-         ~@body))))
+    (when (:index *core*)
+      (index/clear (:index *core*)))
+    (time.controlled/with-controlled-time!
+      (time.controlled/reset-time!)
+      (dorun (pmap #(riemann.service/reload! % *core*) (:services *core*)))
+      (dorun (pmap service/start! (:services *core*)))
+      ~@body
+      (dorun (pmap service/stop! (:services *core*)))))))
 
 (defmacro tests
   "Declares a new namespace named [ns]-test, requires some clojure.test and
@@ -201,7 +200,7 @@
   `(let [out# (atom [])
          stream# (~@stream (streams/append out#))]
      (time.controlled/reset-time!)
-     (doseq [e# ~inputs] 
+     (doseq [e# ~inputs]
        (when-let [t# (:time e#)]
          (time.controlled/advance! t#))
        (stream# e#))

--- a/src/riemann/transport/sse.clj
+++ b/src/riemann/transport/sse.clj
@@ -5,6 +5,7 @@
             [interval-metrics.core    :as metrics]
             [org.httpkit.server       :as http]
             [riemann.common           :as common]
+            [riemann.test              :as test]
             [riemann.pubsub           :refer [subscribe! unsubscribe!]]
             [riemann.instrumentation  :refer [Instrumented]]
             [riemann.service          :refer [Service ServiceEquiv]]
@@ -92,13 +93,14 @@
            (reset! core new-core))
 
   (start! [this]
-          (locking ioutil-lock
-            (locking this
-              (when-not @server
-                (reset! server (http/run-server
-                                 (sse-handler core stats headers)
-                                 {:ip host :port port}))
-                (info "SSE server" host port "online")))))
+          (when-not test/*testing*
+            (locking ioutil-lock
+              (locking this
+                (when-not @server
+                  (reset! server (http/run-server
+                                  (sse-handler core stats headers)
+                                  {:ip host :port port}))
+                  (info "SSE server" host port "online"))))))
 
   (stop! [this]
          (locking this

--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -23,6 +23,7 @@
            [io.netty.channel.nio NioEventLoopGroup]
            [io.netty.channel.socket.nio NioServerSocketChannel])
   (:require [less.awful.ssl :as ssl]
+            [riemann.test :as test]
             [interval-metrics.core :as metrics])
   (:use [clojure.tools.logging :only [info warn]]
         [interval-metrics.measure :only [measure-latency]]
@@ -144,43 +145,41 @@
            (reset! core new-core))
 
   (start! [this]
-          (locking ioutil-lock
-            (locking this
-              (when-not @killer
-                (let [event-loop-group-fn (:event-loop-group-fn
-                                            netty-implementation)
-                      boss-group (event-loop-group-fn)
-                      worker-group (event-loop-group-fn)
-                      bootstrap (ServerBootstrap.)]
-
-                  ; Configure bootstrap
-                  (doto bootstrap
-                    (.group boss-group worker-group)
-                    (.channel (:channel netty-implementation))
-                    (.option ChannelOption/SO_REUSEADDR true)
-                    (.option ChannelOption/SO_BACKLOG so-backlog)
-                    (.childOption ChannelOption/SO_REUSEADDR true)
-                    (.childOption ChannelOption/SO_KEEPALIVE true)
-                    (.childHandler initializer))
-
-                  ; Start bootstrap
-                  (->> (InetSocketAddress. host port)
-                       (.bind bootstrap)
-                       (.sync)
-                       (.channel)
-                       (.add channel-group))
-                  (info "TCP server" host port "online")
-
-                  ; fn to close server
-                  (reset! killer
-                          (fn killer []
-                            (.. channel-group close awaitUninterruptibly)
-                            ; Shut down workers and boss concurrently.
-                            (let [w (shutdown-event-executor-group worker-group)
-                                  b (shutdown-event-executor-group boss-group)]
-                              @w
-                              @b)
-                            (info "TCP server" host port "shut down"))))))))
+          (when-not test/*testing*
+            (locking ioutil-lock
+              (locking this
+                (when-not @killer
+                  (let [event-loop-group-fn (:event-loop-group-fn
+                                             netty-implementation)
+                        boss-group (event-loop-group-fn)
+                        worker-group (event-loop-group-fn)
+                        bootstrap (ServerBootstrap.)]
+                    ; Configure bootstrap
+                    (doto bootstrap
+                      (.group boss-group worker-group)
+                      (.channel (:channel netty-implementation))
+                      (.option ChannelOption/SO_REUSEADDR true)
+                      (.option ChannelOption/SO_BACKLOG so-backlog)
+                      (.childOption ChannelOption/SO_REUSEADDR true)
+                      (.childOption ChannelOption/SO_KEEPALIVE true)
+                      (.childHandler initializer))
+                    ; Start bootstrap
+                    (->> (InetSocketAddress. host port)
+                         (.bind bootstrap)
+                         (.sync)
+                         (.channel)
+                         (.add channel-group))
+                    (info "TCP server" host port "online")
+                    ; fn to close server
+                    (reset! killer
+                            (fn killer []
+                              (.. channel-group close awaitUninterruptibly)
+                                        ; Shut down workers and boss concurrently.
+                              (let [w (shutdown-event-executor-group worker-group)
+                                    b (shutdown-event-executor-group boss-group)]
+                                @w
+                                @b)
+                              (info "TCP server" host port "shut down")))))))))
 
   (stop! [this]
          (locking this

--- a/src/riemann/transport/udp.clj
+++ b/src/riemann/transport/udp.clj
@@ -17,7 +17,8 @@
            [io.netty.channel.group ChannelGroup]
            [io.netty.channel.socket.nio NioDatagramChannel]
            [io.netty.channel.nio NioEventLoopGroup])
-  (:require [interval-metrics.core :as metrics])
+  (:require [interval-metrics.core :as metrics]
+            [riemann.test :as test])
   (:use [clojure.tools.logging :only [warn info]]
         [clojure.string        :only [split]]
         [riemann.instrumentation :only [Instrumented]]
@@ -86,41 +87,41 @@
            (reset! core new-core))
 
   (start! [this]
-          (locking ioutil-lock
-            (locking this
-              (when-not @killer
-                (let [worker-group (NioEventLoopGroup.)
-                      bootstrap (Bootstrap.)]
+          (when-not test/*testing*
+            (locking ioutil-lock
+              (locking this
+                (when-not @killer
+                  (let [worker-group (NioEventLoopGroup.)
+                        bootstrap (Bootstrap.)]
+                    ; Configure bootstrap
+                    (doto bootstrap
+                      (.group worker-group)
+                      (.channel NioDatagramChannel)
+                      (.option ChannelOption/SO_BROADCAST false)
+                      (.option ChannelOption/MESSAGE_SIZE_ESTIMATOR
+                               (DefaultMessageSizeEstimator. max-size))
+                      (.option ChannelOption/RCVBUF_ALLOCATOR
+                               (FixedRecvByteBufAllocator. max-size))
+                      (.handler handler))
 
-                  ; Configure bootstrap
-                  (doto bootstrap
-                    (.group worker-group)
-                    (.channel NioDatagramChannel)
-                    (.option ChannelOption/SO_BROADCAST false)
-                    (.option ChannelOption/MESSAGE_SIZE_ESTIMATOR
-                             (DefaultMessageSizeEstimator. max-size))
-                    (.option ChannelOption/RCVBUF_ALLOCATOR
-                             (FixedRecvByteBufAllocator. max-size))
-                    (.handler handler))
+                    ; Setup Channel options
+                    (if (> so-rcvbuf 0) (.option bootstrap ChannelOption/SO_RCVBUF so-rcvbuf))
 
-                  ; Setup Channel options
-                  (if (> so-rcvbuf 0) (.option bootstrap ChannelOption/SO_RCVBUF so-rcvbuf))
+                    ; Start bootstrap
+                    (->> (InetSocketAddress. host port)
+                         (.bind bootstrap)
+                         (.sync)
+                         (.channel)
+                         (.add channel-group))
 
-                  ; Start bootstrap
-                  (->> (InetSocketAddress. host port)
-                       (.bind bootstrap)
-                       (.sync)
-                       (.channel)
-                       (.add channel-group))
+                    (info "UDP server" host port max-size so-rcvbuf "online")
 
-                  (info "UDP server" host port max-size so-rcvbuf "online")
-
-                  ; fn to close server
-                  (reset! killer
-                          (fn killer []
-                            (-> channel-group .close .awaitUninterruptibly)
-                            @(shutdown-event-executor-group worker-group)
-                            (info "UDP server" host port max-size so-rcvbuf "shut down"))))))))
+                    ; fn to close server
+                    (reset! killer
+                            (fn killer []
+                              (-> channel-group .close .awaitUninterruptibly)
+                              @(shutdown-event-executor-group worker-group)
+                              (info "UDP server" host port max-size so-rcvbuf "shut down")))))))))
 
   (stop! [this]
          (locking this

--- a/src/riemann/transport/websockets.clj
+++ b/src/riemann/transport/websockets.clj
@@ -4,6 +4,7 @@
   (:require [riemann.query         :as query]
             [riemann.index         :as index]
             [riemann.pubsub        :as p]
+            [riemann.test          :as test]
             [cheshire.core         :as json]
             [interval-metrics.core :as metrics]
             [org.httpkit.server    :as http])
@@ -182,12 +183,13 @@
            (reset! core new-core))
 
   (start! [this]
-          (locking this
-            (when-not @server
-              (reset! server (http/run-server (ws-handler core stats)
-                                              {:ip host
-                                               :port port}))
-              (info "Websockets server" host port "online"))))
+          (when-not test/*testing*
+            (locking this
+              (when-not @server
+                (reset! server (http/run-server (ws-handler core stats)
+                                                {:ip host
+                                                 :port port}))
+                (info "Websockets server" host port "online")))))
 
   (stop! [this]
          (locking this

--- a/test/riemann/core_test.clj
+++ b/test/riemann/core_test.clj
@@ -1,6 +1,7 @@
 (ns riemann.core-test
   (:require [riemann.client :refer :all]
             [riemann.common :refer [event]]
+            [riemann.config :as config]
             [riemann.core :refer :all]
             [riemann.index :refer [index]]
             [riemann.logging :as logging]
@@ -249,61 +250,53 @@
                  (stop! core))))))
 
 (deftest expires
-         (let [index (wrap-index (index))
-               res (atom nil)
-               expired-stream (riemann.streams/expired
-                                (fn [e] (reset! res e)))
-               reaper (reaper 0.001)
-               core (logging/suppress
-                      ["riemann.core"
-                       "riemann.transport.tcp"
-                       "riemann.pubsub"]
-                      (transition! (core) {:services [reaper]
-                                           :streams [expired-stream]
-                                           :index index}))]
+  (let [index (wrap-index (index))
+        res (atom nil)
+        expired-stream (riemann.streams/expired
+                        (fn [e] (reset! res e)))
+        reaper (reaper 0.1)
+        core (logging/suppress
+              ["riemann.core"
+               "riemann.transport.tcp"
+               "riemann.pubsub"]
+              (transition! (core) {:services [reaper]
+                                   :streams [expired-stream]
+                                   :index index}))]
 
-           ; Insert events
-           (index {:service 1 :ttl 0.01 :time (unix-time)})
-           (index {:service 2 :ttl 1 :time (unix-time)})
+    ;; Insert events
+    (index {:service 1 :ttl 0.05 :time (unix-time)})
+    (index {:service 2 :ttl 1 :time (unix-time)})
 
-           (advance! 0.011)
+    (advance! 0.11)
 
-           ; Wait for reaper to eat them
-           (Thread/sleep 100)
+    ;; Check that index does not contain these states
+    (is (= [2] (map (fn [e] (:service e)) index)))
 
-           ; Kill reaper
-           (logging/suppress ["riemann.core" "riemann.pubsub"]
-                             (stop! core))
-
-           ; Check that index does not contain these states
-           (is (= [2] (map (fn [e] (:service e)) index)))
-
-           ; Check that expired-stream received them.
-           (is (= @res
-                  {:service 1
-                   :time 0.011
-                   :state "expired"}))))
+    ;; Check that expired-stream received them.
+    (is (= @res
+           {:service 1
+            :time 0.1
+            :state "expired"}))))
 
 (deftest reaper-keep-keys
-         (let [index (wrap-index (index))
-               res (atom nil)
-               expired-stream (riemann.streams/expired
-                                (partial reset! res))
-               reaper (reaper 0.001 {:keep-keys [:tags]})
-               core (logging/suppress
-                      ["riemann.core"
-                       "riemann.transport.tcp"
-                       "riemann.pubsub"]
-                      (transition! (core) {:services [reaper]
-                                           :streams [expired-stream]
-                                           :index index}))]
+  (let [index (wrap-index (index))
+        res (atom nil)
+        expired-stream (riemann.streams/expired
+                        (partial reset! res))
+        reaper (reaper 0.1 {:keep-keys [:tags]})
+        core (logging/suppress
+              ["riemann.core"
+               "riemann.transport.tcp"
+               "riemann.pubsub"]
+              (transition! (core) {:services [reaper]
+                                   :streams [expired-stream]
+                                   :index index}))]
 
-           (index {:service 1 :ttl 0.01 :time 0 :tags ["hi"]})
-           (advance! 2)
-           (Thread/sleep 100)
-           (is (= @res {:tags ["hi"]
-                        :time 2
-                        :state "expired"}))))
+    (index {:service 1 :ttl 0.05 :time 0 :tags ["hi"]})
+    (advance! 0.11)
+    (is (= @res {:tags ["hi"]
+                 :time 0.1
+                 :state "expired"}))))
 
 (deftest ensures-event-times
   (let [out (promise)

--- a/test/riemann/service_test.clj
+++ b/test/riemann/service_test.clj
@@ -195,3 +195,19 @@
                       :time 5}]))
 
              (logging/suppress "riemann.service" (.stop! s)))))
+
+(deftest scheduled-task-service-test
+  (let [state (atom 0)
+        f (fn [_] (swap! state inc))
+        scheduled-service (scheduled-task-service :foo :foo 10 10 f)]
+    (start! scheduled-service)
+    (time.controlled/advance! 9)
+    (is (= @state 0))
+    (time.controlled/advance! 10)
+    (is (= @state 1))
+    (time.controlled/advance! 20)
+    (is (= @state 2))
+    (stop! scheduled-service)
+    (is (:cancelled @(:task scheduled-service)))
+    (time.controlled/advance! 100)
+    (is (= @state 2))))

--- a/test/riemann/test_test.clj
+++ b/test/riemann/test_test.clj
@@ -1,7 +1,8 @@
 (ns riemann.test-test
   "Who tests the testers?"
   (:require [riemann.streams :refer :all]
-            [riemann.test :refer [tap io with-test-env inject!]]
+            [riemann.test :refer [tap io with-test-env inject! fresh-results *results* *taps*]]
+            [riemann.time.controlled :refer :all]
             [clojure.test :refer :all]))
 
 (defmacro bound
@@ -29,15 +30,18 @@
            (ns riemann.test-test)
            (let [downstream (promise)
                  s (rate 5 (tap :cask (partial deliver downstream)))]
-             (is (= (inject! [s]
-                             [{:time 0 :metric 0}
-                              {:time 1 :metric 1}
-                              {:time 2 :metric 2}
-                              {:time 3 :metric 3}
-                              {:time 4 :metric 4}
-                              {:time 5 :metric 5}])
-                    {:cask [{:time 5 :metric 2}]}))
-             (is (= @downstream {:time 5 :metric 2}))))))))
+             (with-controlled-time!
+               (reset-time!)
+               (binding [*results* (fresh-results @*taps*)]
+                         (is (= (inject! [s]
+                                         [{:time 0 :metric 0}
+                                          {:time 1 :metric 1}
+                                          {:time 2 :metric 2}
+                                          {:time 3 :metric 3}
+                                          {:time 4 :metric 4}
+                                          {:time 5 :metric 5}])
+                                {:cask [{:time 5 :metric 2}]}))
+                         (is (= @downstream {:time 5 :metric 2}))))))))))
 
 (deftest io-suppression
   (with-test-env

--- a/test/riemann/transport_test.clj
+++ b/test/riemann/transport_test.clj
@@ -197,3 +197,27 @@
         (finally
           (.close sock)
           (stop! core))))))
+
+(deftest tcp-server-testing-test
+  (let [server (tcp-server {:port 15555})]
+    (binding [riemann.test/*testing* true]
+      (riemann.service/start! server)
+      (is (= nil @(:killer server))))))
+
+(deftest udp-server-testing-test
+  (let [server (udp-server {:port 15555})]
+    (binding [riemann.test/*testing* true]
+      (riemann.service/start! server)
+      (is (= nil @(:killer server))))))
+
+(deftest sse-server-testing-test
+  (let [server (sse-server)]
+    (binding [riemann.test/*testing* true]
+      (riemann.service/start! server)
+      (is (= nil @(:server server))))))
+
+(deftest websocket-server-testing-test
+  (let [server (ws-server)]
+    (binding [riemann.test/*testing* true]
+      (riemann.service/start! server)
+      (is (= nil @(:server server))))))


### PR DESCRIPTION
cf #838 for PR description

- Mock a core in test mode
- The reaper is now a task and not a service, so it will run on the Riemann scheduler.
- Also replaced "aphyr.com" by "127.0.0.1" in influxdb tests, because dns resolution breaks the test suite if offline mode ;)

This PR needs more tests/reviews, but i wanted to show the code now to get feedback on it.
