### PR TITLE
Enable TCP-TLS in logstash plugins

### DIFF
--- a/src/riemann/logstash.clj
+++ b/src/riemann/logstash.clj
@@ -96,26 +96,21 @@
   :key              A PKCS8-encoded private key file
   :cert             The corresponding public certificate
   :ca-cert          The certificate of the CA which signed this key"
-
   [opts]
-
   (let [opts (merge {:host "127.0.0.1"
                      :port 9999
                      :protocol :tcp
                      :claim-timeout 0.1
                      :pool-size 4} opts)
-
         pool (fixed-pool
                (fn []
                  (info "Connecting to " (select-keys opts [:host :port :protocol]))
-                 (let [
-                       host (:host opts)
+                 (let [host (:host opts)
                        port (:port opts)
                        client (open (condp = (:protocol opts)
                                       :tcp (LogStashTCPClient. host port)
                                       :udp (LogStashUDPClient. host port)
-                                      :tls (LogStashTLSClient. host port opts)
-                                      ))]
+                                      :tls (LogStashTLSClient. host port opts)))]
                    (info "Connected")
                    client))
                (fn [client]

--- a/src/riemann/logstash.clj
+++ b/src/riemann/logstash.clj
@@ -38,7 +38,7 @@
 (defrecord LogStashUDPClient [^String host ^int port]
   LogStashClient
   (open [this]
-    (assoc this 
+    (assoc this
            :socket (DatagramSocket.)
            :host host
            :port port))
@@ -50,8 +50,6 @@
       (.send ^DatagramSocket (:socket this) datagram)))
   (close [this]
     (.close ^DatagramSocket (:socket this))))
-
-
 
 (defn logstash
   "Returns a function which accepts an event and sends it to logstash.

--- a/src/riemann/logstash.clj
+++ b/src/riemann/logstash.clj
@@ -6,7 +6,7 @@
              DatagramSocket
              DatagramPacket
              InetAddress)
-   (java.io Writer OutputStreamWriter))
+   (java.io Writer OutputStreamWriter BufferedWriter))
   (:use [clojure.string :only [split join replace]]
         clojure.tools.logging
         riemann.pool
@@ -21,58 +21,38 @@
   (close [client]
          "Cleans up (closes sockets etc.)"))
 
-(defn get-socket
-  [host  port  opts]
-  (cond
-     (= ^Boolean (:tls opts) true)
-         (socket  (ssl-context (:key opts) (:cert opts) (:ca-cert opts))
-                              host
-                              port)
-     :else
-          (Socket. host port)))
-
-(defrecord LogStashTCPClient [^String host ^int port opts]
+(defrecord LogStashTLSClient [^String host ^int port opts]
   LogStashClient
-
   (open [this]
-
-    (let [sock (get-socket host port opts)]
-
-        (cond
-           (= ^Boolean (:tls opts) true)
-              (do
-                (.getSession sock)
-                (assoc this
-                       :socket sock
-                       :out (.getOutputStream sock))
-              )
-          :else
-              (assoc this
-                     :socket sock
-                     :out (OutputStreamWriter. (.getOutputStream sock))))))
-
+    (let [sock  (socket  (ssl-context (:key opts) (:cert opts) (:ca-cert opts))
+                host
+                port)]
+          (.startHandshake sock)
+          (assoc this
+                 :socket sock
+                 :out (BufferedWriter. (OutputStreamWriter. (.getOutputStream sock))))))
   (send-line [this line]
     (let [out (:out this)]
-          (cond
-            (= ^Boolean (:tls opts) true)
-               (do
-                (.write  out  (.getBytes (str line ) ))
-                (.flush out))
-            :else
-              (do
-                (.write ^OutputStreamWriter out ^String line)
-                (.flush ^OutputStreamWriter out)))))
-
+          (.write ^BufferedWriter out  ^String line)
+          (.flush ^BufferedWriter out)))
   (close [this]
-    (cond
-      (= ^Boolean (:tls opts) true)
-         (do
-            (.close (:out this))
-            (.close ^Socket (:socket this)))
-        :else
-        (do
-           (.close ^OutputStreamWriter (:out this))
-           (.close ^Socket (:socket this))))))
+    (.close ^BufferedWriter (:out this))
+    (.close ^Socket (:socket this))))
+
+(defrecord LogStashTCPClient [^String host ^int port]
+  LogStashClient
+  (open [this]
+    (let [sock (Socket. host port)]
+      (assoc this
+             :socket sock
+             :out (OutputStreamWriter. (.getOutputStream sock)))))
+  (send-line [this line]
+    (let [out (:out this)]
+      (.write ^OutputStreamWriter out ^String line)
+      (.flush ^OutputStreamWriter out)))
+  (close [this]
+    (.close ^OutputStreamWriter (:out this))
+    (.close ^Socket (:socket this))))
 
 (defrecord LogStashUDPClient [^String host ^int port]
   LogStashClient
@@ -110,10 +90,9 @@
   :block-start          Wait for the pool's initial connections to open
                         before returning.
 
-  :protocol             Protocol to use. Either :tcp (default) or :udp.
+  :protocol             Protocol to use. Either :tcp (default), :tls or :udp.
 
   TLS options:
-  :tls?             Whether to enable TLS
   :key              A PKCS8-encoded private key file
   :cert             The corresponding public certificate
   :ca-cert          The certificate of the CA which signed this key"
@@ -123,19 +102,20 @@
   (let [opts (merge {:host "127.0.0.1"
                      :port 9999
                      :protocol :tcp
-                     :tls false
                      :claim-timeout 0.1
                      :pool-size 4} opts)
 
         pool (fixed-pool
                (fn []
-                 (info "Connecting to " (select-keys opts [:host :port :security.protocol :tls]))
+                 (info "Connecting to " (select-keys opts [:host :port :protocol]))
                  (let [
                        host (:host opts)
                        port (:port opts)
                        client (open (condp = (:protocol opts)
-                                      :tcp (LogStashTCPClient. host port opts)
-                                      :udp (LogStashUDPClient. host port)))]
+                                      :tcp (LogStashTCPClient. host port)
+                                      :udp (LogStashUDPClient. host port)
+                                      :tls (LogStashTLSClient. host port opts)
+                                      ))]
                    (info "Connected")
                    client))
                (fn [client]


### PR DESCRIPTION
The logstash plugin currently only support TCP connections in clear way (non TLS), but TLS connection support is also required, so this PR contains the changes for supporting it.

The _less-awful-ssl_ library has been used.

NOTE: We have not found any existing test for logstash, so we haven't modified it.