### PR TITLE
Refactor test imports

### DIFF
--- a/test/riemann/core_test.clj
+++ b/test/riemann/core_test.clj
@@ -1,16 +1,14 @@
 (ns riemann.core-test
-  (:require riemann.transport.tcp
-            riemann.streams
-            [riemann.logging :as logging])
-  (:use riemann.client
-        riemann.common
-        [riemann.index :only [index]]
-        riemann.time.controlled
-        riemann.core
-        clojure.test
-        [clojure.algo.generic.functor :only [fmap]]
-        [riemann.service :only [Service ServiceEquiv]]
-        [riemann.time :only [unix-time]]))
+  (:require [riemann.client :refer :all]
+            [riemann.common :refer [event]]
+            [riemann.core :refer :all]
+            [riemann.index :refer [index]]
+            [riemann.logging :as logging]
+            [riemann.time :refer [unix-time]]
+            [riemann.time.controlled :refer :all]
+            [riemann.service :refer [Service ServiceEquiv]]
+            [clojure.algo.generic.functor :refer [fmap]]
+            [clojure.test :refer :all]))
 
 (logging/init)
 (use-fixtures :each reset-time!)

--- a/test/riemann/datadog_test.clj
+++ b/test/riemann/datadog_test.clj
@@ -1,8 +1,8 @@
 (ns riemann.datadog-test
-  (:use riemann.datadog
-        [riemann.time :only [unix-time]]
-        clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:require [riemann.datadog :refer :all]
+            [riemann.logging :as logging]
+            [riemann.time :refer [unix-time]]
+            [clojure.test :refer :all]))
 
 (def datadog-key (or (System/getenv "DATADOG_API_KEY")
                      (do (println "export DATADOG_API_KEY=\"...\" to run these tests.")

--- a/test/riemann/deps_test.clj
+++ b/test/riemann/deps_test.clj
@@ -1,13 +1,9 @@
 (ns riemann.deps-test
-  (:require [riemann.index  :as index]
-            [riemann.core   :refer [wrap-index]]
-            [riemann.common :refer [event]]
+  (:require [riemann.common :refer [event]]
+            [riemann.core   :refer :all ]
             [riemann.deps   :refer :all]
-            [clojure.test   :refer :all])
-  (:use riemann.deps
-        riemann.core
-        [riemann.common :only [event]]
-        clojure.test))
+            [riemann.index  :as index]
+            [clojure.test   :refer :all]))
 
 (defn context [events]
   (let [i (wrap-index (index/nbhm-index))]

--- a/test/riemann/druid_test.clj
+++ b/test/riemann/druid_test.clj
@@ -1,9 +1,9 @@
 (ns riemann.druid-test
-  (:require [clj-http.client :as client]
-            [clojure.test :refer :all]
-            [riemann.druid :as druid]
+  (:require [riemann.druid :as druid]
             [riemann.logging :as logging]
-            [riemann.test-utils :refer [with-mock]]))
+            [riemann.test-utils :refer [with-mock]]
+            [clj-http.client :as client]
+            [clojure.test :refer :all]))
 
 (logging/init)
 

--- a/test/riemann/elasticsearch_test.clj
+++ b/test/riemann/elasticsearch_test.clj
@@ -1,10 +1,10 @@
 (ns riemann.elasticsearch-test
-  (:use riemann.elasticsearch
-        clojure.test)
-  (:require [clj-http.client :as http]
-            [cheshire.core :as json]
+  (:require [riemann.elasticsearch :refer :all]
+            [riemann.logging :as logging]
             [riemann.test-utils :refer [with-mock]]
-            [riemann.logging :as logging]))
+            [cheshire.core :as json]
+            [clj-http.client :as http]
+            [clojure.test :refer :all]))
 
 (logging/init)
 

--- a/test/riemann/email_test.clj
+++ b/test/riemann/email_test.clj
@@ -1,8 +1,8 @@
 (ns riemann.email-test
-  (:use [riemann.time :only [unix-time]]
-        riemann.email
-        [riemann.logging :only [suppress]]
-        clojure.test))
+  (:require [riemann.email :refer :all]
+            [riemann.logging :refer [suppress]]
+            [riemann.time :refer [unix-time]]
+            [clojure.test :refer :all]))
 
 (riemann.logging/init)
 
@@ -10,10 +10,10 @@
          (let [a (promise)]
            (with-redefs [postal.core/send-message #(deliver a [%1 %2])]
              (email-event {} {:body (fn [events]
-                                      (apply str "body " 
+                                      (apply str "body "
                                              (map :service events)))
-                              :subject (fn [events] 
-                                         (apply str "subject " 
+                              :subject (fn [events]
+                                         (apply str "subject "
                                                 (map :service events)))}
                           {:service "foo"}))
            (is (= @a [{} {:subject "subject foo"

--- a/test/riemann/expiration_test.clj
+++ b/test/riemann/expiration_test.clj
@@ -1,8 +1,8 @@
 (ns riemann.expiration-test
-  (:require [clojure.test :refer :all]
-            [riemann.expiration :refer :all]
+  (:require [riemann.expiration :refer :all]
+            [riemann.time :refer [unix-time]]
             [riemann.time.controlled :refer :all]
-            [riemann.time :refer [unix-time]]))
+            [clojure.test :refer :all]))
 
 (use-fixtures :once control-time!)
 (use-fixtures :each reset-time!)

--- a/test/riemann/folds_test.clj
+++ b/test/riemann/folds_test.clj
@@ -1,10 +1,10 @@
 (ns riemann.folds-test
   (:refer-clojure :exclude [count])
-  (:use [riemann.common :only [event]]
-        riemann.folds
-        riemann.time
-        riemann.time.controlled
-        clojure.test))
+  (:require [riemann.common :refer [event]]
+            [riemann.folds :refer :all]
+            [riemann.time :refer :all]
+            [riemann.time.controlled :refer :all]
+            [clojure.test :refer :all]))
 
 (use-fixtures :once control-time!)
 (use-fixtures :each reset-time!)

--- a/test/riemann/graphite_test.clj
+++ b/test/riemann/graphite_test.clj
@@ -1,15 +1,15 @@
 (ns riemann.graphite-test
-  (:use riemann.graphite
-        [riemann.time :only [unix-time]]
-        [riemann.common :only [event]]
-        clojure.tools.logging
-        clojure.test)
-  (:require [riemann.logging :as logging]
+  (:require [riemann.common :refer [event]]
             [riemann.client :as client]
-            [riemann.index :as index]
             [riemann.core :refer [transition! core stop! wrap-index]]
+            [riemann.graphite :refer :all]
+            [riemann.index :as index]
+            [riemann.logging :as logging]
+            [riemann.time :refer [unix-time]]
             [riemann.transport.tcp :refer [tcp-server]]
-            [riemann.transport.graphite :refer [graphite-server]]))
+            [riemann.transport.graphite :refer [graphite-server]]
+            [clojure.test :refer :all]
+            [clojure.tools.logging :refer :all]))
 
 (logging/init)
 

--- a/test/riemann/hipchat_test.clj
+++ b/test/riemann/hipchat_test.clj
@@ -1,7 +1,7 @@
 (ns riemann.hipchat-test
-  (:use riemann.hipchat
-        clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:require [riemann.hipchat :refer :all]
+            [riemann.logging :as logging]
+            [clojure.test :refer :all]))
 
 (def server (System/getenv "HIPCHAT_SERVER"))
 (def api-key (System/getenv "HIPCHAT_API_KEY"))

--- a/test/riemann/index_test.clj
+++ b/test/riemann/index_test.clj
@@ -1,13 +1,13 @@
 (ns riemann.index-test
   (:refer-clojure :exclude [update])
-  (:use riemann.index
-        riemann.core
-        riemann.query
-        [riemann.instrumentation :only [events]]
-        [riemann.common :only [event]]
-        [riemann.time :only [unix-time]]
-        clojure.test)
-  (:require [riemann.service :as service]))
+  (:require [riemann.common :refer [event]]
+            [riemann.core :refer :all]
+            [riemann.index :refer :all]
+            [riemann.instrumentation :refer [events]]
+            [riemann.query :refer :all]
+            [riemann.service :as service]
+            [riemann.time :refer [unix-time]]
+            [clojure.test :refer :all]))
 
 (deftest missing-time-throws
   (riemann.logging/suppress

--- a/test/riemann/influxdb_test.clj
+++ b/test/riemann/influxdb_test.clj
@@ -1,14 +1,12 @@
 (ns riemann.influxdb-test
-  (:require
-   [clojure.test :refer :all]
-   [riemann.influxdb :as influxdb]
-   [riemann.logging :as logging]
-   [riemann.test-utils :refer [with-mock]]
-   [riemann.time :refer [unix-time]])
-  (:import
-   (java.util.concurrent TimeUnit)
-   (org.influxdb InfluxDBFactory InfluxDB$ConsistencyLevel)
-   (org.influxdb.dto BatchPoints Point)))
+  (:require [riemann.influxdb :as influxdb]
+            [riemann.logging :as logging]
+            [riemann.test-utils :refer [with-mock]]
+            [riemann.time :refer [unix-time]]
+            [clojure.test :refer :all])
+  (:import (java.util.concurrent TimeUnit)
+           (org.influxdb InfluxDBFactory InfluxDB$ConsistencyLevel)
+           (org.influxdb.dto BatchPoints Point)))
 
 (logging/init)
 

--- a/test/riemann/instrumentation_test.clj
+++ b/test/riemann/instrumentation_test.clj
@@ -1,9 +1,9 @@
 (ns riemann.instrumentation-test
-  (:require [riemann.logging :as logging])
-  (:use clojure.test
-        riemann.instrumentation
-        riemann.time.controlled
-        [riemann.time :only [unix-time]]))
+  (:require [riemann.instrumentation :refer :all]
+            [riemann.logging :as logging]
+            [riemann.time :refer [unix-time]]
+            [riemann.time.controlled :refer :all]
+            [clojure.test :refer :all]))
 
 (logging/init)
 (use-fixtures :each reset-time!)
@@ -15,7 +15,7 @@
                                [0 3/5 1.0])]
            (dotimes [i 100]
              (measure-latency r (Thread/sleep 1)))
-           
+
            (advance! 5)
            (let [es (events r)]
              ; Should have merged from the original event

--- a/test/riemann/kafka_test.clj
+++ b/test/riemann/kafka_test.clj
@@ -1,11 +1,11 @@
 (ns riemann.kafka-test
-  (:use riemann.kafka
-        [riemann.time :only [unix-time]]
-        [riemann.common :only [event]]
-        clojure.test)
-  (:require [kinsky.client :as client]
+  (:require [riemann.common :refer [event]]
+            [riemann.core :as core]
+            [riemann.kafka :refer :all]
             [riemann.logging :as logging]
-            [riemann.core :as core]))
+            [riemann.time :refer [unix-time]]
+            [clojure.test :refer :all]
+            [kinsky.client :as client]))
 
 (logging/init)
 

--- a/test/riemann/kairosdb_test.clj
+++ b/test/riemann/kairosdb_test.clj
@@ -1,8 +1,8 @@
 (ns riemann.kairosdb-test
-  (:use riemann.kairosdb
-        [riemann.time :only [unix-time]]
-        clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:require [riemann.kairosdb :refer :all]
+            [riemann.logging :as logging]
+            [riemann.time :refer [unix-time]]
+            [clojure.test :refer :all]))
 
 (logging/init)
 

--- a/test/riemann/keenio_test.clj
+++ b/test/riemann/keenio_test.clj
@@ -1,10 +1,10 @@
 (ns riemann.keenio-test
-  (:require [clj-http.client :as client]
+  (:require [riemann.keenio :as k]
+            [riemann.time :refer [unix-time]]
+            [riemann.test-utils :refer [with-mock]]
             [cheshire.core :as json]
             [clojure.test :refer :all]
-            [riemann.keenio :as k]
-            [riemann.time :refer [unix-time]]
-            [riemann.test-utils :refer [with-mock]]))
+            [clj-http.client :as client]))
 
 (deftest keenio-test
   (with-mock [calls client/post]

--- a/test/riemann/librato_test.clj
+++ b/test/riemann/librato_test.clj
@@ -1,10 +1,10 @@
 (ns riemann.librato-test
-  (:use riemann.librato
-        [riemann.time :only [unix-time]]
-        clj-librato.metrics
-        clojure.math.numeric-tower
-        clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:require [riemann.librato :refer :all]
+            [riemann.logging :as logging]
+            [riemann.time :refer [unix-time]]
+            [clj-librato.metrics :refer :all]
+            [clojure.math.numeric-tower :refer :all]
+            [clojure.test :refer :all]))
 
 (def user   (System/getenv "LIBRATO_METRICS_USER"))
 (def api-key (System/getenv "LIBRATO_METRICS_API_KEY"))

--- a/test/riemann/logentries_test.clj
+++ b/test/riemann/logentries_test.clj
@@ -1,13 +1,12 @@
 (ns riemann.logentries-test
-  (:import
-   (java.net Socket
-             ServerSocket)
-   (java.io BufferedReader
-            InputStreamReader))
-  (:use [riemann.logentries :only [logentries event-to-le-format]]
-        riemann.time
-        clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:require [riemann.logentries :refer [logentries event-to-le-format]]
+            [riemann.logging :as logging]
+            [riemann.time :refer :all]
+            [clojure.test :refer :all])
+  (:import (java.net Socket
+                     ServerSocket)
+           (java.io BufferedReader
+                    InputStreamReader)))
 
 (logging/init)
 

--- a/test/riemann/logging_test.clj
+++ b/test/riemann/logging_test.clj
@@ -1,8 +1,7 @@
 (ns riemann.logging-test
-  (:use riemann.logging
-        clojure.test)
   (:require [riemann.logging :as logging]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [clojure.test :refer :all])
   (:import (ch.qos.logback.classic Logger Level)
            (ch.qos.logback.core Appender ConsoleAppender)
            (java.util Iterator)))

--- a/test/riemann/mailgun_test.clj
+++ b/test/riemann/mailgun_test.clj
@@ -1,6 +1,6 @@
 (ns riemann.mailgun-test
-  (:require [riemann.mailgun :as mailgun]
-            [riemann.common :refer [body]]
+  (:require [riemann.common :refer [body]]
+            [riemann.mailgun :as mailgun]
             [clj-http.client :as client]
             [clojure.test :refer [deftest testing is are]]))
 

--- a/test/riemann/msteams_test.clj
+++ b/test/riemann/msteams_test.clj
@@ -1,10 +1,10 @@
 (ns riemann.msteams-test
-  (:use riemann.msteams
-        clojure.test)
-  (:require [clj-http.client :as http]
+  (:require [riemann.test-utils :refer [with-mock]]
+            [riemann.logging :as logging]
+            [riemann.msteams :refer :all]
             [cheshire.core :as json]
-            [riemann.test-utils :refer [with-mock]]
-            [riemann.logging :as logging]))
+            [clj-http.client :as http]
+            [clojure.test :refer :all]))
 
 (logging/init)
 

--- a/test/riemann/nagios_test.clj
+++ b/test/riemann/nagios_test.clj
@@ -1,8 +1,8 @@
 (ns riemann.nagios-test
-  (:use riemann.nagios
-        cljr-nsca.core
-        clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:require [riemann.logging :as logging]
+            [riemann.nagios :refer :all]
+            [cljr-nsca.core :refer :all]
+            [clojure.test :refer :all]))
 
 (logging/init)
 

--- a/test/riemann/netuitive_test.clj
+++ b/test/riemann/netuitive_test.clj
@@ -1,6 +1,6 @@
 (ns riemann.netuitive-test
-  (:use riemann.netuitive
-        clojure.test))
+  (:require [riemann.netuitive :refer :all]
+            [clojure.test :refer :all]))
 
 (def test-event {:host "riemann.local" :service "netuitive test" :state "ok" :description "Successful test" :metric 2 :time (/ (System/currentTimeMillis) 1000) :tags ["riemann" "netuitive"]})
 (def other-event {:host "riemann.local" :service "netuitive other" :state "ok" :description "Successful test" :metric 5 :time (/ (System/currentTimeMillis) 1000) :tags ["other"]})

--- a/test/riemann/opentsdb_test.clj
+++ b/test/riemann/opentsdb_test.clj
@@ -1,8 +1,8 @@
 (ns riemann.opentsdb-test
-  (:use riemann.opentsdb
-        [riemann.time :only [unix-time]]
-        clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:require [riemann.logging :as logging]
+            [riemann.opentsdb :refer :all]
+            [riemann.time :refer [unix-time]]
+            [clojure.test :refer :all]))
 
 (logging/init)
 

--- a/test/riemann/opsgenie_test.clj
+++ b/test/riemann/opsgenie_test.clj
@@ -1,7 +1,7 @@
 (ns riemann.opsgenie-test
-  (:use riemann.opsgenie
-        clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:require [riemann.logging :as logging]
+            [riemann.opsgenie :refer :all]
+            [clojure.test :refer :all]))
 
 (def service-key (System/getenv "OPSGENIE_SERVICE_KEY"))
 (def recipients (System/getenv "OPSGENIE_RECIPIENTS"))

--- a/test/riemann/pagerduty_test.clj
+++ b/test/riemann/pagerduty_test.clj
@@ -1,10 +1,10 @@
 (ns riemann.pagerduty-test
   (:require [riemann.pagerduty :as pg]
-            [clj-http.client :as client]
             [riemann.test-utils :refer [with-mock]]
-            [cheshire.core :as json]
             [riemann.time :refer :all]
             [riemann.time.controlled :refer :all]
+            [cheshire.core :as json]
+            [clj-http.client :as client]
             [clojure.test :refer :all]))
 
 (use-fixtures :once control-time!)

--- a/test/riemann/pool_test.clj
+++ b/test/riemann/pool_test.clj
@@ -1,7 +1,7 @@
 (ns riemann.pool-test
-  (:use riemann.pool
-        [slingshot.slingshot :only [try+]]
-        clojure.test))
+  (:require [riemann.pool :refer :all]
+            [clojure.test :refer :all]
+            [slingshot.slingshot :refer [try+]]))
 
 (deftest claim-release-test
          (let [x (atom 0)

--- a/test/riemann/prometheus_test.clj
+++ b/test/riemann/prometheus_test.clj
@@ -1,9 +1,9 @@
 (ns riemann.prometheus-test
-  (:require [clj-http.client :as client]
-            [clojure.test :refer :all]
+  (:require [riemann.logging :as logging]
             [riemann.prometheus :as prometheus]
-            [riemann.logging :as logging]
-            [riemann.test-utils :refer [with-mock]]))
+            [riemann.test-utils :refer [with-mock]]
+            [clj-http.client :as client]
+            [clojure.test :refer :all]))
 
 (logging/init)
 

--- a/test/riemann/pubsub_test.clj
+++ b/test/riemann/pubsub_test.clj
@@ -1,8 +1,8 @@
 (ns riemann.pubsub-test
-  (:require [riemann.index   :as index]
-            [riemann.logging :as logging]
+  (:require [riemann.common  :refer [event]]
             [riemann.core    :refer [transition! core wrap-index]]
-            [riemann.common  :refer [event]]
+            [riemann.index   :as index]
+            [riemann.logging :as logging]
             [riemann.pubsub  :refer :all]
             [clojure.test    :refer :all]))
 

--- a/test/riemann/pushover_test.clj
+++ b/test/riemann/pushover_test.clj
@@ -1,10 +1,10 @@
 (ns riemann.pushover-test
-  (:use [riemann.time :only [unix-time]]
-        riemann.pushover
-        clojure.test)
-  (:require [clj-http.client :as http]
-            [riemann.test-utils :refer [with-mock]]
-            [riemann.logging :as logging]))
+  (:require [riemann.test-utils :refer [with-mock]]
+            [riemann.time :refer [unix-time]]
+            [riemann.logging :as logging]
+            [riemann.pushover :refer :all]
+            [clj-http.client :as http]
+            [clojure.test :refer :all]))
 
 (logging/init)
 

--- a/test/riemann/query_test.clj
+++ b/test/riemann/query_test.clj
@@ -1,7 +1,7 @@
 (ns riemann.query-test
-  (:use riemann.query
-        [riemann.time :only [linear-time]]
-        clojure.test))
+  (:require [riemann.query :refer :all]
+            [riemann.time :refer [linear-time]]
+            [clojure.test :refer :all]))
 
 (deftest ast-test
   (are [s expr] (= (ast s) expr)

--- a/test/riemann/service_test.clj
+++ b/test/riemann/service_test.clj
@@ -1,4 +1,9 @@
 (ns riemann.service-test
+  (:require [riemann.instrumentation :as instrumentation]
+            [riemann.logging :as logging]
+            [riemann.service :refer :all]
+            [riemann.time.controlled :as time.controlled]
+            [clojure.test :refer :all])
   (:import (java.util.concurrent TimeUnit
                                  AbstractExecutorService
                                  Executor
@@ -7,12 +12,7 @@
                                  LinkedBlockingQueue
                                  ArrayBlockingQueue
                                  SynchronousQueue
-                                 ThreadPoolExecutor))
-  (:require [riemann.logging :as logging]
-            [riemann.instrumentation :as instrumentation]
-            [riemann.time.controlled :as time.controlled])
-  (:use riemann.service
-        clojure.test))
+                                 ThreadPoolExecutor)))
 
 (use-fixtures :once time.controlled/control-time!)
 (use-fixtures :each time.controlled/reset-time!)

--- a/test/riemann/shinken_test.clj
+++ b/test/riemann/shinken_test.clj
@@ -1,10 +1,10 @@
 (ns riemann.shinken-test
-  (:use [riemann.time :only [unix-time]]
-        riemann.shinken
-        clojure.test)
-  (:require [clj-http.client :as http]
+  (:require [riemann.logging :as logging]
             [riemann.test-utils :refer [with-mock]]
-            [riemann.logging :as logging]))
+            [riemann.time :refer [unix-time]]
+            [riemann.shinken :refer :all]
+            [clj-http.client :as http]
+            [clojure.test :refer :all]))
 
 (logging/init)
 

--- a/test/riemann/slack_test.clj
+++ b/test/riemann/slack_test.clj
@@ -1,9 +1,9 @@
 (ns riemann.slack-test
-  (:use clojure.test)
   (:require [riemann.logging :as logging]
             [riemann.slack :as slack]
             [cheshire.core :as json]
-            [clj-http.client :as client]))
+            [clj-http.client :as client]
+            [clojure.test :refer :all]))
 
 
 (def api-key (System/getenv "SLACK_API_KEY"))

