### PR TITLE
Refactor test imports and fix indentation

### DIFF
--- a/test/riemann/blueflood_test.clj
+++ b/test/riemann/blueflood_test.clj
@@ -1,15 +1,14 @@
 (ns riemann.blueflood-test
-  (:use riemann.blueflood
-        riemann.streams
-        riemann.time.controlled
-        riemann.time
-        [riemann.test :refer [run-stream]]
-        [riemann.config :refer [apply!]]
-        clojure.test)
-  (:require 
+  (:require [riemann.blueflood :refer :all]
+            [riemann.config :refer [apply!]]
             [riemann.logging :as logging]
+            [riemann.streams :refer :all]
+            [riemann.test :refer [run-stream]]
+            [riemann.time.controlled :refer :all]
+            [riemann.time :refer :all]
             [cheshire.core :as json]
-            [clj-http.client :as client]))
+            [clj-http.client :as client]
+            [clojure.test :refer :all]))
 
 (logging/init)
 
@@ -25,7 +24,7 @@
 (defn test-helper [opts]
   (let [service (str (java.util.UUID/randomUUID))
         host "a"
-        query-url (format query-url-template host service) 
+        query-url (format query-url-template host service)
         timestamp 3
         value 3
         input

--- a/test/riemann/boundary_test.clj
+++ b/test/riemann/boundary_test.clj
@@ -1,10 +1,10 @@
 (ns riemann.boundary-test
-  (:use riemann.boundary
-        [riemann.time :only [unix-time]]
-        clojure.test)
-  (:require [clj-http.client :as client]
+  (:require [riemann.boundary :refer :all]
             [riemann.logging :as logging]
-            [riemann.test-utils :refer [with-mock]]))
+            [riemann.test-utils :refer [with-mock]]
+            [riemann.time :refer [unix-time]]
+            [clj-http.client :as client]
+            [clojure.test :refer :all]))
 
 (logging/init)
 

--- a/test/riemann/cloudwatch_test.clj
+++ b/test/riemann/cloudwatch_test.clj
@@ -1,48 +1,46 @@
 (ns riemann.cloudwatch-test
-  (:use riemann.cloudwatch
-        [riemann.time :only [unix-time]]
-        clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:require [riemann.cloudwatch :refer :all]
+            [riemann.logging :as logging]
+            [riemann.time :refer [unix-time]]
+            [clojure.test :refer :all]))
 
 (logging/init)
 
 (deftest ^:cloudwatch ^:integration cloudwatch-test
-         (let [k (cloudwatch {:access-key "aws-access-key"
-                              :secret-key "aws-secret-key"})]
-           (k {:host "riemann.local"
-               :service "cloudwatch test"
-               :state "ok"
-               :description "all clear, uh, situation normal"
-               :metric -2
-               :time (unix-time)}))
+  (let [k (cloudwatch {:access-key "aws-access-key"
+                       :secret-key "aws-secret-key"})]
+    (k {:host "riemann.local"
+        :service "cloudwatch test"
+        :state "ok"
+        :description "all clear, uh, situation normal"
+        :metric -2
+        :time (unix-time)}))
 
-         (let [k (cloudwatch {:access-key "aws-access-key"
-                              :secret-key "aws-secret-key"})]
-           (k {:service "cloudwatch test"
-               :state "ok"
-               :description "all clear, uh, situation normal"
-               :metric 3.14159
-               :time (unix-time)}))
+  (let [k (cloudwatch {:access-key "aws-access-key"
+                       :secret-key "aws-secret-key"})]
+    (k {:service "cloudwatch test"
+        :state "ok"
+        :description "all clear, uh, situation normal"
+        :metric 3.14159
+        :time (unix-time)}))
 
-         (let [k (cloudwatch {:access-key "aws-access-key"
-                              :secret-key "aws-secret-key"})]
-           (k {:host "no-service.riemann.local"
-               :state "ok"
-               :description "Missing service, not transmitted"
-               :metric 4
-               :time (unix-time)}))
+  (let [k (cloudwatch {:access-key "aws-access-key"
+                       :secret-key "aws-secret-key"})]
+    (k {:host "no-service.riemann.local"
+        :state "ok"
+        :description "Missing service, not transmitted"
+        :metric 4
+        :time (unix-time)}))
 
-         (let [k (cloudwatch {:access-key "aws-access-key"
-                              :secret-key "aws-secret-key"})]
-           (k [
-               {:host "no-service.riemann.local"
-                :state "ok"
-                :description "Missing service, not transmitted"
-                :metric 4
-                :time (unix-time)},
-               {:host "no-service.riemann.local"
-                :state "ok"
-                :description "Missing service, not transmitted"
-                :metric 4
-                :time (unix-time)}
-              ])))
+  (let [k (cloudwatch {:access-key "aws-access-key"
+                       :secret-key "aws-secret-key"})]
+    (k [{:host "no-service.riemann.local"
+         :state "ok"
+         :description "Missing service, not transmitted"
+         :metric 4
+         :time (unix-time)},
+        {:host "no-service.riemann.local"
+         :state "ok"
+         :description "Missing service, not transmitted"
+         :metric 4
+         :time (unix-time)}])))

--- a/test/riemann/common_test.clj
+++ b/test/riemann/common_test.clj
@@ -1,93 +1,92 @@
 (ns riemann.common-test
-  (:use riemann.common)
-  (:use clojure.test))
+  (:require [riemann.common :refer :all]
+            [clojure.test :refer :all]))
 
 (deftest iso8601->unix-test
-         (let [times (map iso8601->unix
-                          ["2013-04-15T18:06:58-07:00"
-                          "2013-04-15T18:06:58.123+11:00"
-                           "2013-04-15T18:06:58Z"
-                           "2013-04-15"])]
-           (is (= times [1366074418
-                         1366009618
-                         1366049218
-                         1365984000]))))
+  (let [times (map iso8601->unix
+                   ["2013-04-15T18:06:58-07:00"
+                    "2013-04-15T18:06:58.123+11:00"
+                    "2013-04-15T18:06:58Z"
+                    "2013-04-15"])]
+    (is (= times [1366074418
+                  1366009618
+                  1366049218
+                  1365984000]))))
 
 (deftest subset-test
-         (are [a b] (subset? a b)
-              []    []
-              []    [1 2 3]
-              [1]   [1]
-              [1]   [2 1 3]
-              [1 2] [1 2 3]
-              [1 2] [2 3 1])
+  (are [a b] (subset? a b)
+    []    []
+    []    [1 2 3]
+    [1]   [1]
+    [1]   [2 1 3]
+    [1 2] [1 2 3]
+    [1 2] [2 3 1])
 
-         (are [a b] (not (subset? a b))
-              [1]   []
-              [1 2] [1]
-              [1]   [2]
-              [1]   [2 3]
-              [1 2] [1 3]
-              [1 2] [3 1]))
+  (are [a b] (not (subset? a b))
+    [1]   []
+    [1 2] [1]
+    [1]   [2]
+    [1]   [2 3]
+    [1 2] [1 3]
+    [1 2] [3 1]))
 
 (deftest overlap-test
-         (are [a b] (overlap? a b)
-              [1 2] [1]
-              [1]   [1]
-              [1 2] [2 3]
-              [3 2] [1 3]
-              [1 3] [3 1])
+  (are [a b] (overlap? a b)
+    [1 2] [1]
+    [1]   [1]
+    [1 2] [2 3]
+    [3 2] [1 3]
+    [1 3] [3 1])
 
-         (are [a b] (not (overlap? a b))
-              []     []
-              [1]    []
-              [1]    [2]
-              [3]    [1 2]
-              [1 2]  [3 4]))
+  (are [a b] (not (overlap? a b))
+    []     []
+    [1]    []
+    [1]    [2]
+    [3]    [1 2]
+    [1 2]  [3 4]))
 
 (deftest disjoint-test
-         (are [a b] (disjoint? a b)
-              []     []
-              [1]    []
-              [1]    [2]
-              [3]    [1 2]
-              [1 2]  [3 4])
+  (are [a b] (disjoint? a b)
+    []     []
+    [1]    []
+    [1]    [2]
+    [3]    [1 2]
+    [1 2]  [3 4])
 
-         (are [a b] (not (disjoint? a b))
-              [1 2] [1]
-              [1]   [1]
-              [1 2] [2 3]
-              [3 2] [1 3]
-              [1 3] [3 1]))
+  (are [a b] (not (disjoint? a b))
+    [1 2] [1]
+    [1]   [1]
+    [1 2] [2 3]
+    [3 2] [1 3]
+    [1 3] [3 1]))
 
 (deftest subject-test
-         (let [s #'subject]
-           (are [events subject] (= (s events) subject)
-                [] ""
+  (let [s #'subject]
+    (are [events subject] (= (s events) subject)
+      [] ""
 
-                [{}] ""
+      [{}] ""
 
-                [{:host "foo"}] "foo"
+      [{:host "foo"}] "foo"
 
-                [{:host "foo"} {:host "bar"}] "foo and bar"
+      [{:host "foo"} {:host "bar"}] "foo and bar"
 
-                [{:host "foo"} {:host "bar"} {:host "baz"}]
-                "foo, bar, baz"
+      [{:host "foo"} {:host "bar"} {:host "baz"}]
+      "foo, bar, baz"
 
-                [{:host "foo"} {:host "baz"} {:host "bar"} {:host "baz"}]
-                "foo, baz, bar"
+      [{:host "foo"} {:host "baz"} {:host "bar"} {:host "baz"}]
+      "foo, baz, bar"
 
-                [{:host 1} {:host 2} {:host 3} {:host 4} {:host 5}]
-                "5 hosts"
+      [{:host 1} {:host 2} {:host 3} {:host 4} {:host 5}]
+      "5 hosts"
 
-                [{:host "foo" :state "ok"}] "foo ok"
+      [{:host "foo" :state "ok"}] "foo ok"
 
-                [{:host "foo" :state "ok"} {:host "bar" :state "ok"}]
-                "foo and bar ok"
+      [{:host "foo" :state "ok"} {:host "bar" :state "ok"}]
+      "foo and bar ok"
 
-                [{:host "foo" :state "error"} {:host "bar" :state "ok"}]
-                "foo and bar error and ok"
-                )))
+      [{:host "foo" :state "error"} {:host "bar" :state "ok"}]
+      "foo and bar error and ok")))
 
 (deftest count-string-bytes-test
   (is (= (count-string-bytes "") 0))
@@ -124,7 +123,7 @@
 
   (let [e (ex-info "fake test error" {})]
     (is (= e
-         (:exception (exception->event e)))))
+           (:exception (exception->event e)))))
 
   (is (= "original-event"
          (:service (:event (exception->event (ex-info "fake test error" {}) {:service "original-event"}))))))

