### PR TITLE
Use clj-nsca fork

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
     [riemann-clojure-client "0.4.5"]
     [less-awful-ssl "1.0.1"]
     [slingshot "0.12.2"]
-    [clj-nsca "0.0.3"]
+    [cljr-nsca "0.0.3"]
     [amazonica "0.3.95" :exclusions [joda-time]]
     [spootnik/kinsky "0.1.16"]
     [pjstadig/humane-test-output "0.8.1"]]

--- a/src/riemann/nagios.clj
+++ b/src/riemann/nagios.clj
@@ -1,6 +1,6 @@
 (ns riemann.nagios
   "Forwards events to Nagios via NSCA"
-  (:require [clj-nsca.core :as nsca]))
+  (:require [cljr-nsca.core :as nsca]))
 
 (def NONE nsca/NO_ENCRYPTION)
 (def XOR nsca/XOR_ENCRYPTION)

--- a/test/riemann/nagios_test.clj
+++ b/test/riemann/nagios_test.clj
@@ -1,6 +1,6 @@
 (ns riemann.nagios-test
   (:use riemann.nagios
-        clj-nsca.core
+        cljr-nsca.core
         clojure.test)
   (:require [riemann.logging :as logging]))
 
@@ -22,6 +22,6 @@
 (deftest test-stream
   (testing "Events get transformed and are sent"
   (let [message (atom nil)]
-    (with-redefs [clj-nsca.core/send-message (fn [_ msg] (reset! message msg))]
+    (with-redefs [cljr-nsca.core/send-message (fn [_ msg] (reset! message msg))]
       ((nagios {}) test-event))
     (is (= expected @message)))))


### PR DESCRIPTION
Fix #870 

I forked clj-nsca, renamed cljr-nsca, and uploaded it to clojars.