--- a/test/riemann/sns_test.clj
+++ b/test/riemann/sns_test.clj
@@ -1,9 +1,9 @@
 (ns riemann.sns-test
-  (:import [com.amazonaws.services.sns.model PublishResult])
-  (:use [riemann.time :only [unix-time]]
-        [riemann.common :only [time-at count-string-bytes]]
-        riemann.sns
-        clojure.test))
+  (:require [riemann.common :refer [time-at count-string-bytes]]
+            [riemann.sns :refer :all]
+            [riemann.time :refer [unix-time]]
+            [clojure.test :refer :all])
+  (:import [com.amazonaws.services.sns.model PublishResult]))
 
 (def env-access-key-id     (System/getenv "AWS_ACCESS_KEY_ID"))
 (def env-secret-access-key (System/getenv "AWS_SECRET_ACCESS_KEY"))

--- a/test/riemann/stackdriver_test.clj
+++ b/test/riemann/stackdriver_test.clj
@@ -1,8 +1,8 @@
 (ns riemann.stackdriver-test
-  (:use riemann.stackdriver
-        [riemann.time :only [unix-time]]
-        clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:require [riemann.logging :as logging]
+            [riemann.stackdriver :refer :all]
+            [riemann.time :refer [unix-time]]
+            [clojure.test :refer :all]))
 
 (logging/init)
 

