### PR TITLE
Results Dashboard for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,16 @@ jdk:
   - oraclejdk8
   - oraclejdk9
 
+before_install:
+  - mkdir -p $HOME/bin
+  - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+  - testspace config url $TS_ORG.testspace.com
+
+script: lein test2junit
+
+after_script:
+  -  testspace [${TRAVIS_JDK_VERSION}]test2junit/xml/*.xml{test/riemann};
+
 addons:
   apt:
     packages:

--- a/project.clj
+++ b/project.clj
@@ -46,6 +46,7 @@
     [pjstadig/humane-test-output "0.8.3"]]
   :plugins [[lein-codox "0.10.2"]
             [lein-difftest "2.0.0"]
+            [test2junit "1.3.3"]
             [lein-rpm "0.0.6"
              :exclusions [org.apache.maven/maven-plugin-api
                           org.codehaus.plexus/plexus-container-default


### PR DESCRIPTION

Hi, `riemann` team. We’ve made a few minor changes to demonstrate how you can better manage your Travis CI build results with [Testspace.com](https://www.testspace.com/). 

Note, we saw @jamtur01 interest in `Zeus.ci` from Sentry, so we thought there might be some interest in checking out Testspace & providing some feedback. 

> Monitor the results for **all** of your organization's repositories, their local branches, and pull requests from a single Dashboard!
 
YOUR TEST RESULTS, from `our fork`, at https://open.testspace.com/projects/TryTestspace:riemann.

---



#### Tired of scrolling through Travis logs to find test failures? 
 
 * Triage failures faster with single-click filtering and complete failure context; call stack, timing info, and more.

#### Want better-organized test results?  
 * Move beyond a flat, endless window of test output. In Testspace, your test results mirror your test folders and subfolders as defined in your repo. 
 * For larger volumes of tests, use hierarchy to reflect your overall test design. 

#### Want actionable metrics to assess the value of your testing?   
 * View historical tracking of all your important metrics; test case and code coverage growth, static analysis issues, and more.  
 * Leverage analytic indicators to assess the effectiveness of your automated testing. 
 
----

#### Setup is Easy

1. Create a free [Open Source Account](https://signup.testspace.com/?plan_id=open.2)
2. Create a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on name selected in step 1
