### PR TITLE
Add multiple events support to the Graphite stream

### DIFF
--- a/src/riemann/graphite.clj
+++ b/src/riemann/graphite.clj
@@ -15,11 +15,13 @@
 
 (defprotocol GraphiteClient
   (open [client]
-        "Creates a Graphite client")
+    "Creates a Graphite client")
   (send-line [client line]
-        "Sends a formatted line to Graphite")
+    "Sends a formatted line to Graphite")
+  (send-lines [client lines]
+    "Sends a list of formatted lines to Graphite")
   (close [client]
-         "Cleans up (closes sockets etc.)"))
+    "Cleans up (closes sockets etc.)"))
 
 (defrecord GraphiteTCPClient [^String host ^int port]
   GraphiteClient
@@ -31,6 +33,11 @@
   (send-line [this line]
     (let [out (:out this)]
       (.write ^OutputStreamWriter out ^String line)
+      (.flush ^OutputStreamWriter out)))
+  (send-lines [this lines]
+    (let [out (:out this)]
+      (doseq [line lines]
+        (.write ^OutputStreamWriter out ^String line))
       (.flush ^OutputStreamWriter out)))
   (close [this]
     (.close ^OutputStreamWriter (:out this))
@@ -49,6 +56,13 @@
           addr (InetAddress/getByName (:host this))
           datagram (DatagramPacket. bytes length ^InetAddress addr port)]
       (.send ^DatagramSocket (:socket this) datagram)))
+  (send-lines [this lines]
+    (doseq [line lines]
+      (let [bytes (.getBytes ^String line)
+            length (count line)
+            addr (InetAddress/getByName (:host this))
+            datagram (DatagramPacket. bytes length ^InetAddress addr port)]
+        (.send ^DatagramSocket (:socket this) datagram))))
   (close [this]
     (.close ^DatagramSocket (:socket this))))
 
@@ -134,12 +148,15 @@
                    (assoc :size (:pool-size opts))
                    (assoc :regenerate-interval (:reconnect-interval opts))))
         path (:path opts)]
-
-    (fn [event]
-      (when (:metric event)
-        (with-pool [client pool (:claim-timeout opts)]
-                   (let [string (str (join " " [(path event)
-                                                (graphite-metric event)
-                                                (int (:time event))])
-                                     "\n")]
-                     (send-line client string)))))))
+    (fn [events]
+      (let [events (->> (if (sequential? events) events (list events))
+                        (filter :metric))]
+        (when-not (empty? events)
+          (with-pool [client pool (:claim-timeout opts)]
+            (let [lines (map (fn [event]
+                               (str (join " " [(path event)
+                                               (graphite-metric event)
+                                               (int (:time event))])
+                                    "\n"))
+                             events)]
+              (send-lines client lines))))))))

--- a/test/riemann/graphite_test.clj
+++ b/test/riemann/graphite_test.clj
@@ -39,6 +39,34 @@
          (client/close! client)
          (stop! core))))))
 
+(deftest graphite-server-batch-test
+  (logging/suppress
+   ["riemann.transport" "riemann.core" "riemann.pubsub" "riemann.graphite"]
+   (let [s1       (graphite-server)
+         s2       (tcp-server)
+         index    (wrap-index (index/index))
+         core     (transition!
+                   (core)
+                   {:index    index
+                    :services [s1 s2]
+                    :streams  [index]})
+         sendout! (graphite {:path graphite-path-basic})
+         client   (client/tcp-client)]
+     (try
+       (sendout! [{:service "service1" :metric 1.0 :time 0}
+                  {:service "service2" :metric 1.0 :time 0}
+                  {:service "service3" :time 0}])
+       (Thread/sleep 100)
+       (let [[r1 r2 :as res] @(client/query client "true")]
+         (is (= (count res) 2))
+         (is (and (#{"service1" "service2"} (:service r1))
+                  (= 1.0 (:metric r1))))
+         (is (and (#{"service1" "service2"} (:service r2))
+                  (= 1.0 (:metric r2)))))
+       (finally
+         (client/close! client)
+         (stop! core))))))
+
 (deftest parse-error-test
   (logging/suppress
     ["riemann.transport" "riemann.core" "riemann.pubsub" "riemann.graphite"]
@@ -92,24 +120,35 @@
          (double 3.14159))))
 
 (deftest ^:graphite ^:integration graphite-test
-         (let [g (graphite {:block-start true})]
-           (g {:host "riemann.local"
-               :service "graphite test"
-               :state "ok"
-               :description "all clear, uh, situation normal"
-               :metric -2
-               :time (unix-time)}))
+  (let [g (graphite {:block-start true})]
+    (g {:host "riemann.local"
+        :service "graphite test"
+        :state "ok"
+        :description "all clear, uh, situation normal"
+        :metric -2
+        :time (unix-time)}))
 
-         (let [g (graphite {:block-start true})]
-           (g {:service "graphite test"
-               :state "ok"
-               :description "all clear, uh, situation normal"
-               :metric 3.14159
-               :time (unix-time)}))
+  (let [g (graphite {:block-start true})]
+    (g {:service "graphite test"
+        :state "ok"
+        :description "all clear, uh, situation normal"
+        :metric 3.14159
+        :time (unix-time)}))
 
-         (let [g (graphite {:block-start true})]
-           (g {:host "no-service.riemann.local"
-               :state "ok"
-               :description "all clear, uh, situation normal"
-               :metric 4
-               :time (unix-time)})))
+  (let [g (graphite {:block-start true})]
+    (g {:host "no-service.riemann.local"
+        :state "ok"
+        :description "all clear, uh, situation normal"
+        :metric 4
+        :time (unix-time)}))
+  (let [g (graphite {:block-start true})]
+    (g [{:host "no-service.riemann.local"
+         :state "ok"
+         :description "all clear, uh, situation normal"
+         :metric 4
+         :time (unix-time)}
+        {:host "no-service.riemann.local"
+         :state "ok"
+         :description "all clear, uh, situation normal"
+         :metric 10
+         :time (unix-time)}])))


### PR DESCRIPTION
Actually, you cannot send list of events (like the output of `batch`) to the Graphite stream.

I added a new fn on the Graphite protocol (`send-lines`) and implemented it for the Graphite TCP/UDP client. I also modified the Graphite stream to use it, so you can now send to the Graphite stream list of events.