--- a/test/riemann/streams_test.clj
+++ b/test/riemann/streams_test.clj
@@ -1,14 +1,14 @@
 (ns riemann.streams-test
-  (:use riemann.streams
-        [riemann.common :exclude [match]]
-        riemann.time.controlled
-        riemann.time
-        [riemann.test :refer [run-stream run-stream-intervals test-stream
-                              with-test-stream test-stream-intervals]]
-        clojure.test)
-  (:require [riemann.index :as index]
+  (:require [riemann.common :refer :all :exclude [match]]
             [riemann.folds :as folds]
-            [riemann.logging :as logging])
+            [riemann.index :as index]
+            [riemann.logging :as logging]
+            [riemann.streams :refer :all]
+            [riemann.test :refer [run-stream run-stream-intervals test-stream
+                                  with-test-stream test-stream-intervals]]
+            [riemann.time :refer :all]
+            [riemann.time.controlled :refer :all]
+            [clojure.test :refer :all])
   (:import (java.util.concurrent Executor
                                  CountDownLatch)))
 

--- a/test/riemann/telegram_test.clj
+++ b/test/riemann/telegram_test.clj
@@ -1,8 +1,8 @@
 (ns riemann.telegram-test
-  (:require [clojure.test :refer :all]
+  (:require [riemann.logging :as logging]
             [riemann.telegram :refer :all]
-            [riemann.logging :as logging]
-            [riemann.test-utils :refer [with-mock]]))
+            [riemann.test-utils :refer [with-mock]]
+            [clojure.test :refer :all]))
 
 (def api-token (System/getenv "TELEGRAM_API_TOKEN"))
 (def chat-id (System/getenv "TELEGRAM_CHAT_ID"))