--- a/test/riemann/config_test.clj
+++ b/test/riemann/config_test.clj
@@ -1,13 +1,13 @@
 (ns riemann.config-test
-  (:use riemann.config
-        clojure.test
-        [riemann.common :only [event]]
-        [riemann.index :only [Index]])
-  (:require [riemann.core :as core]
-            [riemann.pubsub :as pubsub]
+  (:require [riemann.common :refer [event]]
+            [riemann.config :refer :all]
+            [riemann.core :as core]
+            [riemann.index :refer [Index]]
             [riemann.logging :as logging]
+            [riemann.pubsub :as pubsub]
             [riemann.service :as service]
-            [riemann.streams :as streams])
+            [riemann.streams :as streams]
+            [clojure.test :refer :all])
   (:import (java.util.concurrent RejectedExecutionException)))
 
 ; (set! *print-level* 4)
@@ -28,22 +28,22 @@
 (use-fixtures :each reset-core!)
 
 (deftest blank-test
-         (is (empty? (:streams @core)))
-         (is (empty? (:streams @next-core)))
-         (is (every? true? (map service/equiv?
-                                (:services @core)
-                                (:services (core/core)))))
-         (is (every? true? (map service/equiv?
-                                (:services @next-core)
-                                (:services (core/core))))))
+  (is (empty? (:streams @core)))
+  (is (empty? (:streams @next-core)))
+  (is (every? true? (map service/equiv?
+                         (:services @core)
+                         (:services (core/core)))))
+  (is (every? true? (map service/equiv?
+                         (:services @next-core)
+                         (:services (core/core))))))
 
 (deftest apply-test
-         (is (not= @core @next-core))
-         (let [old-next-core @next-core]
-           (apply!)
-           (is (= (dissoc old-next-core :pubsub :services)
-                  (dissoc @core :pubsub :services)))
-           (is (not= @core @next-core))))
+  (is (not= @core @next-core))
+  (let [old-next-core @next-core]
+    (apply!)
+    (is (= (dissoc old-next-core :pubsub :services)
+           (dissoc @core :pubsub :services)))
+    (is (not= @core @next-core))))
 
 (defn verify-service
   "Tests that the given service a.) is a service, b.) is in the next core, and
@@ -59,47 +59,47 @@
   (is (some #{s} (:services @next-core))))
 
 (deftest service-test
-         (let [sleep (fn [_] (Thread/sleep 1))]
-           (testing "Adds an equivalent service to a core."
-                    (let [s1 (service! (service/thread-service :foo sleep))]
-                      (satisfies? service/Service s1)
-                      (apply!)
-                      (is (some #{s1} (:services @core)))
-                      (is (deref (:running s1)))
+  (let [sleep (fn [_] (Thread/sleep 1))]
+    (testing "Adds an equivalent service to a core."
+      (let [s1 (service! (service/thread-service :foo sleep))]
+        (satisfies? service/Service s1)
+        (apply!)
+        (is (some #{s1} (:services @core)))
+        (is (deref (:running s1)))
 
-                      ; Now add an equivalent service
-                      (let [s (service/thread-service :foo sleep)
-                            s2 (service! s)]
-                        (is (= s1 s2))
-                        (is (not= s s2))
-                        (apply!)
-                        (is (deref (:running s1)))
-                        (is (not (deref (:running s))))
-                        (is (some #{s1} (:services @core)))
-                        (is (not (some #{s} (:services @core)))))))
+                                        ; Now add an equivalent service
+        (let [s (service/thread-service :foo sleep)
+              s2 (service! s)]
+          (is (= s1 s2))
+          (is (not= s s2))
+          (apply!)
+          (is (deref (:running s1)))
+          (is (not (deref (:running s))))
+          (is (some #{s1} (:services @core)))
+          (is (not (some #{s} (:services @core)))))))
 
-           (testing "Adds a distinct service to a core."
-                    (let [defaults (set (:services @next-core))
-                          s1 (service! (service/thread-service :foo sleep))]
-                      (satisfies? service/Service s1)
-                      (apply!)
-                      (is (some #{s1} (:services @core)))
-                      (is (deref (:running s1)))
+    (testing "Adds a distinct service to a core."
+      (let [defaults (set (:services @next-core))
+            s1 (service! (service/thread-service :foo sleep))]
+        (satisfies? service/Service s1)
+        (apply!)
+        (is (some #{s1} (:services @core)))
+        (is (deref (:running s1)))
 
-                      ; Add a distinct service. S1 should shut down since
-                      ; it is no longer present in the new target core.
-                      (let [s2 (service! (service/thread-service :bar sleep))]
-                        (is (not= s1 s2))
-                        (apply!)
-                        (is (not (deref (:running s1))))
-                        (is (deref (:running s2)))
-                        (is (some #{s2} (:services @core)))
-                        (is (not (some #{s1} (:services @core)))))))))
+        ; Add a distinct service. S1 should shut down since
+        ; it is no longer present in the new target core.
+        (let [s2 (service! (service/thread-service :bar sleep))]
+          (is (not= s1 s2))
+          (apply!)
+          (is (not (deref (:running s1))))
+          (is (deref (:running s2)))
+          (is (some #{s2} (:services @core)))
+          (is (not (some #{s1} (:services @core)))))))))
 
 (deftest instrumentation-test
-         (let [s (verify-service (instrumentation {:interval 2
-                                                   :enabled? false}))]
-           (is (= [2000 false] (:equiv-key s)))))
+  (let [s (verify-service (instrumentation {:interval 2
+                                            :enabled? false}))]
+    (is (= [2000 false] (:equiv-key s)))))
 
 (deftest tcp-server-test
   (verify-service (tcp-server :host "a"))
@@ -122,103 +122,103 @@
   (verify-service (graphite-server {:port 1})))
 
 (deftest streams-test
-         (streams :a)
-         (streams :b)
-         (is (= [:a :b] (:streams @next-core)))
-         (is (empty? (:streams @core))))
+  (streams :a)
+  (streams :b)
+  (is (= [:a :b] (:streams @next-core)))
+  (is (empty? (:streams @core))))
 
 (deftest index-test
-         (let [i (index)]
-           (testing "index creation helper creates the index properly"
-             (is (satisfies? Index i))
-             (is (= i (:index @next-core)))
-             (is (nil? (:index @core))))
-           (testing "index is applied to the core properly during initial load"
-             (apply!)
-             (is (identical? i (:index @core))))
-           (testing "we have the proper reference to the index after a reload"
-             (let [i' (index)]
-               (is (identical? i' (:index @next-core)))
-               (is (identical? i' (:index @core)))
-               (apply!)
-               (is (identical? i' (:index @core)))))))
+  (let [i (index)]
+    (testing "index creation helper creates the index properly"
+      (is (satisfies? Index i))
+      (is (= i (:index @next-core)))
+      (is (nil? (:index @core))))
+    (testing "index is applied to the core properly during initial load"
+      (apply!)
+      (is (identical? i (:index @core))))
+    (testing "we have the proper reference to the index after a reload"
+      (let [i' (index)]
+        (is (identical? i' (:index @next-core)))
+        (is (identical? i' (:index @core)))
+        (apply!)
+        (is (identical? i' (:index @core)))))))
 
 (deftest update-index-test
-         (let [i (index)]
-           (apply!)
-           (i {:service 1 :state "ok" :time 0})
-           (is (= (seq i) [{:service 1 :state "ok" :time 0}]))
-           (testing "ensure that index state persists through reloads"
-             (let [i' (index)]
-               (apply!)
-               (is (= (seq i') [{:service 1 :state "ok" :time 0}]))))))
+  (let [i (index)]
+    (apply!)
+    (i {:service 1 :state "ok" :time 0})
+    (is (= (seq i) [{:service 1 :state "ok" :time 0}]))
+    (testing "ensure that index state persists through reloads"
+      (let [i' (index)]
+        (apply!)
+        (is (= (seq i') [{:service 1 :state "ok" :time 0}]))))))
 
 (deftest delete-from-index-test
-         (let [i (index)
-               delete (delete-from-index)
-               states [{:host 1 :state "ok" :time 0}
-                       {:host 2 :state "ok" :time 0}
-                       {:host 1 :state "bad" :time 0}]]
-           (apply!)
-           (dorun (map i states))
-           (delete {:host 1 :state "definitely not seen before"})
-           (is (= (seq i) [{:host 2 :state "ok" :time 0}]))))
+  (let [i (index)
+        delete (delete-from-index)
+        states [{:host 1 :state "ok" :time 0}
+                {:host 2 :state "ok" :time 0}
+                {:host 1 :state "bad" :time 0}]]
+    (apply!)
+    (dorun (map i states))
+    (delete {:host 1 :state "definitely not seen before"})
+    (is (= (seq i) [{:host 2 :state "ok" :time 0}]))))
 
 (deftest delete-from-index-fields
-         (let [i (index)
-               delete (delete-from-index [:host :state])]
-           (apply!)
-           (i {:host 1 :state "foo" :time 0})
-           (i {:host 2 :state "bar" :time 0})
-           (delete {:host 1 :state "not seen"})
-           (delete {:host 2 :state "bar"})
-           (is (= (seq i) [{:host 1 :state "foo" :time 0}]))))
+  (let [i (index)
+        delete (delete-from-index [:host :state])]
+    (apply!)
+    (i {:host 1 :state "foo" :time 0})
+    (i {:host 2 :state "bar" :time 0})
+    (delete {:host 1 :state "not seen"})
+    (delete {:host 2 :state "bar"})
+    (is (= (seq i) [{:host 1 :state "foo" :time 0}]))))
 
 (deftest async-queue-test
-         (let [out    (atom [])
-               p      (promise)
-               stream (async-queue! :test {}
-                                    (fn [event]
-                                      (swap! out conj event)
-                                      (deliver p nil)))]
-           (is (thrown? RejectedExecutionException
-                        (stream :foo)))
-           (apply!)
-           (stream :bar)
-           (deref p)
-           (is (= [:bar] @out))))
+  (let [out    (atom [])
+        p      (promise)
+        stream (async-queue! :test {}
+                             (fn [event]
+                               (swap! out conj event)
+                               (deliver p nil)))]
+    (is (thrown? RejectedExecutionException
+                 (stream :foo)))
+    (apply!)
+    (stream :bar)
+    (deref p)
+    (is (= [:bar] @out))))
 
 (deftest reinject-test
   (let [event (promise)]
     (streams
-      (streams/where (service "bar")
-                     (partial deliver event))
-      (streams/where (service "foo")
-                     (streams/with :service "bar" reinject)))
+     (streams/where (service "bar")
+                    (partial deliver event))
+     (streams/where (service "foo")
+                    (streams/with :service "bar" reinject)))
     (apply!)
     (core/stream! @core {:service "foo" :metric 2 :time 0})
     (is (= (deref event 10 :timeout) {:service "bar" :metric 2 :time 0}))))
 
 (deftest subscribe-in-stream-test
-         (let [received (promise)]
-           (streams
-             (streams/where (service "test-in")
-                            (publish :test))
-             (subscribe :test (partial deliver received)))
-           (apply!)
+  (let [received (promise)]
+    (streams
+     (streams/where (service "test-in")
+                    (publish :test))
+     (subscribe :test (partial deliver received)))
+    (apply!)
 
-           ; Send through streams
-           ((first (:streams @core)) {:service "test-in"})
-           (is (= {:service "test-in"} @received))))
+    ; Send through streams
+    ((first (:streams @core)) {:service "test-in"})
+    (is (= {:service "test-in"} @received))))
 
 (deftest subscribe-outside-stream-test
-         (let [received (promise)]
-           (subscribe :test (partial deliver received))
-           (apply!)
+  (let [received (promise)]
+    (subscribe :test (partial deliver received))
+    (apply!)
 
-           ; Send outside streams
-           (pubsub/publish! (:pubsub @core) :test "hi")
-           (is (= "hi" @received))))
+    ; Send outside streams
+    (pubsub/publish! (:pubsub @core) :test "hi")
+    (is (= "hi" @received))))
 
 (deftest index-pubsub-test
   (let [received (promise)


### PR DESCRIPTION
Sometimes Riemann uses `:uses` for import, sometimes `:require`, sometimes both. I think we should only use `:require` (as advised since clojure 1.4).

Also, Indentation is sometimes different even between differents functions in the same file, so it would be nice to reindent some functions.

This PR do it for the first 6 namespaces in riemann.test. If you are OK with that, i can do the PRs for every namespaces in Riemann (6 namespaces/PR to avoid big PR).
