### PR TITLE
config: lexicographically sort files before including them

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -182,19 +182,19 @@
   (kafka-consumer {:consumer.config {:bootstrap.servers \"localhost:9092\"
                                      :group.id \"riemann\"}
                    :topics [\"riemann\"]})
- 
+
   Options:
-   
+
   For a full list of :consumer.config options see the kafka consumer docs.
   NOTE: The :enable.auto.commit option is ignored and defaults to true.
 
-  :consumer.config      Consumer configuration 
+  :consumer.config      Consumer configuration
     :bootstrap.servers  Bootstrap configuration, default is \"localhost:9092\"
     :group.id           Consumer group id, default is \"riemann\"
   :topics               Topics to consume from, default is [\"riemann\"]
-  :key.deserializer     Key deserializer function, defaults to the 
+  :key.deserializer     Key deserializer function, defaults to the
                         keyword-deserializer.
-  :value.deserializer   Value deserializer function, defaults to 
+  :value.deserializer   Value deserializer function, defaults to
                         json-deserializer.
   :poll.timeout.ms      Polling timeout, default is 100."
 
@@ -437,6 +437,7 @@
              file-seq
              (filter config-file?)
              (map str)
+             (sort)
              (map include)
              dorun)
         (load-file path)))))


### PR DESCRIPTION
A common use of the include directory functionality is to
load files in order, allowing symbols referenced early
in the inclusion process in subsequently loaded files.

With a lexicographical sort, the canonical use-case
of using a numbered naming scheme for include files
is now possible.