--- a/test/riemann/test_test.clj
+++ b/test/riemann/test_test.clj
@@ -1,8 +1,8 @@
 (ns riemann.test-test
   "Who tests the testers?"
-  (:require [riemann.test :refer [tap io with-test-env inject!]]
-            [clojure.test :refer :all]
-            [riemann.streams :refer :all]))
+  (:require [riemann.streams :refer :all]
+            [riemann.test :refer [tap io with-test-env inject!]]
+            [clojure.test :refer :all]))
 
 (defmacro bound
   "Invokes body in a bound fn. Tests may run without a binding context, which

--- a/test/riemann/time/controlled_test.clj
+++ b/test/riemann/time/controlled_test.clj
@@ -1,10 +1,9 @@
 (ns riemann.time.controlled-test
-  (:use riemann.time.controlled
-        riemann.time
-        [riemann.common :exclude [unix-time linear-time]]
-        clojure.math.numeric-tower
-        clojure.test)
-  (:require [riemann.logging :as logging]))
+  (:require [riemann.logging :as logging]
+            [riemann.time :refer :all]
+            [riemann.time.controlled :refer :all]
+            [clojure.math.numeric-tower :refer :all]
+            [clojure.test :refer :all]))
 
 (use-fixtures :once control-time!)
 (use-fixtures :each reset-time!)

