### PR TITLE
Add support for tags in Graphite input and output

### DIFF
--- a/src/riemann/graphite.clj
+++ b/src/riemann/graphite.clj
@@ -76,6 +76,26 @@
                                                 frac))))
       event)))
 
+(defn graphite-path-tags
+  "Returns a function which constructs a path for an event.
+  Takes the service with spaces converted to dots, followed by the tags
+  referenced in `tags` if they exists in the event.
+
+  Example:
+
+  (def graph (graphite {:path (graphite-path-tags [:host :rack])}))
+
+  {:host \"foo\" :service \"api req\" :rack \"n1\"}
+  will have this path: api.req;host=foo;rack=n1"
+  [tags]
+  (fn [event]
+    (let [service (replace (:service event) #" " ".")
+          tags (filter #(get event %) tags)
+          tag-string (join ";" (map #(str (name %) "=" (get event %)) tags))]
+      (if (= tag-string "")
+        service
+        (str service ";" tag-string)))))
+
 (defn graphite-metric
   "convert riemann metric value to graphite"
   [event]

--- a/src/riemann/transport/graphite.clj
+++ b/src/riemann/transport/graphite.clj
@@ -18,6 +18,22 @@
                                join]]
         [clojure.tools.logging :only [warn]]))
 
+(defn tags->attributes
+  "Converts a sequence of Graphite tag (key=val) into a Clojure map."
+  [tags]
+  (reduce (fn [state tag]
+         (let [[name value] (split tag #"=")]
+           (assoc state (keyword name) value)))
+          {}
+          tags))
+
+(defn decode-graphite-service-tag
+  "Takes the service, converts it in a Clojure map with a `:service` key
+  and a key for each Graphite tag."
+  [service]
+  (let [[service-name & tags] (split service #";")]
+    (merge (tags->attributes tags) {:service service-name})))
+
 (defn decode-graphite-line
   "Decode a line coming from graphite.
 
@@ -30,7 +46,7 @@
 
   Decode-graphite-line will yield a simple event with just a service, metric,
   and timestamp."
-  [line]
+  [line tags]
   (let [[service metric timestamp & garbage] (split line #"\s+")]
     ; Validate format
     (cond garbage
@@ -54,17 +70,19 @@
                         (throw+ "invalid metric")))
           timestamp (try (Long. timestamp)
                          (catch NumberFormatException e
-                           (throw+ "invalid timestamp")))]
-
-      ; Construct event
-      (->Event nil
-               service
-               nil
-               nil
-               metric
-               nil
-               timestamp
-               nil))))
+                           (throw+ "invalid timestamp")))
+          ; Construct event
+          event (->Event nil
+                         service
+                         nil
+                         nil
+                         metric
+                         nil
+                         timestamp
+                         nil)]
+      (if tags
+        (merge event (decode-graphite-service-tag service))
+        event))))
 
 (defn graphite-frame-decoder
   "Creates a netty MessageToMessage for graphite lines. Takes a parser-fn: a
@@ -74,8 +92,9 @@
   name, tags) from; to fill in default states or TTLs, and so on.
 
   If parser-fn is nil, defaults to identity."
