### PR TITLE
Add missing atom deref to properly close kafka client

### DIFF
--- a/src/riemann/kafka.clj
+++ b/src/riemann/kafka.clj
@@ -73,7 +73,7 @@
       (try
         (info "Subscribing to " topics "...")
         (client/subscribe! consumer topics)
-        (while running?
+        (while @running?
           (let [msgs (client/poll! consumer (:poll.timeout.ms opts))
                 msgs-by-topic (get msgs :by-topic)]
             (doseq [records msgs-by-topic


### PR DESCRIPTION
Missing deref makes the condition always evaluate to true, thus never properly closing the kafka client.

To reproduce:

1. Create configuration with kafka client.
2. Change client's opts.
3. bin/reload!
4. Observe two kafka client threads, while there should be only one.
