### PR TITLE
Allow for not using `index-suffix`

### DIFF
--- a/src/riemann/elasticsearch.clj
+++ b/src/riemann/elasticsearch.clj
@@ -73,7 +73,9 @@
             es-endpoint (format "%s/%s%s/%s"
                                 (:es-endpoint opts)
                                 (:es-index opts)
-                                (time-format/unparse (time-format/formatter (:index-suffix opts)) (datetime-from-event event))
+                                (if (empty? (:index-suffix opts))
+                                  ""
+                                  (time-format/unparse (time-format/formatter (:index-suffix opts)) (datetime-from-event event)))
                                 (:type opts))
             http-options {}]
         (post


### PR DESCRIPTION
Currently, if `index-suffix` is set to `nil` or an empty string, you get an error because `time-format/formatter` won't accept it.

This patch makes it possible to not use an `index-suffix`.