-  [parser-fn protocol]
-  (let [parser-fn (or parser-fn identity)]
+  [parser-fn protocol tags]
+  (let [parser-fn (or parser-fn identity)
+        decode-fn (fn [line] (decode-graphite-line line tags))]
     (proxy [MessageToMessageDecoder] []
       (decode [context message out]
         (try+
@@ -83,7 +102,7 @@
                 (-> (if (= protocol :udp)
                       (.toString (.content message) CharsetUtil/UTF_8)
                       message)
-                    decode-graphite-line
+                    decode-fn
                     parser-fn))
           (catch Object e
             (warn (str "Graphite server received malformed message ("
@@ -104,13 +123,15 @@
   :host       \"127.0.0.1\"
   :port       2003
   :protocol   :tcp or :udp (default :tcp)
-  :parser-fn  an optional function to further transform events after decoding."
+  :parser-fn  an optional function to further transform events after decoding.
+  :tags       converts Graphite tags into event attributes (default false)"
   ([] (graphite-server {}))
   ([opts]
      (let [core (get opts :core (atom nil))
            host (get opts :host "127.0.0.1")
            port (get opts :port 2003)
            protocol (get opts :protocol :tcp)
+           tags (get opts :tags false)
            server (if (= protocol :tcp) tcp-server udp-server)
            channel-group (channel-group (str "graphite server " host ":" port))
            graphite-message-handler (if (= protocol :tcp)
@@ -128,7 +149,7 @@
              ^:shared string-encoder (StringEncoder.
                                        CharsetUtil/UTF_8)
              ^:shared graphite-decoder (graphite-frame-decoder
-                                         (:parser-fn opts) protocol)
+                                         (:parser-fn opts) protocol tags)
              ^{:shared true :executor shared-event-executor} handler
              graphite-message-handler)]
        (server (merge opts

--- a/test/riemann/graphite_test.clj
+++ b/test/riemann/graphite_test.clj
@@ -58,21 +58,41 @@
           (stop! core))))))
 
 (deftest percentiles
-         (is (= (graphite-path-percentiles
-                  {:service "foo bar"})
-                "foo.bar"))
-         (is (= (graphite-path-percentiles
-                  {:service "foo bar 1"})
-                "foo.bar.1"))
-         (is (= (graphite-path-percentiles
-                  {:service "foo bar 99"})
-                "foo.bar.99"))
-         (is (= (graphite-path-percentiles
-                  {:service "foo bar 0.99"})
-                "foo.bar.99"))
-         (is (= (graphite-path-percentiles
-                  {:service "foo bar 0.999"})
-                "foo.bar.999")))
+  (is (= (graphite-path-percentiles
+          {:service "foo bar"})
+         "foo.bar"))
+  (is (= (graphite-path-percentiles
+          {:service "foo bar 1"})
+         "foo.bar.1"))
+  (is (= (graphite-path-percentiles
+          {:service "foo bar 99"})
+         "foo.bar.99"))
+  (is (= (graphite-path-percentiles
+          {:service "foo bar 0.99"})
+         "foo.bar.99"))
+  (is (= (graphite-path-percentiles
+          {:service "foo bar 0.999"})
+         "foo.bar.999")))
+
+(deftest graphite-path-tags-test
+  (let [path (graphite-path-tags [])]
+    (is (= (path
+            {:service "foo bar"})
+           "foo.bar")))
+  (let [path (graphite-path-tags [:host :rack :environment])]
+    (is (= (path
+            {:service "foo bar"
+             :host "riemann.io"
+             :rack "n1"
+             :environment "production"})
+           "foo.bar;host=riemann.io;rack=n1;environment=production"))
+    (is (= (path
+            {:service "foo bar"
+             :host "riemann.io"})
+           "foo.bar;host=riemann.io"))
+    (is (= (path
+            {:service "foo bar"})
+           "foo.bar"))))
 
 (deftest graphite-metric-test
   (is (= (graphite-metric

--- a/test/riemann/transport/graphite_test.clj
+++ b/test/riemann/transport/graphite_test.clj
@@ -7,26 +7,54 @@
             [clojure.test :refer :all]
             [slingshot.slingshot :refer [try+]]))
 
+(deftest tags->attributes-test
+  (is (= (tags->attributes [])
+         {}))
+  (is (= (tags->attributes ["foo=bar"])
+         {:foo "bar"}))
+  (is (= (tags->attributes ["foo=bar" "bar=baz"])
+         {:foo "bar" :bar "baz"})))
+
+(deftest decode-graphite-service-tag-test
+  (is (= (decode-graphite-service-tag "name")
+         {:service "name"}))
+  (is (= (decode-graphite-service-tag "name;")
+         {:service "name"}))
+  (is (= (decode-graphite-service-tag "name;tag1=value1;tag2=value2")
+         {:service "name" :tag1 "value1" :tag2 "value2"})))
+
 (deftest decode-graphite-line-success-test
-  (is (= (event {:service "name", :metric 123.0, :time 456})
-         (decode-graphite-line "name 123 456")))
-  (is (= (event {:service "name", :metric 456.0 :time 789})
-         (decode-graphite-line "name\t456\t789")))
-  (is (= (event {:service "name", :metric 456.0 :time 789})
-         (decode-graphite-line "name\t 456\t 789")))
-  (is (= (event {:service "name", :metric 456.0 :time 789})
-         (decode-graphite-line "name\t\t456\t\t789")))
-  (is (= (event {:service "name", :metric 456.0 :time 789})
-         (decode-graphite-line "name\t\t456 789")))
-  (is (= (event {:service "name", :metric 456.0 :time 789})
-         (decode-graphite-line "name 456\t789")))
-  (is (= (event {:service "name", :metric 456.0 :time 789})
-         (decode-graphite-line "name\t456 789")))
-  (is (= (event {:service "name", :metric 456.0 :time 789})
-         (decode-graphite-line "name  456      789"))))
+  (testing "without tags"
+    (is (= (event {:service "name", :metric 123.0, :time 456})
+           (decode-graphite-line "name 123 456" false)))
+    (is (= (event {:service "name", :metric 456.0 :time 789})
+           (decode-graphite-line "name\t456\t789" false)))
+    (is (= (event {:service "name", :metric 456.0 :time 789})
+           (decode-graphite-line "name\t 456\t 789" false)))
+    (is (= (event {:service "name", :metric 456.0 :time 789})
+           (decode-graphite-line "name\t\t456\t\t789" false)))
+    (is (= (event {:service "name", :metric 456.0 :time 789})
+           (decode-graphite-line "name\t\t456 789" false)))
+    (is (= (event {:service "name", :metric 456.0 :time 789})
+           (decode-graphite-line "name 456\t789" false)))
+    (is (= (event {:service "name", :metric 456.0 :time 789})
+           (decode-graphite-line "name\t456 789" false)))
+    (is (= (event {:service "name", :metric 456.0 :time 789})
+           (decode-graphite-line "name  456      789" false))))
+  (testing "with tags"
+    (is (= (event {:service "name", :metric 123.0, :time 456})
+           (decode-graphite-line "name 123 456" true)))
+    (is (= (event {:service "name", :metric 123.0, :time 456})
+           (decode-graphite-line "name; 123 456" true)))
+    (is (= (event {:service "name"
+                   :host "foo"
+                   :description "desc"
+                   :metric 123.0
+                   :time 456})
+           (decode-graphite-line "name;host=foo;description=desc 123 456" true)))))
 
 (deftest decode-graphite-line-failure-test
-  (let [err #(try+ (decode-graphite-line %)
+  (let [err #(try+ (decode-graphite-line % false)
                    (catch Object e e))]
     (is (= (err "") "blank line"))
     (is (= (err "name nan 456") "NaN metric"))
@@ -86,6 +114,43 @@
                  (event {:host        nil
                          :service     "computar.hi.there"
                          :state       nil
+                         :description nil
+                         :metric      2.5
+                         :tags        nil
+                         :time        123
+                         :ttl         nil}))))
+        (finally
+          (core/stop! core))))))
+
+(deftest round-trip-test-tags
+  (riemann.logging/suppress ["riemann.transport"
+                             "riemann.pubsub"
+                             "riemann.graphite"
+                             "riemann.core"]
+    (let [server (graphite-server {:tags [:host :rack]})
+          sink   (promise)
+          core   (core/transition! (core/core)
+                                   {:services [server]
+                                    :streams  [(partial deliver sink)]})]
+      (try
+        ; Open a client and send an event
+        (let [client (client/graphite {:pool-size 1
+                                       :block-start true
+                                       :path (client/graphite-path-tags
+                                              [:host :rack])})]
+          (client {:host "computar"
+                   :service "hi there"
+                   :metric 2.5
+                   :time 123
+                   :rack "n1"
+                   :ttl 10})
+
+          ; Verify event arrives
+          (is (= (deref sink 1000 :timed-out)
+                 (event {:host        "computar"
+                         :service     "hi.there"
+                         :state       nil
+                         :rack "n1"
                          :description nil
                          :metric      2.5
                          :tags        nil


### PR DESCRIPTION
Graphite now support tags (http://graphite.readthedocs.io/en/latest/tags.html, https://grafana.com/blog/2018/01/11/graphite-1.1-teaching-an-old-dog-new-tricks/).

This PR adds support for Graphite tags for the Riemann Graphite server and the Graphite output.

## Server

I added a new option `:tags` (default to false). If true, Graphite tags will be added as Riemann attributes. Example:

```clojure
(graphite-server {:host host :tags true})
```

If you send to the Riemann Graphite server this string:
`foo.bar;host=riemann.fr;rack=n1;environment=production 30 1518544178`

You will have in Riemann:

`Event{:host riemann.fr, :service foo.bar, :state nil, :description nil, :metric 30.0, :tags nil, :time 1518544178, :ttl nil, :rack n1, :environment production}`

## Client:

You can use the existing `:path` option in the Graphite client to convert Riemann attributes as Graphite tags.  If i want to converts the :host, :rack and :environment attributes into Graphite tags, i can use the `graphite-path-tags` function in `:path`.

```clojure
(def graph (graphite {:host "localhost"
                      :path (riemann.graphite/graphite-path-tags
                             [:host :rack :environment])}))
```
For example, the previous event will have a Graphite path equal to `foo.bar;host=riemann.fr;rack=n1;environment=production`.