### PR TITLE
initiates controlled time in with-test-env

### DIFF
--- a/src/riemann/test.clj
+++ b/src/riemann/test.clj
@@ -104,11 +104,12 @@
        persistent!))
 
 (defmacro with-test-env
-  "Prepares a fresh set of taps, binds *testing* to true, and runs body in an
-  implicit do. Wrap your entire test suite (including defining the streams
-  themselves) in this macro. Note that you'll have to use (eval) or
-  (load-file), etc, in order for this to work because the binding takes effect
-  at *run time*, not *compile time*--so make your compile time run time and wow
+  "Prepares a fresh set of taps, binds *testing* to true, initiates controlled
+  time and resets the schedulerand runs body in an implicit do. Wrap your entire
+  test suite (including defining the streams themselves) in this macro. Note that
+  you'll have to use (eval) or (load-file), etc, in order for this to work
+  because the binding takes effect at *run time*, not *compile time*--so make
+  your compile time run time and wow
   this gets confusing.
 
   (with-test-env
@@ -119,7 +120,9 @@
   [& body]
   `(binding [*testing* true
              *taps*    (atom {})]
-     ~@body))
+     (time.controlled/with-controlled-time!
+       (time.controlled/reset-time!)
+       ~@body)))
 
 (defn inject!
   "Takes a sequence of streams, initiates controlled time and resets the


### PR DESCRIPTION
I found a bug while playing with Riemann:

```clojure
(streams
 #(info "RECEIVED = " % " at time " (riemann.time/unix-time))
 (batch 100 10
        #(info "BATCH = " %)
        (tap :batch-tap)))

(tests
 (deftest foo-test
   (let [result (inject!
                 [{:time 1}
                  {:time 2}
                  {:time 3}
                  {:time 4}
                  {:time 5}])]
     (is (= (:batch-tap result)
            [])))))
```

I wrote a test for this stream and launched it several time:

```
INFO [2017-12-18 20:51:08,116] main - riemann.bin - Loading /etc/riemann/riemann.config

Testing riemann.config-test
INFO [2017-12-18 20:51:08,372] main - riemann.config - RECEIVED =  {:time 1}  at time  1
INFO [2017-12-18 20:51:08,376] main - riemann.config - RECEIVED =  {:time 2}  at time  2
INFO [2017-12-18 20:51:08,377] main - riemann.config - RECEIVED =  {:time 3}  at time  3
INFO [2017-12-18 20:51:08,377] main - riemann.config - RECEIVED =  {:time 4}  at time  4
INFO [2017-12-18 20:51:08,378] main - riemann.config - RECEIVED =  {:time 5}  at time  5

Ran 1 tests containing 1 assertions.
0 failures, 0 errors.
root@mcorbin:~# riemann test /etc/riemann/riemann.config 
INFO [2017-12-18 20:51:13,854] main - riemann.bin - Loading /etc/riemann/riemann.config

Testing riemann.config-test
INFO [2017-12-18 20:51:14,143] main - riemann.config - RECEIVED =  {:time 1}  at time  1
INFO [2017-12-18 20:51:14,147] main - riemann.config - RECEIVED =  {:time 2}  at time  2
INFO [2017-12-18 20:51:14,148] main - riemann.config - RECEIVED =  {:time 3}  at time  3
INFO [2017-12-18 20:51:14,156] main - riemann.config - BATCH =  [{:time 1} {:time 2} {:time 3}]
INFO [2017-12-18 20:51:14,157] main - riemann.config - RECEIVED =  {:time 4}  at time  4
INFO [2017-12-18 20:51:14,158] main - riemann.config - RECEIVED =  {:time 5}  at time  5

FAIL in (foo-test) (riemann.config:30)
expected: [[{:time 1} {:time 2} {:time 3}]]
  actual: []
    diff: - [[{:time 1} {:time 2} {:time 3}]]
```

As you can see, the tests don't have the same result for each launch.

@aphyr told me the problem was probably [here](https://github.com/riemann/riemann/blob/0.2.14/src/riemann/streams.clj#L598), and effectively the anchor was equal to the current real world timestamp and not zero in test mode.

So i added `with-controlled-time!` and `reset-time!` in `with-test-env`, so the time will be mocked when riemann includes the configuration.  