### PR TITLE
fix ws out rate metric and remove ws latency metric

### DIFF
--- a/src/riemann/transport/websockets.clj
+++ b/src/riemann/transport/websockets.clj
@@ -47,7 +47,9 @@
                                  (when (pred event)
                                    ;; http-kit's send does not provide a way
                                    ;; to measure output latency
-                                   (http/send! ch (event-to-json event))))
+                                   (measure-latency
+                                    (:out stats)
+                                    (http/send! ch (event-to-json event)))))
                                true)]
       (info "New websocket subscription to" topic ":" query)
 
@@ -214,10 +216,6 @@
                            :metric (:rate in)}]
 
                          ; Latencies
-                         (map (fn [[q latency]]
-                                {:service (str svc " out latency " q)
-                                 :metric latency})
-                              (:latencies out))
                          (map (fn [[q latency]]
                                 {:service (str svc " in latency " q)
                                  :metric latency})


### PR DESCRIPTION
Fix #880

- `ws in rate` : this metric measure the input latency for the Riemann HTTP server. It's not really documented but you can send json events using HTTP POST to Riemann. That's why @faxm0dem saw the `ws in rate` at 0. Just do `curl -X POST -H "Content-Type: application/json" -d '{ "service": "foobar"}' localhost:5556/events/` with the ws server started and ws in rate will be > 0.

- `ws out rate` and  `ws out latency`: the events was sent but the measure never updated.  For the latency, http-kit's send does not provide a way to measure output latency (cf [this comment](https://github.com/riemann/riemann/blob/master/src/riemann/transport/websockets.clj#L48)). But i wrapped `http/send!` with `measure-latency` so now we have out the rate (and i removed the latency event so it will not be sent anymore). Example rate event with this PR:

```
INFO [2017-12-16 20:07:02,174] Thread-7 - riemann.config - #riemann.codec.Event{:host mcorbin, :service riemann server ws 0.0.0.0:5556 out rate, :state ok, :description nil, :metric 2.992849136475493, :tags [riemann], :time 756725611079/500, :ttl 20}
```