--- a/test/riemann/time_test.clj
+++ b/test/riemann/time_test.clj
@@ -1,10 +1,10 @@
 (ns riemann.time-test
-  (:use riemann.time
-        [riemann.common :exclude [unix-time linear-time]]
-        clojure.math.numeric-tower
-        clojure.test
-        clojure.tools.logging)
-  (:require [riemann.logging :as logging]))
+  (:require [riemann.common :refer [approx-equal]]
+            [riemann.logging :as logging]
+            [riemann.time :refer :all]
+            [clojure.math.numeric-tower :refer :all]
+            [clojure.test :refer :all]
+            [clojure.tools.logging :refer :all]))
 
 (riemann.logging/init)
 

--- a/test/riemann/transport/graphite_test.clj
+++ b/test/riemann/transport/graphite_test.clj
@@ -1,11 +1,11 @@
 (ns riemann.transport.graphite-test
-  (:use clojure.test
-        [riemann.common :only [event]]
-        riemann.transport.graphite
-        [slingshot.slingshot :only [try+]])
-  (:require [riemann.logging :as logging]
+  (:require [riemann.common :refer [event]]
             [riemann.core :as core]
-            [riemann.graphite :as client]))
+            [riemann.graphite :as client]
+            [riemann.logging :as logging]
+            [riemann.transport.graphite :refer :all]
+            [clojure.test :refer :all]
+            [slingshot.slingshot :refer [try+]]))
 
 (deftest decode-graphite-line-success-test
   (is (= (event {:service "name", :metric 123.0, :time 456})

--- a/test/riemann/transport/opentsdb_test.clj
+++ b/test/riemann/transport/opentsdb_test.clj
@@ -1,13 +1,13 @@
 (ns riemann.transport.opentsdb-test
-  (:use clojure.test
-        [riemann.common :only [event]]
-        riemann.transport.opentsdb
-        [slingshot.slingshot :only [try+]])
-  (:require [riemann.logging :as logging]
+  (:require [riemann.common :refer [event]]
             [riemann.core :as core]
             [riemann.opentsdb :as client]
+            [riemann.logging :as logging]
             [riemann.pubsub :as pubsub]
-            [clojure.pprint :refer [pprint]]))
+            [riemann.transport.opentsdb :refer :all]
+            [clojure.pprint :refer [pprint]]
+            [clojure.test :refer :all]
+            [slingshot.slingshot :refer [try+]]))
 
 (deftest decode-opentsdb-line-success-test
   (is (= (event {:service "name" :description "name" :metric 456.0 :time 123})

--- a/test/riemann/transport_test.clj
+++ b/test/riemann/transport_test.clj
@@ -1,19 +1,19 @@
 (ns riemann.transport-test
-  (:use riemann.common
-        riemann.core
-        riemann.transport.tcp
-        riemann.transport.udp
-        riemann.transport.websockets
-        clojure.test)
-  (:require [clj-http.client :as http]
-            [clojure.java.io :as io]
+  (:require [riemann.client :as client]
+            [riemann.codec :as codec]
+            [riemann.common :refer :all]
+            [riemann.core :refer :all]
+            [riemann.index :as index]
             [riemann.logging :as logging]
             [riemann.pubsub :as pubsub]
             [riemann.transport.sse :refer [sse-server]]
+            [riemann.transport.tcp :refer :all]
+            [riemann.transport.udp :refer :all]
+            [riemann.transport.websockets :refer :all]
             [cheshire.core :as json]
-            [riemann.client :as client]
-            [riemann.codec :as codec]
-            [riemann.index :as index])
+            [clj-http.client :as http]
+            [clojure.java.io :as io]
+            [clojure.test :refer :all])
   (:import (java.net Socket
                      SocketException
                      InetAddress)

--- a/test/riemann/twilio_test.clj
+++ b/test/riemann/twilio_test.clj
@@ -1,6 +1,6 @@
 (ns riemann.twilio-test
-  (:require [riemann.twilio :as twilio]
-            [riemann.common :refer [body]]
+  (:require [riemann.common :refer [body]]
+            [riemann.twilio :as twilio]
             [clj-http.client :as client]
             [clojure.test :refer [deftest testing is are]]))
 

--- a/test/riemann/user_test.clj
+++ b/test/riemann/user_test.clj
@@ -1,16 +1,5 @@
 (ns riemann.user-test
-  "Userland macros for testing snippets of Riemann config."
-  (:use
-   riemann.streams
-   riemann.email
-   riemann.sns
-   [riemann.time :only [unix-time linear-time once! every!]])
-  (:require
-   riemann.streams
-   riemann.config
-   riemann.core
-   riemann.index
-   riemann.query))
+  "Userland macros for testing snippets of Riemann config.")
 
 (defmacro configure-core [& conf]
   "Load the given Riemann conf into the current core and reset the index.

--- a/test/riemann/victorops_test.clj
+++ b/test/riemann/victorops_test.clj
@@ -1,8 +1,8 @@
 (ns riemann.victorops-test
-  (:require [clj-http.client :as client]
-            [clojure.test :refer :all]
-            [riemann.victorops :as vo]
-            [riemann.test-utils :refer [with-mock]]))
+  (:require [riemann.victorops :as vo]
+            [riemann.test-utils :refer [with-mock]]
+            [clj-http.client :as client]
+            [clojure.test :refer :all]))
 
 (deftest victorops-test
   (with-mock [calls client/post]

--- a/test/riemann/xymon_test.clj
+++ b/test/riemann/xymon_test.clj
@@ -1,9 +1,8 @@
 (ns riemann.xymon-test
-  (:use riemann.xymon
-        [riemann.time :only [unix-time]]
-        clojure.test)
   (:require [riemann.logging :as logging]
-            [clojure.string]))
+            [riemann.time :refer [unix-time]]
+            [riemann.xymon :refer :all]
+            [clojure.test :refer :all]))
 
 (logging/init)
 


### PR DESCRIPTION
- Stop using `:use` (which is sort of deprecated in Clojure) and replace it with `:require`
- `:require` imports are now sorted alphabetically (first Riemann imports, then other imports)
- Remove some unused imports.