### PR TITLE
Improve the formatting of the API documentation

### DIFF
--- a/src/riemann/boundary.clj
+++ b/src/riemann/boundary.clj
@@ -83,10 +83,12 @@
 
   Examples:
 
+  ```clojure
   (def bdry (boundary eml tkn))
   (when :foo (bdry)) => builds the destination metric id with :service
   (when :foo (bdry {:async true})) => same as previous, but async
-  (when :foo (bdry {:metric-id \"METRIC_ID\"})) => sends to METRIC_ID"
+  (when :foo (bdry {:metric-id \"METRIC_ID\"})) => sends to METRIC_ID
+  ```"
   [email token]
   (fn b
     ([] (b {}))

--- a/src/riemann/cloudwatch.clj
+++ b/src/riemann/cloudwatch.clj
@@ -18,28 +18,27 @@
   "Returns a function which accepts an event and sends it to cloudwatch.
   Usage:
 
+  ```clojure
   (cloudwatch {:access-key \"AKJALPVWYQ6BFMVLSZDA\"
                :secret-key \"ZFEemkafy0paNMx5JcinMUiOC4dcMKhxXCL85DhM\"})
-  
+
   (cloudwatch {}) will make use of IAM Instance Profile.
+  ```
 
   Options:
 
-  :access-key  AWS access key of your AWS Account.
-
-  :secret-key  AWS secret key for the above access key.
-
-  :endpoint    AWS Endpoint for posting metrics(changes with AWS region).
-
-  :namespace   AWS CloudWatch namespace."
+  - :access-key  AWS access key of your AWS Account.
+  - :secret-key  AWS secret key for the above access key.
+  - :endpoint    AWS Endpoint for posting metrics(changes with AWS region).
+  - :namespace   AWS CloudWatch namespace."
   [opts]
   (let [opts (if (or (contains? opts :access-key) (contains? opts :secret-key))
-               (merge 
+               (merge
                     {:access-key "aws-access-key"
                      :secret-key "aws-secret-key"
                      :endpoint   "monitoring.us-east-1.amazonaws.com"
                      :namespace  "Riemann"} opts)
-               (merge 
+               (merge
                     {:endpoint   "monitoring.us-east-1.amazonaws.com"
                      :namespace  "Riemann"} opts))]
     (fn [event]

--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -95,10 +95,12 @@
   where possible, re-use existing services without interruption--e.g., when
   reloading. For example, say you want to use a threadpool executor:
 
+  ```clojure
   (let [executor (service! (ThreadPoolExecutor. 1 2 ...))]
     (where (service \"graphite\")
       (on executor
         graph)))
+  ```
 
   If you reload this config, the *old* executor is busily processing messages
   from the old set of streams. When the new config evaluates (service! ...)
@@ -179,24 +181,26 @@
 (defn kafka-consumer
   "Add a new kafka consumer with opts to the default core.
 
+  ```
   (kafka-consumer {:consumer.config {:bootstrap.servers \"localhost:9092\"
                                      :group.id \"riemann\"}
                    :topics [\"riemann\"]})
+  ```
 
   Options:
 
   For a full list of :consumer.config options see the kafka consumer docs.
   NOTE: The :enable.auto.commit option is ignored and defaults to true.
 
-  :consumer.config      Consumer configuration
-    :bootstrap.servers  Bootstrap configuration, default is \"localhost:9092\"
-    :group.id           Consumer group id, default is \"riemann\"
-  :topics               Topics to consume from, default is [\"riemann\"]
-  :key.deserializer     Key deserializer function, defaults to the
-                        keyword-deserializer.
-  :value.deserializer   Value deserializer function, defaults to
-                        json-deserializer.
-  :poll.timeout.ms      Polling timeout, default is 100."
+  - :consumer.config      Consumer configuration
+      - :bootstrap.servers  Bootstrap configuration, default is \"localhost:9092\"
+      - :group.id           Consumer group id, default is \"riemann\"
+  - :topics               Topics to consume from, default is [\"riemann\"]
+  - :key.deserializer     Key deserializer function, defaults to the
+                          keyword-deserializer.
+  - :value.deserializer   Value deserializer function, defaults to
+                          json-deserializer.
+  - :poll.timeout.ms      Polling timeout, default is 100."
 
   [& opts]
   (service! (kafka/kafka-consumer (kwargs-or-map opts))))
@@ -280,6 +284,7 @@
 
   Example:
 
+  ```clojure
   (let [downstream (batch 100 1/10
                           (async-queue! :agg {:queue-size     1e3
                                               :core-pool-size 4
@@ -291,7 +296,8 @@
       ...
       ; Forward all events downstream to the aggregator.
       (where (service #\"^riemann.*\")
-        downstream)))"
+        downstream)))
+  ```"
   [name threadpool-service-opts & children]
   (let [s (service! (service/threadpool-service name threadpool-service-opts))]
     (apply execute-on s children)))

--- a/src/riemann/core.clj
+++ b/src/riemann/core.clj
@@ -278,7 +278,9 @@
   streamed states have only the host and service copied, current time, and
   state expired. Expired events from the index are also published to the
   \"index\" pubsub channel.
+
   Options:
+
   :keep-keys A list of event keys which should be preserved from the indexed
              event in the expired event. Defaults to [:host :service], which
              means that when an event expires, its :host and :service are

--- a/src/riemann/datadog.clj
+++ b/src/riemann/datadog.clj
@@ -37,11 +37,17 @@
   "Return a function which accepts either single events or batches of
    events in a vector and sends them to datadog. Batching reduces latency
    by at least one order of magnitude and is highly recommended.
+
   Usage:
+
   (datadog {:api-key \"bn14a6ac2e3b5h795085217d49cde7eb\"})
+
   Option:
-  :api-key    Datadog's API Key for authentication.
+
+  - :api-key    Datadog's API Key for authentication.
+
   Example:
+
   (def datadog-forwarder
     (batch 100 1/10
       (async-queue!

--- a/src/riemann/druid.clj
+++ b/src/riemann/druid.clj
@@ -33,14 +33,18 @@
    events in a vector and sends them to the Druid Tranquility Server.
 
    Usage:
+
    (druid {:host \"druid.example.com\"})
 
    Options:
-   `:host`     Hostname of Druid Tranquility server. (default: `\"localhost\"`)
-   `:port`     Port at which Druid Tranquility is listening (default: `8200`)
-   `:dataset`  Dataset name to be given (default: `\"riemann\"`)
+
+   - `:host`     Hostname of Druid Tranquility server. (default: `\"localhost\"`)
+   - `:port`     Port at which Druid Tranquility is listening (default: `8200`)
+   - `:dataset`  Dataset name to be given (default: `\"riemann\"`)
 
    Example:
+
+  ```clojure
    (def druid-async
    (batch 100 1/10
      (async-queue!
@@ -49,7 +53,7 @@
         :core-pool-size 5    ; Minimum 5 threads
         :max-pools-size 100} ; Maximum 100 threads
         (druid {:host \"localhost\"}))))
-  "
+  ```"
   [opts]
   (let [opts (merge {:host     "localhost"
                      :port     8200

--- a/src/riemann/elasticsearch.clj
+++ b/src/riemann/elasticsearch.clj
@@ -41,15 +41,16 @@
 
   Options:
 
-  :es-endpoint     Elasticsearch, default is \"http://127.0.0.1:9200\".
-  :es-index        Index name, default is \"riemann\".
-  :index-suffix    Index-suffix, default is \"-yyyy.MM.dd\".
-  :type            Type to send to index, default is \"event\".
-  :username        Username to authenticate with.
-  :password        Password to authenticate with.
+  - :es-endpoint     Elasticsearch, default is \"http://127.0.0.1:9200\".
+  - :es-index        Index name, default is \"riemann\".
+  - :index-suffix    Index-suffix, default is \"-yyyy.MM.dd\".
+  - :type            Type to send to index, default is \"event\".
+  - :username        Username to authenticate with.
+  - :password        Password to authenticate with.
 
   Example:
 
+  ```clojure
   (elasticsearch
     ; ES options
     {:es-endpoint \"https:example-elastic.com\"
@@ -58,7 +59,8 @@
     (fn [event]
       (let
         [newtags (concat (:tags event) [\"extra-tag\"])]
-        (merge event {:tags newtags}))))"
+        (merge event {:tags newtags}))))
+  ```"
   [opts & maybe-formatter]
   (let [opts (merge {:es-endpoint "http://127.0.0.1:9200"
                      :es-index "riemann"
@@ -104,10 +106,11 @@
   "Returns a function which accepts an event and formats it for the Elasticsearch bulk API.
 
   Options :
-  :es-index        Elasticsearch index name (without suffix).
-  :type            Type to send to index.
-  :es-action       Elasticsearch action, for example \"index\".
-  :index-suffix    Index suffix, for example \"-yyyy.MM.dd\".
+
+  - :es-index        Elasticsearch index name (without suffix).
+  - :type            Type to send to index.
+  - :es-action       Elasticsearch action, for example \"index\".
+  - :index-suffix    Index suffix, for example \"-yyyy.MM.dd\".
 
   Each event received by the function can also have these keys (which override default options), and an optional `es-id` key."
   [{:keys [es-index type es-action index-suffix]}]
@@ -138,16 +141,20 @@
 (defn elasticsearch-bulk
   "Returns a function which accepts an event (or a list of events) and sends it to
   Elasticsearch using the Bulk API. Custom event formatter can be provided using the `:formatter` key.
+
   A formatter is a function which accepts an event.
+
   Event time is mandatory.
 
   Events should have this format :
 
+  ```clojure
   {:es-action \"index\"
    :es-metadata {:_index \"test\"
                  :_type \"type1\"
                  :_id \"1\"}
    :es-source {:field1 \"value1\"}}
+  ```
 
   `:es-action` is the action (create, update, index, delete), `:es-metadata` the document metadata, and `es-source` the document source.
 
@@ -157,11 +164,11 @@
 
   Options:
 
-  :es-endpoint     Elasticsearch, default is \"http://127.0.0.1:9200\".
-  :username        Username to authenticate with.
-  :password        Password to authenticate with.
-  :formatter       Fn taking an event and returning it with the ES Bulk API format
-  :http-options    Http options (like proxy). See https://github.com/dakrone/clj-http for option list"
+  - :es-endpoint     Elasticsearch, default is \"http://127.0.0.1:9200\".
+  - :username        Username to authenticate with.
+  - :password        Password to authenticate with.
+  - :formatter       Fn taking an event and returning it with the ES Bulk API format
+  - :http-options    Http options (like proxy). See https://github.com/dakrone/clj-http for option list"
   [opts]
   (let [opts (merge {:es-endpoint "http://127.0.0.1:9200"} opts)]
     (fn [events]

--- a/src/riemann/email.clj
+++ b/src/riemann/email.clj
@@ -21,38 +21,49 @@
   "Returns a mailer, which is a function invoked with an address or a sequence
   of addresses and returns a stream. That stream is a function which takes a
   single event, or a sequence of events, and sends email about them.
-  
+
+  ```clojure
   (def email (mailer))
- 
+  ```
+
   This mailer uses the local sendmail.
 
+  ```clojure
   (changed :state
     (email \"xerxes@trioptimum.org\" \"shodan@trioptimum.org\"))
+  ```
 
   The first argument are SMTP options like :host, :port, :user, :pass, :tls,
   and :ssl. The second argument is a map of default message options, like :from
   or :subject.
-  
+
+  ```clojure
   (def email (mailer {:host \"mail.relay\"}
                      {:from \"riemann@trioptimum.com\"}))
 
+  ```
+
   If you provide a single map, mailer will split the SMTP options out for you.
 
+  ```clojure
   (def email (mailer {:host \"mail.relay\"
                       :user \"foo\"
                       :pass \"bar\"
                       :from \"riemann@trioptimum.com\"}))
-  
+  ```
+
   smtp-opts and msg-opts are passed to postal. For more documentation, see
   https://github.com/drewr/postal
-  
+
   By default, riemann uses (subject events) and (body events) to format emails.
   You can set your own subject or body formatter functions by including
   :subject or :body in msg-opts. These formatting functions take a sequence of
   events and return a string.
 
-  (def email (mailer {} {:body (fn [events] 
-                                 (apply prn-str events))}))"
+  ```clojure
+  (def email (mailer {} {:body (fn [events]
+                                 (apply prn-str events))}))
+  ```"
   ([] (mailer {}))
   ([opts]
         (let [smtp-keys #{:host :port :user :pass :ssl :tls :sender}

--- a/src/riemann/graphite.clj
+++ b/src/riemann/graphite.clj
@@ -100,6 +100,7 @@
   (def graph (graphite {:path (graphite-path-tags [:host :rack])}))
 
   {:host \"foo\" :service \"api req\" :rack \"n1\"}
+
   will have this path: api.req;host=foo;rack=n1"
   [tags]
   (fn [event]
@@ -125,22 +126,17 @@
 
   Options:
 
-  :path       A function which, given an event, returns the string describing
-              the path of that event in graphite. graphite-path-percentiles by
-              default.
-
-  :pool-size  The number of connections to keep open. Default 4.
-
-  :reconnect-interval   How many seconds to wait between attempts to connect.
-                        Default 5.
-
-  :claim-timeout        How many seconds to wait for a graphite connection from
-                        the pool. Default 0.1.
-
-  :block-start          Wait for the pool's initial connections to open
-                        before returning.
-
-  :protocol             Protocol to use. Either :tcp (default) or :udp."
+  - :path       A function which, given an event, returns the string describing
+                the path of that event in graphite. graphite-path-percentiles by
+                default.
+  - :pool-size  The number of connections to keep open. Default 4.
+  - :reconnect-interval   How many seconds to wait between attempts to connect.
+                          Default 5.
+  - :claim-timeout        How many seconds to wait for a graphite connection from
+                          the pool. Default 0.1.
+  - :block-start          Wait for the pool's initial connections to open
+                          before returning.
+  - :protocol             Protocol to use. Either :tcp (default) or :udp."
   [opts]
   (let [opts (merge {:host "127.0.0.1"
                      :port 2003

--- a/src/riemann/hipchat.clj
+++ b/src/riemann/hipchat.clj
@@ -59,11 +59,13 @@
   If you're using hosted HipChat, you can leave out :server (or set it to
   'api.hipchat.com').
 
+  ```clojure
   (let [hc (hipchat {:server \"...\"
                      :token \"...\"
                      :room 12345
                      :notify 0})]
-    (changed-state hc))"
+    (changed-state hc))
+  ```"
   [{:keys [server token room notify]}]
   (if (not (= 40 (count token)))
     (throw (IllegalArgumentException. "This adapter now requires a v2 API key")))

--- a/src/riemann/index.clj
+++ b/src/riemann/index.clj
@@ -7,9 +7,9 @@
 
   Indexes must extend three protocols:
 
-  Index: indexing and querying events
-  Seqable: returning a list of events
-  Service: lifecycle management"
+  - Index: indexing and querying events
+  - Seqable: returning a list of events
+  - Service: lifecycle management"
   (:refer-clojure :exclude [update])
   (:require [riemann.query :as query]
             [riemann.common :refer [deprecated]]

--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -21,9 +21,10 @@
 
 ;; specific influxdb-deprecated code
 (defn event-tags
-  "Generates a map of InfluxDB tags from a Riemann event. Any fields in the
-  event which are named in `tag-fields` will be converted to a string key/value
-  entry in the tag map."
+  "Generates a map of InfluxDB tags from a Riemann event.
+
+  Any fields in the event which are named in `tag-fields` will be converted to
+  a string key/value entry in the tag map."
   [tag-fields event]
   (->> (select-keys event tag-fields)
        (remove (fn [[k v]] (nil-or-empty-str v)))
@@ -32,10 +33,10 @@
 
 ;; specific influxdb-deprecated code
 (defn event-fields
-  "Generates a map of InfluxDB fields from a Riemann event. The event's
-  `metric` is converted to the `value` field, and any additional event fields
-  which are not standard Riemann properties or in `tag-fields` will also be
-  present."
+  "Generates a map of InfluxDB fields from a Riemann event.
+
+  The event's `metric` is converted to the `value` field, and any additional
+  event fields which are not standard Riemann properties or in `tag-fields` will also  be present."
   [tag-fields event]
   (let [ignored-fields (set/union special-fields tag-fields)]
     (-> event
@@ -98,7 +99,9 @@
 
 (defn get-time-unit
   "returns a value from the TimeUnit enum depending of the `precision` parameters.
+
   The `precision` parameter is a keyword whose possibles values are `:seconds`, `:milliseconds` and `:microseconds`.
+
   Returns `TimeUnit/SECONDS` by default"
   [precision]
   (cond
@@ -109,7 +112,9 @@
 
 (defn convert-time
   "Converts the `time-event` parameter (which is time second) in a new time unit specified by the `precision` parameter. It also converts the time to long.
+
   The `precision` parameter is a keyword whose possibles values are `:seconds`, `:milliseconds` and `:microseconds`.
+
   Returns time in seconds by default"
   [time-event precision]
   (cond
@@ -128,8 +133,9 @@
 ;; specific influxdb-deprecated code
 (defn event->point-9
   "Converts a Riemann event into an InfluxDB Point (an instance of `org.influxdb.dto.Point`.
-  The first parameter is the event. The `:precision` key of the event is used to converts the event `time` into the correct time unit (default seconds).
-  The second parameter is the option map passed to the influxdb stream."
+
+  - The first parameter is the event. The `:precision` key of the event is used to converts the event `time` into the correct time unit (default seconds).
+  - The second parameter is the option map passed to the influxdb stream."
   [event opts]
   (when (and (:time event) (:service event) (:metric event))
     (let [precision (:precision event (:precision opts))
@@ -144,11 +150,14 @@
 
 (defn event->point
   "Converts a Riemann event into an InfluxDB Point (an instance of `org.influxdb.dto.Point`.
-  The first parameter is the event.
-  The `:precision` event key is used to converts the event `time` into the correct time unit (default seconds).
-  The `:measurement` event key is the influxdb measurement.
-  The `:influxdb-tags` event key contains all the Influxdb tags.
-  The `:influxdb-fields` event key contains all the Influxdb fields.
+
+  The first parameter is the event:
+
+    - The `:precision` event key is used to converts the event `time` into the correct time unit (default seconds).
+    - The `:measurement` event key is the influxdb measurement.
+    - The `:influxdb-tags` event key contains all the Influxdb tags.
+    - The `:influxdb-fields` event key contains all the Influxdb fields.
+
   The second parameter is the option map passed to the influxdb stream."
   [event opts]
   (when (and (:time event) (:measurement event))
@@ -184,7 +193,9 @@
 (defn get-batchpoints
   "Create a `org.influxdb.dto.BatchPoints` for each element in the `events` list.
   `events` is a list where each element is a list of events.
+
   Each element contains events with the same `:db`, `:retention` and `:consistency` keys.
+
   These options are used to create the BatchPoints.
   `opts` are the global influxdb stream options."
   [opts events]
@@ -201,6 +212,7 @@
 
 (defn partition-events
   "`events` is a list of events.
+
   partition `events` depending of the `db`, `retention` and `consistency` keys
   returns a list, each element being a list of events (the result of the partitioning)."
   [events]
@@ -213,13 +225,14 @@
   them to InfluxDB.
 
   streams receive an event or a list of events. Each event can have these keys :
-  `:measurement`     The influxdb measurement.
-  `:influxdb-tags`   A map of influxdb tags. Exemple : `{:foo \"bar\"}`
-  `:influxdb-fields` A map of influxdb fields. Exemple : `{:bar \"baz\"}`
-  `:precision`       The time precision. Possibles values are `:seconds`, `:milliseconds` and `:microseconds` (default `:seconds`). The event `time` will be converted.
-  `:db`              Name of the database to write to. (optional)
-  `:retention`       Name of retention policy to use. (optional)
-  `:consistency`     The InfluxDB consistency level (default: `\"ONE\"`). Possibles values are ALL, ANY, ONE, QUORUM."
+
+  - `:measurement`     The influxdb measurement.
+  - `:influxdb-tags`   A map of influxdb tags. Exemple : `{:foo \"bar\"}`
+  - `:influxdb-fields` A map of influxdb fields. Exemple : `{:bar \"baz\"}`
+  - `:precision`       The time precision. Possibles values are `:seconds`, `:milliseconds` and `:microseconds` (default `:seconds`). The event `time` will be converted.
+  - `:db`              Name of the database to write to. (optional)
+  - `:retention`       Name of retention policy to use. (optional)
+  - `:consistency`     The InfluxDB consistency level (default: `\"ONE\"`). Possibles values are ALL, ANY, ONE, QUORUM."
   [opts]
   (let [opts (merge default-opts opts)
         connection (get-client opts)]
@@ -235,12 +248,14 @@
   them to InfluxDB.
 
   influxdb-deprecated specifics options :
-  `:tag-fields`     A set of event fields to map into InfluxDB series tags.
+
+  - `:tag-fields`     A set of event fields to map into InfluxDB series tags.
                     (default: `#{:host}`).
 
   Each event can have these keys :
-  `:tag-fields`     A set of event fields to map into InfluxDB series tags..
-  `:precision`       The time precision. Possibles values are `:seconds`, `:milliseconds` and `:microseconds` (default `:seconds`). The event `time` will be converted."
+
+  - `:tag-fields`     A set of event fields to map into InfluxDB series tags..
+  - `:precision`       The time precision. Possibles values are `:seconds`, `:milliseconds` and `:microseconds` (default `:seconds`). The event `time` will be converted."
   [opts]
   (let [opts (merge default-opts opts)
         connection (get-client opts)]
@@ -257,25 +272,31 @@
   "Returns a function which accepts an event, or sequence of events, and writes
   them to InfluxDB as a batch of measurement points. For performance, you should
   wrap this stream with `batch` or an asynchronous queue.
+
   Support InfluxdbDB 0.9 and higher.
+
+  ```clojure
   (influxdb {:host \"influxdb.example.com\"
              :db \"my_db\"
              :user \"riemann\"
              :password \"secret\"})
+  ```
+
   General Options:
-  `:db`             Name of the database to write to. (default: `\"riemann\"`)
-  `:version`        Version of InfluxDB client to use. (default: `\":deprecated\"`)
-  `:scheme`         URL scheme for endpoint. (default: `\"http\"`)
-  `:host`           Hostname to write points to. (default: `\"localhost\"`)
-  `:port`           API port number. (default: `8086`)
-  `:username`       Database user to authenticate as. (default: `\"root\"`)
-  `:password`       Password to authenticate with. (optional)
-  `:tags`           A common map of tags to apply to all points. (optional)
-  `:retention`      Name of retention policy to use. (optional)
-  `:timeout`        HTTP timeout in milliseconds. (default: `5000`)
-  `:consistency`    The InfluxDB consistency level (default: `\"ONE\"`). Possibles values are ALL, ANY, ONE, QUORUM.
-  `:insecure`       If scheme is https and certficate is self-signed. (optional)
-  `:precision`      The time precision. Possibles values are `:seconds`, `:milliseconds` and `:microseconds` (default `:seconds`). The event `time` will be converted.
+
+  - `:db`             Name of the database to write to. (default: `\"riemann\"`)
+  - `:version`        Version of InfluxDB client to use. (default: `\":deprecated\"`)
+  - `:scheme`         URL scheme for endpoint. (default: `\"http\"`)
+  - `:host`           Hostname to write points to. (default: `\"localhost\"`)
+  - `:port`           API port number. (default: `8086`)
+  - `:username`       Database user to authenticate as. (default: `\"root\"`)
+  - `:password`       Password to authenticate with. (optional)
+  - `:tags`           A common map of tags to apply to all points. (optional)
+  - `:retention`      Name of retention policy to use. (optional)
+  - `:timeout`        HTTP timeout in milliseconds. (default: `5000`)
+  - `:consistency`    The InfluxDB consistency level (default: `\"ONE\"`). Possibles values are ALL, ANY, ONE, QUORUM.
+  - `:insecure`       If scheme is https and certficate is self-signed. (optional)
+  - `:precision`      The time precision. Possibles values are `:seconds`, `:milliseconds` and `:microseconds` (default `:seconds`). The event `time` will be converted.
 
   See `influxdb-deprecated` and `influxdb-new-stream` for version-specific options."
   [opts]

--- a/src/riemann/kafka.clj
+++ b/src/riemann/kafka.clj
@@ -10,25 +10,29 @@
 
 (defn kafka
   "Returns a function that is invoked with a topic name and an optional message key and returns a stream. That stream is a function which takes an event or a sequence of events and sends them to Kafka.
-  
+
+  ```clojure
   (def kafka-output (kafka))
 
   (changed :state
     (kafka-output \"mytopic\"))
+  ```
 
   Options:
 
-  For a complete list of producer configuration options see https://kafka.apache.org/documentation/#producerconfigs  
+  For a complete list of producer configuration options see https://kafka.apache.org/documentation/#producerconfigs
 
-  :bootstrap.servers  Bootstrap configuration, default is \"localhost:9092\".
-  :value.serializer   Value serializer, default is json-serializer.
+  - :bootstrap.servers  Bootstrap configuration, default is \"localhost:9092\".
+  - :value.serializer   Value serializer, default is json-serializer.
 
   Example with SSL enabled:
 
+  ```clojure
   (def kafka-output (kafka {:bootstrap.servers \"kafka.example.com:9092\"
                             :security.protocol \"SSL\"
                             :ssl.truststore.location \"/path/to/my/truststore.jks\"
-                            :ssl.truststore.password \"mypassword\"}))"
+                            :ssl.truststore.password \"mypassword\"}))
+  ```"
 
   ([] (kafka {}))
   ([opts]
@@ -82,7 +86,7 @@
                 (stream! @core event)))))
         (catch Exception e
           (error e "Interrupted consumption"))
-        (finally 
+        (finally
           (client/close! consumer))))))
 
 (defn kafka-consumer

--- a/src/riemann/kairosdb.clj
+++ b/src/riemann/kairosdb.clj
@@ -95,39 +95,36 @@
   and sends them to KairosDB. Silently drops events when KairosDB is down.
   Attempts to reconnect automatically every five seconds. Use:
 
+  ```clojure
   (kairosdb {:host \"kairosdb.local\" :port 4242 :protocol :tcp})
+  ```
 
   or
 
+  ```clojure
   (kairosdb {:host \"kairosdb.local\" :port 8080 :protocol :http})
+  ```
 
   Options:
 
-  :protocol       :tcp to use the Telnet API, or :http for the HTTP REST API.
-                  Default :tcp.
-
-  :metric-name    A function which, given an event, returns the string describing
-                  the path of that event in kairosdb. kairosdb-metric-name by
-                  default.
-
-  :tags    A function which, given an event, returns the hash-map for the tags.
-           kairosdb-tags by default.
-
-  :pool-size  The number of connections to keep open. Default 4.
-
-  :reconnect-interval   How many seconds to wait between attempts to connect.
-                        Default 5.
-
-  :claim-timeout        How many seconds to wait for a kairosdb connection from
-                        the pool. Default 0.1.
-
-  :block-start          Wait for the pool's initial connections to open
-                        before returning.
-
-  :ttl                  A function which, given an event, returns the TTL in
-                        seconds.
-                        Note: TTL is only supported in the HTTP API, and is
-                              ignored when sent via Telnet."
+  - :protocol       :tcp to use the Telnet API, or :http for the HTTP REST API.
+                    Default :tcp.
+  - :metric-name    A function which, given an event, returns the string describing
+                    the path of that event in kairosdb. kairosdb-metric-name by
+                    default.
+  - :tags    A function which, given an event, returns the hash-map for the tags.
+             kairosdb-tags by default.
+  - :pool-size  The number of connections to keep open. Default 4.
+  - :reconnect-interval   How many seconds to wait between attempts to connect.
+                          Default 5.
+  - :claim-timeout        How many seconds to wait for a kairosdb connection from
+                          the pool. Default 0.1.
+  - :block-start          Wait for the pool's initial connections to open
+                          before returning.
+  - :ttl                  A function which, given an event, returns the TTL in
+                          seconds.
+                          Note: TTL is only supported in the HTTP API, and is
+                                ignored when sent via Telnet."
   [opts]
   (let [opts (merge {:host "127.0.0.1"
                      :port 4242

--- a/src/riemann/keenio.clj
+++ b/src/riemann/keenio.clj
@@ -25,9 +25,11 @@
   returns a function that accepts an event and sends it to Keen IO. The full
   event will be sent.
 
+  ```clojure
   (streams
     (let [kio (keenio \"COLLECTION_NAME\" \"PROJECT_ID\" \"WRITE_KEY\")]
-      (where (state \"error\") kio)))"
+      (where (state \"error\") kio)))
+  ```"
   [collection project-id write-key]
   (fn [event]
     (post collection project-id write-key event)))

--- a/src/riemann/librato.clj
+++ b/src/riemann/librato.clj
@@ -46,11 +46,11 @@
   "Creates a librato metrics adapter. Takes your username and API key, and
   returns a map of streams:
 
-  :gauge
-  :counter
-  :annotation
-  :start-annotation
-  :end-annotation
+  - :gauge
+  - :counter
+  - :annotation
+  - :start-annotation
+  - :end-annotation
 
   Gauge and counter submit events as measurements. Annotation creates an
   annotation from the given event; it will have only a start time unless
@@ -61,6 +61,7 @@
 
   Example:
 
+  ```
   (def librato (librato-metrics \"aphyr@aphyr.com\" \"abcd01234...\"))
 
   (tagged \"latency\"
@@ -71,7 +72,8 @@
       (where (state \"ok\")
         (:start-annotation librato)
         (else
-          (:end-annotation librato)))))"
+          (:end-annotation librato)))))
+  ```"
   ([user api-key]
      (librato-metrics user api-key {:threads 4}))
   ([user api-key connection-mgr-options]

--- a/src/riemann/logentries.clj
+++ b/src/riemann/logentries.clj
@@ -31,7 +31,7 @@
   LogentriesClient
   (open [this]
     (let [sock (Socket. host port)]
-      (assoc this 
+      (assoc this
              :socket sock
              :out (OutputStreamWriter. (.getOutputStream sock)))))
   (send-line [this line]
@@ -48,20 +48,19 @@
   Silently drops events when Logentries is down. Attempts to reconnect
   automatically every five seconds. Use:
 
+  ```clojure
   (logentries {:token \"2bfbea1e-10c3-4419-bdad-7e6435882e1f\"})
+  ```
 
   Options:
 
-  :pool-size            The number of connections to keep open. Default 4.
-
-  :reconnect-interval   How many seconds to wait between attempts to connect.
-                        Default 5.
-
-  :claim-timeout        How many seconds to wait for a Logentries connection from
-                        the pool. Default 0.1.
-
-  :block-start          Wait for the pool's initial connections to open
-                        before returning."
+  - :pool-size            The number of connections to keep open. Default 4.
+  - :reconnect-interval   How many seconds to wait between attempts to connect.
+                          Default 5.
+  - :claim-timeout        How many seconds to wait for a Logentries connection from
+                          the pool. Default 0.1.
+  - :block-start          Wait for the pool's initial connections to open
+                          before returning."
   [opts]
   (let [host               (get opts :host "data.logentries.com")
         port               (get opts :port 80)

--- a/src/riemann/logging.clj
+++ b/src/riemann/logging.clj
@@ -185,22 +185,23 @@
   "Initialize logging. You will probably call this from the config file. You can
   call init more than once; its changes are destructive. Options:
 
-  :console?         Determine if logging should happen on the console.
-  :console-layout   Specifying console layout.
-  :file             The file to log to. If omitted, log to console only.
-  :file-layout      Specifying file layout.
-  :files            A list of files to log to. If provided, a seq or vector is
-                    expected containing maps with a :file and an :file-layout
-  :logsize-rotate   If size (in bytes) is specified use size based rotation
-                    otherwise use default time based rotation.
-  :rotate-count     Specifying the number of rotated files to keep. If omitted,
-                    keep last 10 rotated files.
+  - :console?         Determine if logging should happen on the console.
+  - :console-layout   Specifying console layout.
+  - :file             The file to log to. If omitted, log to console only.
+  - :file-layout      Specifying file layout.
+  - :files            A list of files to log to. If provided, a seq or vector is
+                      expected containing maps with a :file and an :file-layout
+  - :logsize-rotate   If size (in bytes) is specified use size based rotation
+                      otherwise use default time based rotation.
+  - :rotate-count     Specifying the number of rotated files to keep. If omitted,
+                      keep last 10 rotated files.
 
   Layout can be :riemann or :json. If layout is omitted, the default layout
   :riemann will be used.
 
   For example:
 
+  ```clojure
       ; Basic console logging
       (init)
 
@@ -220,7 +221,8 @@
              :files [{:file \"/var/log/riemann.log\"},
                      {:file \"/var/log/riemann.json.log\" :file-layout :json}]
              :logsize-rotate 100
-             :rotate-count 5})"
+             :rotate-count 5})
+  ```"
   ([] (init {}))
   ([opts]
     (let [logger   (get-logger)

--- a/src/riemann/logstash.clj
+++ b/src/riemann/logstash.clj
@@ -79,23 +79,23 @@
 
   Options:
 
-  :pool-size  The number of connections to keep open. Default 4.
+  - :pool-size  The number of connections to keep open. Default 4.
+  - :reconnect-interval   How many seconds to wait between attempts to connect.
+                          Default 5.
 
-  :reconnect-interval   How many seconds to wait between attempts to connect.
-                        Default 5.
+  - :claim-timeout        How many seconds to wait for a logstash connection from
+                          the pool. Default 0.1.
 
-  :claim-timeout        How many seconds to wait for a logstash connection from
-                        the pool. Default 0.1.
+  - :block-start          Wait for the pool's initial connections to open
+                          before returning.
 
-  :block-start          Wait for the pool's initial connections to open
-                        before returning.
-
-  :protocol             Protocol to use. Either :tcp (default), :tls or :udp.
+  - :protocol             Protocol to use. Either :tcp (default), :tls or :udp.
 
   TLS options:
-  :key              A PKCS8-encoded private key file
-  :cert             The corresponding public certificate
-  :ca-cert          The certificate of the CA which signed this key"
+
+  - :key              A PKCS8-encoded private key file
+  - :cert             The corresponding public certificate
+  - :ca-cert          The certificate of the CA which signed this key"
   [opts]
   (let [opts (merge {:host "127.0.0.1"
                      :port 9999

--- a/src/riemann/mailgun.clj
+++ b/src/riemann/mailgun.clj
@@ -43,44 +43,56 @@
   "Returns a mailer, which is a function invoked with an address or a sequence
   of addresses and returns a stream. That stream is a function which takes a
   single event, or a sequence of events, and sends email about them.
-  
+
+  ```clojure
   (def mailer (mailgun))
   (def email (mailer \"xerxes@trioptimum.org\" \"shodan@trioptimum.org\"))
- 
+  ```
+
   This mailer sends email out via mailgun using the mailgun http api. When used
   it outputs the http response recieved from mailgun.
 
+  ```clojure
   (changed :state
     #(info \"mailgun response\" (email %)))
+  ```
 
   The first argument is a map of the mailgun options :sandbox and :service-key.
   The second argument is a map of default message options, like :from,
   :subject, or :body.
-  
+
+  ```clojure
   (def email (mailgun {:sandbox \"mail.relay\" :service-key \"key\"}
-                     {:from \"riemann@trioptimum.com\"}))
+                      {:from \"riemann@trioptimum.com\"}))
+  ```
 
   If you provide a single map, the mailer will split the mailgun options out
   for you.
 
+  ```clojure
   (def email (mailgun {:sandbox \"mail.relay\"
-                      :service-key \"foo\"
-                      :from \"riemann@trioptimum.com\"}))
-  
+                       :service-key \"foo\"
+                       :from \"riemann@trioptimum.com\"}))
+  ```
+
   By default, riemann uses (subject events) and (body events) to format emails.
   You can set your own subject or body formatter functions by including
   :subject or :body in msg-opts. These formatting functions take a sequence of
   events and return a string.
 
-  (def email (mailgun {} {:body (fn [events] 
+  ```clojure
+  (def email (mailgun {} {:body (fn [events]
                                  (apply prn-str events))}))
-  
+  ```
+
   This api uses text body by default. If you want to use HTML body, you can set
   a body formatter function returns a map of fields :type and :content.
 
-  (def email (mailgun {} {:body (fn [events] 
+  ```
+  (def email (mailgun {} {:body (fn [events]
                                  {:type :html
-                                  :content \"<h1>HTML Body</h1>\"})}))"
+                                  :content \"<h1>HTML Body</h1>\"})}))
+  ```"
   ([] (mailgun {}))
   ([opts]
         (let [mg-keys #{:sandbox :service-key}

--- a/src/riemann/msteams.clj
+++ b/src/riemann/msteams.clj
@@ -33,20 +33,22 @@
 
 (defn msteams
   "Posts events to Microsoft Teams using Incoming Webhook.
-  Returns a function which is invoked with a URL and an optional formatter function 
-  and returns a stream. That stream is a function which takes an event or a 
+  Returns a function which is invoked with a URL and an optional formatter function
+  and returns a stream. That stream is a function which takes an event or a
   sequence of events and sends them to Microsoft Teams.
-  
+
+  ```clojure
   (def msteams-output (msteams {:url \"https://outlook.office.com/webhook/abc/IncomingWebhook/xyz\")
 
   (rollup 5 60 msteams-output)
+  ```
 
   Options:
 
-  :url Microsoft Teams Incoming Webhook URL
-  :formatter Optional message card formatting function, defaults to default-formatter
+  - :url Microsoft Teams Incoming Webhook URL
+  - :formatter Optional message card formatting function, defaults to default-formatter
 
-  The arity-2 version of the function accepts a map as the second argument which is 
+  The arity-2 version of the function accepts a map as the second argument which is
   passed directly to clj-http and can be used to set e.g. socket and connection timeouts.
   "
   ([opts]
@@ -55,7 +57,7 @@
    (fn [event]
      (let [events (if (sequential? event) event (list event))
            {url :url
-            formatter :formatter, :or {formatter default-formatter}} opts 
+            formatter :formatter, :or {formatter default-formatter}} opts
            request (json/generate-string (formatter events))]
        (client/post url
                     (merge http-params

--- a/src/riemann/nagios.clj
+++ b/src/riemann/nagios.clj
@@ -31,12 +31,10 @@
 
   (nagios {:host \"localhost\" :port 5667 :password \"secret\" :encryption TRIPLE_DES})
 
-  :host       Host where the Nagios service runs. Defaults to \"127.0.0.1\".
-  :port       The port to connect to. Defaults to 5667.
-  :password   The password as set in /etc/nsca.cfg. Defaults to \"password\".
-  :encryption The encryption method as set in /etc/nsca.cfg. Defaults to TRIPLE_DES.
-              Please note that currently only NONE, XOR and TRIPLE_DES are supported.
-  "
+  - :host       Host where the Nagios service runs. Defaults to \"127.0.0.1\".
+  - :port       The port to connect to. Defaults to 5667.
+  - :password   The password as set in /etc/nsca.cfg. Defaults to \"password\".
+  - :encryption The encryption method as set in /etc/nsca.cfg. Defaults to TRIPLE_DES. Please note that currently only NONE, XOR and TRIPLE_DES are supported."
   [opts]
   (let [opts (merge {:host "127.0.0.1"
                      :port 5667

--- a/src/riemann/netuitive.clj
+++ b/src/riemann/netuitive.clj
@@ -54,13 +54,20 @@
 (defn netuitive
   "Return a function which accepts either single events or batches of
    events in a vector and sends them to Netuitive.
+
   Usage:
+
   (netuitive {:api-key \"0123456789abcdef01234567890abcde\"})
+
   Option:
-  :api-key    Required - Netuitive's API Key for authentication.
-  :url        Optional - URL to post to Netuitive ingest - defaults to Production
-  :type       Optional - Arbitrary String to use as Element Type - defaults to \"Riemann\"
+
+  - :api-key    Required - Netuitive's API Key for authentication.
+  - :url        Optional - URL to post to Netuitive ingest - defaults to Production
+  - :type       Optional - Arbitrary String to use as Element Type - defaults to \"Riemann\"
+
   Example:
+
+  ```clojure
   (def netuitive-forwarder
     (batch 100 1/10
       (async-queue!
@@ -68,7 +75,8 @@
         {:queue-size     1e4  ; 10,000 events max
          :core-pool-size 5    ; Minimum 5 threads
          :max-pools-size 100} ; Maximum 100 threads
-        (netuitive {:api-key \"0123456789abcdef01234567890abcde\" :url \"https://api.app.netuitive.com/ingest/\" :type \"Riemann\"}))))"
+        (netuitive {:api-key \"0123456789abcdef01234567890abcde\" :url \"https://api.app.netuitive.com/ingest/\" :type \"Riemann\"}))))
+  ```"
   [opts]
   (let [opts (merge {:api-key "netuitive-api-key"} opts)]
     (fn [event]

--- a/src/riemann/opentsdb.clj
+++ b/src/riemann/opentsdb.clj
@@ -59,23 +59,18 @@
 
   Options:
 
-  :metric-name    A function which, given an event, returns the string describing
-                  the path of that event in opentsdb. opentsdb-metric-name by
-                  default.
-
-  :tags    A function which, given an event, returns the hash-map for the tags.
-           opentsdb-tags by default.
-
-  :pool-size  The number of connections to keep open. Default 4.
-
-  :reconnect-interval   How many seconds to wait between attempts to connect.
-                        Default 5.
-
-  :claim-timeout        How many seconds to wait for a opentsdb connection from
-                        the pool. Default 0.1.
-
-  :block-start          Wait for the pool's initial connections to open
-                        before returning."
+  - :metric-name    A function which, given an event, returns the string describing
+                    the path of that event in opentsdb. opentsdb-metric-name by
+                    default.
+  - :tags    A function which, given an event, returns the hash-map for the tags.
+             opentsdb-tags by default.
+  - :pool-size  The number of connections to keep open. Default 4.
+  - :reconnect-interval   How many seconds to wait between attempts to connect.
+                          Default 5.
+  - :claim-timeout        How many seconds to wait for a opentsdb connection from
+                          the pool. Default 0.1.
+  - :block-start          Wait for the pool's initial connections to open
+                          before returning."
   [opts]
   (let [opts (merge {:host "127.0.0.1"
                      :port 4242

--- a/src/riemann/opsgenie.clj
+++ b/src/riemann/opsgenie.clj
@@ -65,10 +65,12 @@
   functions which trigger and resolve events. clojure/hash from event host, service and tags
   will be used as the alias.
 
+  ```clojure
   (let [og (opsgenie \"my-service-key\" \"recipient@example.com\")]
     (changed-state
       (where (state \"ok\") (:resolve og))
-      (where (state \"critical\") (:trigger og))))"
+      (where (state \"critical\") (:trigger og))))
+  ```"
   [service-key recipients]
   {:trigger     #(create-alert service-key % recipients)
    :resolve     #(close-alert service-key %)})

--- a/src/riemann/pagerduty.clj
+++ b/src/riemann/pagerduty.clj
@@ -97,13 +97,13 @@
 
   General options:
 
-  `:service-key`         Pagerduty service key (also called integration key
+  - `:service-key`         Pagerduty service key (also called integration key
   or routing key)
-  `:formatter`           Formatter for the pagerduty event. You can override
+  - `:formatter`           Formatter for the pagerduty event. You can override
   the default formatter. The formatter must be a function that accepts an event
   and emits a hash. (optional)
-  `:options`             Extra HTTP options. (optional)
-  `:version`             set to `:v2` to use Pagerduty v2 API. (optional)
+  - `:options`             Extra HTTP options. (optional)
+  - `:version`             set to `:v2` to use Pagerduty v2 API. (optional)
 
   v1 API:
 
@@ -121,6 +121,7 @@
 
   Example, using the v1 API with a custom formatter:
 
+  ```clojure
   (defn pd-format-event
     [event]
     {:incident_key 'Incident key', :description 'Incident Description',
@@ -129,7 +130,8 @@
   (let [pd (pagerduty { :service-key \"my-service-key\" :formatter pd-format-event})]
     (changed-state
       (where (state \"ok\") (:resolve pd))
-      (where (state \"critical\") (:trigger pd))))"
+      (where (state \"critical\") (:trigger pd))))
+  ```"
   [config]
   {:trigger     (fn [e] (send-event :trigger config e))
    :acknowledge (fn [e] (send-event :acknowledge config e))

--- a/src/riemann/pool.clj
+++ b/src/riemann/pool.clj
@@ -60,10 +60,10 @@
   nil, the pool will sleep for regenerate-interval seconds before retrying
   (open).
 
-  :regenerate-interval    How long to wait between retrying (open).
-  :size                   Number of thingys in the pool.
-  :block-start            Should (fixed-pool) wait until the pool is full
-                          before returning?
+  - :regenerate-interval    How long to wait between retrying (open).
+  - :size                   Number of thingys in the pool.
+  - :block-start            Should (fixed-pool) wait until the pool is full
+                            before returning?
 
   Note that fixed-pool is correct only if every successful (claim) is followed
   by exactly one of either (invalidate) or (release). If calls are unbalanced;
@@ -97,10 +97,12 @@
   given pool, with specified claim timeout. Releases thingy at the end of the
   body, or if an exception is thrown, invalidates them and rethrows. Example:
 
+  ```clojure
   ; With client, taken from connection-pool, waiting 5 seconds to claim, send
   ; client a message.
   (with-pool [client connection-pool 5]
-    (send client a-message))"
+    (send client a-message))
+  ```"
   [[thingy pool timeout] & body]
   ; Destructuring bind could change nil to a, say, vector, and cause
   ; unbalanced claim/release.

--- a/src/riemann/prometheus.clj
+++ b/src/riemann/prometheus.clj
@@ -83,15 +83,16 @@
   "Returns a function which accepts an event and sends it to prometheus.
 
    Usage:
+
    (prometheus {:host \"prometheus.example.com\"})
 
    Options:
-   `:host`           Prometheus Pushgateway Server IP (default: \"localhost\")
-   `:port`           Prometheus Pushgateway Server Port (default: 9091)
-   `:job`            Group Name to be assigned (default: \"riemann\")
-   `:separator`      Separator to be used for Riemann tags (default: \",\")
-   `:exclude-fields` Set of Riemann fields to exclude from Prometheus labels
-  "
+
+   - `:host`           Prometheus Pushgateway Server IP (default: \"localhost\")
+   - `:port`           Prometheus Pushgateway Server Port (default: 9091)
+   - `:job`            Group Name to be assigned (default: \"riemann\")
+   - `:separator`      Separator to be used for Riemann tags (default: \",\")
+   - `:exclude-fields` Set of Riemann fields to exclude from Prometheus labels"
   [opts]
   (let [opts (merge {:host            "localhost"
                      :port            9091

--- a/src/riemann/pushover.clj
+++ b/src/riemann/pushover.clj
@@ -22,21 +22,22 @@
                  (:metric event) ")")})
 
 (defn pushover
-  "Returns a function which accepts an event and sends it to Pushover. 
-  An options map can be provided as an optional third argument. 
-  
+  "Returns a function which accepts an event and sends it to Pushover.
+  An options map can be provided as an optional third argument.
+
   Options:
 
-    :formatter Optional event formatter function
+  - :formatter Optional event formatter function
 
   For details on Pushover options see https://pushover.net/api
 
   Examples:
 
+  ```clojure
   (pushover \"APPLICATION_TOKEN\" \"USER_KEY\")
 
-  (pushover \"APPLICATION_TOKEN\" \"USER_KEY\" {:formatter my-custom-event-formatter})"
-
+  (pushover \"APPLICATION_TOKEN\" \"USER_KEY\" {:formatter my-custom-event-formatter})
+  ```"
   ([token user]
    (pushover token user {}))
   ([token user opts]

--- a/src/riemann/query.clj
+++ b/src/riemann/query.clj
@@ -199,9 +199,11 @@
   "Transforms an AST into a fn [event] which returns true if the query matches
   that event. Example:
 
+  ```clojure
   (def q (fun (ast \"metric > 2\")))
   (q {:metric 1}) => false
-  (q {:metric 3}) => true"
+  (q {:metric 3}) => true
+  ```"
   [ast]
   (if-let [fun (cache/lookup @fun-cache ast)]
     ; Cache hit

--- a/src/riemann/repl.clj
+++ b/src/riemann/repl.clj
@@ -18,9 +18,9 @@
 
 (defn start-server!
   "Starts a new repl server. Stops the old server first, if any. Options:
-  
-  :host (default \"127.0.0.1\")
-  :port (default 5557)"
+
+  - :host (default \"127.0.0.1\")
+  - :port (default 5557)"
   [opts]
   (stop-server!)
   (let [opts (merge {:port 5557 :host "127.0.0.1"} opts)]

--- a/src/riemann/service.clj
+++ b/src/riemann/service.clj
@@ -136,18 +136,22 @@
 (defmacro all-equal?
   "Takes two objects to compare and a list of forms to compare them by.
 
+  ```clojure
   (all-equiv? foo bar
     (class)
     (foo 2)
     (.getSize))
+  ```
 
   becomes
 
+  ```clojure
   (let [a foo
         b bar]
     (and (= (class a) (class b))
          (= (foo 2 a) (foo 2 b))
-         (= (.getSize a) (.getSize b))))"
+         (= (.getSize a) (.getSize b))))
+  ```"
   [a b & forms]
   (let [asym (gensym "a__")
         bsym (gensym "b__")]
@@ -308,8 +312,10 @@
   Otherwise, services are equivalent when their class, name, and equiv-key are
   equal.
 
+  ```clojure
   (executor-service* :graphite {foo: 4}
-    #(ThreadPoolExecutor. 2 ...))"
+    #(ThreadPoolExecutor. 2 ...))
+  ```"
   ([name f] (executor-service name nil f))
   ([name equiv-key f]
    (ExecutorServiceService. name equiv-key f nil (atom nil))))
@@ -320,9 +326,9 @@
   any variables or function calls, they will be compared as code, not as
   their evaluated values.
 
-  OK:  (literal-executor-service :io (ThreadPoolExecutor. 2 ...))
-  OK:  (literal-executor-service :io (ThreadPoolExecutor. (inc 1) ...))
-  BAD: (literal-executor-service :io (ThreadPoolExecutor. x ...))"
+  - OK:  (literal-executor-service :io (ThreadPoolExecutor. 2 ...))
+  - OK:  (literal-executor-service :io (ThreadPoolExecutor. (inc 1) ...))
+  - BAD: (literal-executor-service :io (ThreadPoolExecutor. x ...))"
   [name executor-service-expr]
   `(executor-service
      ~name
@@ -333,11 +339,11 @@
   "An ExecutorServiceService based on a ThreadPoolExecutor with core and
   maximum threadpool sizes, and a LinkedBlockingQueue of a given size. Options:
 
-  :core-pool-size             Default 1
-  :max-pool-size              Default 128
-  :keep-alive-time            Default 10
-  :keep-alive-unit            Default MILLISECONDS
-  :queue-size                 Default 1000"
+  - :core-pool-size             Default 1
+  - :max-pool-size              Default 128
+  - :keep-alive-time            Default 10
+  - :keep-alive-unit            Default MILLISECONDS
+  - :queue-size                 Default 1000"
   ([name] (threadpool-service name {}))
   ([name {:keys [core-pool-size
                  max-pool-size

--- a/src/riemann/shinken.clj
+++ b/src/riemann/shinken.clj
@@ -28,12 +28,11 @@
 
   Options:
 
-  :hostname     Host name of the Shinken receiver/arbiter. Default is
-                \"127.0.0.1\".
-  :port         Port that mod-ws-arbiter is listening to. Default is 7760
-  :username     Username. Default is \"admin\".
-  :password     Password of the corresponding user. Default is \"admin\"."
-
+  - :hostname     Host name of the Shinken receiver/arbiter. Default is
+                  \"127.0.0.1\".
+  - :port         Port that mod-ws-arbiter is listening to. Default is 7760
+  - :username     Username. Default is \"admin\".
+  - :password     Password of the corresponding user. Default is \"admin\"."
   [opts]
   (let
     [opts (merge {:hostname "127.0.0.1"

--- a/src/riemann/slack.clj
+++ b/src/riemann/slack.clj
@@ -73,12 +73,14 @@
   Takes your account name, webhook token, bot username and channel name.
   Returns a function that will post a message into slack.com channel:
 
+  ```clojure
   (def credentials {:account \"some_org\", :token \"53CR3T\"})
   (def slacker (slack credentials {:username \"Riemann bot\"
                                    :channel \"#monitoring\"
                                    :icon \":smile:\"}))
 
   (by [:service] slacker)
+  ```
 
   Hint: token is the last part of the webhook URL that Slack gives you.
   https://hooks.slack.com/services/QWERSAFG0/AFOIUYTQ48/120984SAFJSFR
@@ -87,30 +89,33 @@
   You can also supply a custom formatter for formatting events into Slack
   messages. Formatter result may contain:
 
-    * `username` - overrides the username provided upon construction
-    * `channel` - overrides the channel provided upon construction
-    * `icon` - overrides the icon provided upon construction
-    * `text` - main text formatted using Slack markup
-    * `attachments` - array of attachments according to https://api.slack.com/docs/attachments
+    - `username` - overrides the username provided upon construction
+    - `channel` - overrides the channel provided upon construction
+    - `icon` - overrides the icon provided upon construction
+    - `text` - main text formatted using Slack markup
+    - `attachments` - array of attachments according to https://api.slack.com/docs/attachments
 
+  ```clojure
   (def slacker (slack credentials {:username \"Riemann bot\", :channel \"#monitoring\"
                                    :formatter (fn [e] {:text (:state e)
                                                        :icon \":happy:\"})))
+  ```
 
   You can use `slack` inside of a grouping function which produces a seq of
   events, like `rollup`:
 
+  ```clojure
   (def slacker (slack credentials {:username \"Riemann bot\", :channel \"#monitoring\"
                                    :formatter (fn [es] {:text (apply str (map :state es))})))
 
   (rollup 5 60 slacker)
+  ```
 
   The last parameter of the arity-3 version of the function is a map
   of parameters passed directly to clj-http. For example, you can set
   socket and connection timeouts like so:
 
-  (slack {...} {...} {:socket-timeout 1000 :conn-timeout 1000})
-  "
+  (slack {...} {...} {:socket-timeout 1000 :conn-timeout 1000})"
   ([account_name token username channel] (slack {:account account_name, :token token}
                                                 {:username username, :channel channel}))
   ([account-info message-info]

--- a/src/riemann/sns.clj
+++ b/src/riemann/sns.clj
@@ -119,16 +119,18 @@
   sequence of ARNs and returns a stream. That stream is a function which takes a
   single event, or a sequence of events, and publishes a message about them.
 
+  ```clojure
   (def sns (sns-publisher))
 
   (changed :state
     (sns \"arn:aws:sns:region:id:xerxes\" \"arn:aws:sns:region:id:shodan\"))
+  ```
 
   The first argument is a map of AWS credentials:
 
-    :access-key ; required
-    :secret-key ; required
-    :region     ; optional
+    - :access-key ; required
+    - :secret-key ; required
+    - :region     ; optional
 
   The :region value is passed to com.amazonaws.regions.RegionUtils/getRegion.
   For a list of region names that you can use, see:
@@ -140,26 +142,30 @@
   The second argument is a map of default message options, like :body or
   :subject.
 
+  ```clojure
   (def sns (sns-publisher {:access-key \"my-access-key\"
                            :secret-key \"my-secret-key\"}
                           {:subject \"something is ok\"}))
+  ```
 
   The third is an optional map specifying async options:
 
-    :async   ; optional true / false (default)
-    :success ; optional callback invoked on success
-             ; e.g. (fn [req res] ...)
-    :error   ; optional callback invoked on error
-             ; e.g. (fn [exception] ...)
-             ; you must specify both :success and :error
-             ; or else, none at all
+    - :async   ; optional true / false (default)
+    - :success ; optional callback invoked on success
+               ; e.g. (fn [req res] ...)
+    - :error   ; optional callback invoked on error
+               ; e.g. (fn [exception] ...)
+               ; you must specify both :success and :error
+               ; or else, none at all
 
   If you provide a single map, they will be split out for you.
 
+  ```clojure
   (def sns (sns-publisher {:access-key \"your-access-key\"
                            :secret-key \"your-secret-key\"
                            :subject \"something went wrong\"
                            :async true}))
+  ```
 
   By default, riemann uses (riemann.common/subject events) and
   (riemann.common/body events) to format messages.
@@ -167,8 +173,10 @@
   :subject or :body in msg-opts. These formatting functions take a sequence of
   events and return a string.
 
+  ```clojure
   (def sns (sns-publisher {} {:body (fn [events]
-                                      (apply prn-str events))}))"
+                                      (apply prn-str events))}))
+  ```"
   ([] (sns-publisher {}))
   ([opts]
      (let [{aws-opts   :aws-opts

--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -82,9 +82,11 @@
   "Catches exceptions, converts them to events, and sends those events to a
   special exception stream.
 
+  ```clojure
   (exception-stream (email \"polito@vonbraun.com\")
     (async-queue! :graphite {:core-pool-size 128}
       graph))
+  ```
 
   Streams often take multiple children and send an event to each using
   call-rescue. Call-rescue will rescue any exception thrown by a child stream,
@@ -102,8 +104,10 @@
   *also* during the evaluation of the child streams themselves, e.g. at the
   invocation time of exceptions itself. If we write
 
+  ```clojure
   (exception-stream (email ...)
     (rate 5 index))
+  ```
 
   then (rate), when invoked, might need access to this variable immediately.
   Therefore, this macro binds *exception-stream* twice: one when evaluating
@@ -123,7 +127,9 @@
 (defn dual
   "A stream which splits events into two mirror-images streams, based on
   (pred e).
+
   If (pred e) is true, calls (true-stream e) and (false-stream (expire e)).
+
   If (pred e) is false, does the opposite. Expired events are forwarded to both
   streams.
 
@@ -158,8 +164,10 @@
   "Streaming map. Calls children with (f event), whenever (f event) is non-nil.
   Prefer this to (adjust f) and (combine f). Example:
 
+  ```clojure
   (smap :metric prn) ; prints the metric of each event.
-  (smap #(assoc % :state \"ok\") index) ; Indexes each event with state \"ok\""
+  (smap #(assoc % :state \"ok\") index) ; Indexes each event with state \"ok\"
+  ```"
   [f & children]
   (fn stream [event]
     (let [value (f event)]
@@ -173,6 +181,7 @@
   aggregate all services, and smapcat to find the mode and assoc the proper
   states; emitting a series of individual events to the index.
 
+  ```clojure
   (coalesce
     (smapcat (fn [events]
                (let [freqs (frequencies (map :metric events))
@@ -180,7 +189,8 @@
                  (map #(assoc % :state (if (= mode (:metric %))
                                          \"ok\" \"warning\"))
                       events)))
-      index))"
+      index))
+  ```"
   [f & children]
   (fn stream [event]
     (doseq [e (f event)]
@@ -196,8 +206,10 @@
 (defn sreduce
   "Streaming reduce. Two forms:
 
+  ```clojure
   (sreduce f child1 child2 ...)
   (sreduce f val child1 child2 ...)
+  ```
 
   Maintains an internal value, which defaults to the first event received or,
   if provided, val. When the stream receives an event, calls (f val event) to
@@ -205,10 +217,14 @@
   effects. Examples:
 
   Passes on events, but with the *maximum* of all received metrics:
+
+  ```clojure
   (sreduce (fn [acc event] (assoc event :metric
                                   (max (:metric event) (:metric acc)))) ...)
+  ```
 
   Or, using riemann.folds, a simple moving average:
+
   (sreduce (fn [acc event] (folds/mean [acc event])) ...)"
   [f & opts]
   (if (fn? (first opts))
@@ -258,13 +274,15 @@
   riemann.service/executor-service for reloadable asynchronous execution of
   streams. See also: async-queue!, which may be simpler.
 
+  ```clojure
   (let [io-pool (service!
                   (executor-service
                     #(ThreadPoolExecutor. 1 10 ...)))
         graph (execute-on io-pool (graphite {:host ...}))]
     ...
     (tagged \"graph\"
-      graph))"
+      graph))
+  ```"
   [^Executor executor & children]
   (fn stream [event]
     (.execute executor
@@ -340,6 +358,7 @@
   *not* overlap; each event appears at most once in the output stream. Once an
   event is emitted, all events *older or equal* to that emitted event are
   silently dropped.
+
   Events without times accrue in the current window."
   [n start-time-fn & children]
   ; This is not a particularly inspired or clear implementation. :-(
@@ -529,10 +548,10 @@
 
   Concurrency guarantees:
 
-  (create) may be called multiple times for a given time slice.
-  (add)    when called, will receive exactly one distinct bucket in each time
-           slice.
-  (finish) will be called *exactly once* for each time slice."
+  - (create) may be called multiple times for a given time slice.
+  - (add)    when called, will receive exactly one distinct bucket in each time
+             slice.
+  - (finish) will be called *exactly once* for each time slice."
   [interval create add finish]
   (let [state (atom nil)
         ; Set up an initial bin and start time.
@@ -810,8 +829,10 @@
   the difference between the current event and the previous one, divided by the
   difference in their times. Skips events without metrics.
 
+  ```clojure
   (ddt 5 graph index)
-  (ddt graph index)"
+  (ddt graph index)
+  ```"
   [& args]
   (if (number? (first args))
     (apply ddt-real args)
@@ -880,11 +901,13 @@
   "Counts things. The first argument may be an initial counter value, which
   defaults to zero.
 
+  ```clojure
   ; Starts at zero
   (counter index)
 
   ; Starts at 500
   (counter 500 index)
+  ```
 
   Events without metrics are passed through unchanged. Events with metrics
   increment the counter, and are passed on with their metric set to the current
@@ -1044,13 +1067,17 @@
 
   Index the top 10 events, by metric:
 
+  ```clojure
   (top 10 :metric index)
+  ```
 
   Index everything, but tag the top k events with \"top\":
 
+  ```clojure
   (top 10 :metric
     (tag \"top\" index)
     index)
+  ```
 
   This implementation of top is lazy, in the sense that it won't proactively
   expire events which are bumped from the top-k set--you have to wait for
@@ -1095,11 +1122,11 @@
   *vectors* of events to children, not a single event at a time. For instance,
   (rollup 3 1 f) receives five events and forwards three times per second:
 
-  1 -> (f [1])
-  2 -> (f [2])
-  3 -> (f [3])
-  4 ->
-  5 ->
+  - 1 -> (f [1])
+  - 2 -> (f [2])
+  - 3 -> (f [3])
+  - 4 ->
+  - 5 ->
 
   ... and events 4 and 5 are rolled over into the next period:
 
@@ -1192,8 +1219,10 @@
   Every 10 seconds, print a sequence of events including all the events which
   share the same :foo and :bar attributes:
 
+  ```clojure
   (by [:foo :bar]
-    (coalesce 10 prn))"
+    (coalesce 10 prn))
+  ```"
   [& [dt & children]]
   (let [children (if (number? dt) children (cons dt children))
         dt (if (number? dt) dt 1)
@@ -1235,12 +1264,14 @@
   "Passes events on to children only when (f event) matches value, using
   riemann.common/match. For instance:
 
+  ```clojure
   (match :service nil prn)
   (match :state #{\"warning\" \"critical\"} prn)
   (match :description #\"error\" prn)
   (match :metric 5 prn)
   (match expired? true prn)
   (match (fn [e] (/ (:metric e) 1000)) 5 prn)
+  ```
 
   For cases where you only care about whether (f event) is truthy, use (where
   some-fn) instead of (match some-fn true)."
@@ -1262,8 +1293,10 @@
 
   Can be used as a predicate in a where form.
 
+  ```clojure
   (tagged-all \"foo\" prn)
-  (tagged-all [\"foo\" \"bar\"] prn)"
+  (tagged-all [\"foo\" \"bar\"] prn)
+  ```"
   [tags & children]
   (let [tag-coll (flatten [tags])]
     (fn stream [event]
@@ -1283,8 +1316,10 @@
 
   Can be used as a predicate in a where form.
 
+  ```clojure
   (tagged-any \"foo\" prn)
-  (tagged-all [\"foo\" \"bar\"] prn)"
+  (tagged-all [\"foo\" \"bar\"] prn)
+  ```"
   [tags & children]
   (let [tag-coll (flatten [tags])]
     (fn stream [event]
@@ -1319,11 +1354,13 @@
   event, use `adjust`. If you want to update events using arbitrary functions,
   use `smap`.
 
+  ```clojure
   ; Print each event, but with service \"foo\"
   (with :service \"foo\" prn)
 
   ; Print each event, but with no host and state \"broken\".
-  (with {:host nil :state \"broken\"} prn)"
+  (with {:host nil :state \"broken\"} prn)
+  ```"
   [& args]
   (if (map? (first args))
     (let [[m & children] args
@@ -1358,8 +1395,10 @@
   when you want to fill in default values for events that might come in without
   them.
 
+  ```clojure
   (default :ttl 300 index)
-  (default {:service \"jrecursive\" :state \"chicken\"} index)"
+  (default {:service \"jrecursive\" :state \"chicken\"} index)
+  ```"
   [& args]
   (if (map? (first args))
     ; Merge in a map of new values.
@@ -1413,6 +1452,7 @@
    metric with the given scale factor.
 
   ; Convert bytes to kilobytes
+
   (scale 1/1024 index)"
   [factor & children]
   (let [scale-event (fn [{:keys [metric] :as event}]
@@ -1443,10 +1483,12 @@
 
   With pipe, we write
 
+  ```clojure
   (pipe ↧ (a ↧)
           (b ↧)
           (c ↧)
           d)
+  ```
 
   The first argument ↧ is a *marker* for points where events should flow down
   into the next stage. A delightful list of marker symbols you might enjoy is
@@ -1457,19 +1499,23 @@
   the expression*. For instance, we might want to categorize events based on
   their metric, and send all those events into the same throttled email stream.
 
+  ```clojure
   (let [throttled-emailer (throttle 100 1 (email \"ops@rickenbacker.mil\"))]
     (splitp < metric
       0.9 (with :state :critical throttled-emailer)
       0.5 (with :state :warning  throttled-emailer)
           (with :state :ok       throttled-emailer)))
+  ```
 
   But with pipe, we can write:
 
+  ```clojure
   (pipe - (splitp < metric
                   0.9 (with :state :critical -)
                   0.5 (with :state :warning  -)
                       (with :state :ok       -))
           (throttle 100 1 (email \"ops@rickenbacker.mil\")))
+  ```
 
   So pipe lets us do three things:
 
@@ -1554,8 +1600,9 @@
   "Passes on events only when (f event) differs from that of the previous
   event. Options:
 
-  :init   The initial value to assume for (pred event).
+  - :init   The initial value to assume for (pred event).
 
+  ```clojure
   ; Print all state changes
   (changed :state prn)
 
@@ -1569,7 +1616,8 @@
 
   ; Note that f can be an arbitrary function:
 
-  (changed (fn [e] (> (:metric e) 2)) ...)"
+  (changed (fn [e] (> (:metric e) 2)) ...)
+  ```"
   [pred & children]
   (let [options  (if (map? (first children)) (first children) {})
         children (if (map? (first children))
@@ -1679,12 +1727,14 @@
   When (f event) is truthy, passes event to children--and otherwise, passes
   event to (else ...) children. For example:
 
+  ```clojure
   (where* (fn [e] (< 2 (:metric e))) prn)
 
   (where* expired?
     (partial prn \"Expired\")
     (else
-      (partial prn \"Not expired!\")))"
+      (partial prn \"Not expired!\")))
+  ```"
   [f & children]
   (let [[true-kids else-kids] (where-partition-clauses children)]
     `(let [true-kids# ~true-kids
@@ -1701,6 +1751,7 @@
   "Passes on events where expr is true. Expr is rewritten using where-rewrite.
   'event is bound to the event under consideration. Examples:
 
+  ```clojure
   ; Match any event where metric is either 1, 2, 3, or 4.
   (where (metric 1 2 3 4) ...)
 
@@ -1716,14 +1767,17 @@
   (where (service #{\"service-foo\" \"service-bar\"}) ...)
   ; which is equivalent to
   (where (service \"service-foo\" \"service-bar\") ...)
+  ```
 
   If a child begins with (else ...), the else's body is executed when expr is
   false. For instance:
 
+  ```clojure
   (where (service \"www\")
     (notify-www-team)
     (else
       (notify-misc-team)))
+  ```
 
   The streams generated by (where) return the value of expr: truthy if expr
   matched the given event, and falsey otherwise. This means (where (metric 5))
@@ -1753,10 +1807,12 @@
    Conditions are functions as for where*.  An odd number of forms will make
   the last form the default stream. For example:
 
+  ```clojure
    (split*
      (fn [e] (< 0.9  (:metric e))) (with :state \"critical\" index)
      (fn [e] (< 0.75 (:metric e))) (with :state \"warning\" index)
-     (with :state \"ok\" index))"
+     (with :state \"ok\" index))
+  ```"
   [& clauses]
   (let [clauses (partition-all 2 clauses)]
     (fn stream [event]
@@ -1767,10 +1823,12 @@
   "Behave as for split*, expecting predicates to be (where) expressions instead
   of functions. Example:
 
+  ```clojure
   (split
     (< 0.9  metric) (with :state \"critical\" index)
     (< 0.75 metric) (with :state \"warning\" index)
-    (with :state \"ok\" index))"
+    (with :state \"ok\" index))
+  ```"
   [& clauses]
   (let [clauses (mapcat (fn [clause]
                           (if (nil? (second clause))
@@ -1798,10 +1856,12 @@
 
   Example:
 
+  ```clojure
   (splitp < metric
     0.9  (with :state \"critical\" index)
     0.75 (with :state \"warning\" index)
-         (with :state \"ok\" index))"
+         (with :state \"ok\" index))
+  ```"
   [pred expr & clauses]
   (let [; Split up clauses into [stream test-expr] pairs
         clauses (map (fn [[a b :as clause]]
@@ -1868,6 +1928,7 @@
   In these plots, stable events are shown as =, and unstable events are shown
   as -. = events are passed to children, and - events are ignored.
 
+  ```
        A spike           Flapping           Stable changes
   |                 |                    |
   |       -         |    -- -   ======   |      =====
@@ -1875,13 +1936,16 @@
   |======= ======   |====  -  --         |======
   +------------->   +---------------->   +------------------>
         time              time                  time
+  ```
 
   May buffer events for up to dt seconds when the value of (f event) changes,
   in order to determine if the new value is stable or not.
 
+  ```clojure
   ; Passes on events where the state remains the same for at least five
   ; seconds.
-  (stable 5 :state prn)"
+  (stable 5 :state prn)
+  ```"
   [dt f & children]
   (let [state (atom {:prev   ::unknown
                      :task   nil
@@ -2004,11 +2068,13 @@
   Use project when you want to compare a small number of distinct states over
   time. For instance, to find the ratio of enqueues to dequeues:
 
+  ```clojure
   (project [(service \"enqueues\")
             (service \"dequeues\")]
     (smap folds/quotient
       (with :service \"enqueues per dequeue\"
         ...)))
+  ```
 
   Here we've combined separate events--enqueues and dequeues--into a single
   event, using the folds/quotient function, which divides the first event's

--- a/src/riemann/telegram.clj
+++ b/src/riemann/telegram.clj
@@ -57,24 +57,26 @@
 
   Options:
 
-  `:token`              The telegram token
-  `:http-options`       clj-http extra options (optional)
-  `:telegram-options`   These options are merged with the `:form-params` key of
+  - `:token`              The telegram token
+  - `:http-options`       clj-http extra options (optional)
+  - `:telegram-options`   These options are merged with the `:form-params` key of
   the request. The `:chat_id` key is mandatory.
   By default, the `:parse_mode` key is \"Markdown\".
-  `:message-formatter`  A function accepting an event and returning a string. (optional).
+  - `:message-formatter`  A function accepting an event and returning a string. (optional).
   If not specified, `html-parse-mode` or `markdown-parse-mode` will be used,
   depending on the `:parse_mode` value.
 
   Usage:
 
+  ```clojure
   (def token \"define_your_token\")
   (def chat-id \"0123456\")
 
   (streams
     (telegram {:token token
                :telegram-options {:chat_id chat-id
-                                  :parse_mode \"HTML\"}}))"
+                                  :parse_mode \"HTML\"}}))
+  ```"
   [opts]
   (fn [event]
     (let [events (if (sequential? event) event [event])]

--- a/src/riemann/test.clj
+++ b/src/riemann/test.clj
@@ -84,9 +84,11 @@
   at compile time, returns a function that discards any incoming events. When
   *testing* is false, compiles to (sdo child1 child2 ...).
 
+  ```clojure
   (io
     (fn [e]
-      (http/put \"http://my.service/callback\", {:body (event->json e)})))"
+      (http/put \"http://my.service/callback\", {:body (event->json e)})))
+  ```"
   [& children]
   (if *testing*
     `streams/bit-bucket
@@ -112,9 +114,11 @@
   your compile time run time and wow
   this gets confusing.
 
+  ```clojure
   (with-test-env
     (eval '(let [s (tap :foo prn)]
              (run-test! [s] [:hi]))))
+  ```
 
   prints :hi, and returns {:foo [:hi]}"
   [& body]
@@ -165,9 +169,11 @@
   "Like clojure.test deftest, but establishes a fresh time context and a fresh
   set of tap results for the duration of the body.
 
+  ```clojure
   (deftest my-tap
     (let [rs (test/inject! [{:time 2 :service \"bar\"}])]
-      (is (= 1 (count (:some-tap rs))))))"
+      (is (= 1 (count (:some-tap rs))))))
+  ```"
   [name & body]
   `(test/deftest ~name
      (binding [*results* (fresh-results @*taps*)]

--- a/src/riemann/transport.clj
+++ b/src/riemann/transport.clj
@@ -75,10 +75,12 @@
   on their names are bound once and re-used in every invocation of
   getPipeline(), other handlers will be evaluated each time.
 
+  ```clojure
   (channel-pipeline-factory
              frame-decoder    (make-an-int32-frame-decoder)
     ^:shared protobuf-decoder (ProtobufDecoder. (Proto$Msg/getDefaultInstance))
-    ^:shared msg-decoder      msg-decoder)"
+    ^:shared msg-decoder      msg-decoder)
+  ```"
   [& names-and-exprs]
   (assert (even? (count names-and-exprs)))
   (let [handlers (partition 2 names-and-exprs)

--- a/src/riemann/transport/graphite.clj
+++ b/src/riemann/transport/graphite.clj
@@ -120,11 +120,11 @@
 (defn graphite-server
   "Start a graphite-server. Options:
 
-  :host       \"127.0.0.1\"
-  :port       2003
-  :protocol   :tcp or :udp (default :tcp)
-  :parser-fn  an optional function to further transform events after decoding.
-  :tags       converts Graphite tags into event attributes (default false)"
+  - :host       \"127.0.0.1\"
+  - :port       2003
+  - :protocol   :tcp or :udp (default :tcp)
+  - :parser-fn  an optional function to further transform events after decoding.
+  - :tags       converts Graphite tags into event attributes (default false)"
   ([] (graphite-server {}))
   ([opts]
      (let [core (get opts :core (atom nil))

--- a/src/riemann/transport/opentsdb.clj
+++ b/src/riemann/transport/opentsdb.clj
@@ -120,10 +120,10 @@
 (defn opentsdb-server
   "Start a opentsdb-server. Options:
 
-  :host       \"127.0.0.1\"
-  :port       4242
-  :parser-fn  an optional function which transforms events prior to streaming
-              into the core."
+  - :host       \"127.0.0.1\"
+  - :port       4242
+  - :parser-fn  an optional function which transforms events prior to streaming
+                into the core."
   ([] (opentsdb-server {}))
   ([opts]
      (let [core  (get opts :core (atom nil))

--- a/src/riemann/transport/sse.clj
+++ b/src/riemann/transport/sse.clj
@@ -142,13 +142,14 @@
   "Creates a new SSE server for a core.
 
   Options:
-  :host    The address to listen on (default 127.0.0.1)
-  :port    The port to listen on (default 5558)
-  :headers Additional headers to send with the reply. By default
-           Content-Type is set to text/event-stream and Cache-Control to
-           no-cache. If you do not expose your client web application behind
-           the same host, you will probably need to add an
-           Access-Control-Allow-Origin header here"
+
+  - :host    The address to listen on (default 127.0.0.1)
+  - :port    The port to listen on (default 5558)
+  - :headers Additional headers to send with the reply. By default
+             Content-Type is set to text/event-stream and Cache-Control to
+             no-cache. If you do not expose your client web application behind
+             the same host, you will probably need to add an
+             Access-Control-Allow-Origin header here"
   ([] (sse-server {}))
   ([{:keys [host port headers]
      :or   {host    "127.0.0.1"

--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -247,18 +247,20 @@
   "Create a new TCP server. Doesn't start until (service/start!).
 
   Options:
-  :host             The host to listen on (default 127.0.0.1).
-  :port             The port to listen on. (default 5554 with TLS, or 5555 std)
-  :core             An atom used to track the active core for this server.
-  :so-backlog       The maximum queue length for incoming tcp connections (default 50).
-  :channel-group    A global channel group used to track all connections.
-  :initializer      A ChannelInitializer for creating new pipelines.
+
+  - :host             The host to listen on (default 127.0.0.1).
+  - :port             The port to listen on. (default 5554 with TLS, or 5555 std)
+  - :core             An atom used to track the active core for this server.
+  - :so-backlog       The maximum queue length for incoming tcp connections (default 50).
+  - :channel-group    A global channel group used to track all connections.
+  - :initializer      A ChannelInitializer for creating new pipelines.
 
   TLS options:
-  :tls?             Whether to enable TLS
-  :key              A PKCS8-encoded private key file
-  :cert             The corresponding public certificate
-  :ca-cert          The certificate of the CA which signed this key"
+
+  - :tls?             Whether to enable TLS
+  - :key              A PKCS8-encoded private key file
+  - :cert             The corresponding public certificate
+  - :ca-cert          The certificate of the CA which signed this key"
   ([]
    (tcp-server {}))
   ([opts]

--- a/src/riemann/transport/udp.clj
+++ b/src/riemann/transport/udp.clj
@@ -153,12 +153,13 @@
   dropped with protobuf parse errors in the log.
 
   Options:
-  :host             The address to listen on (default 127.0.0.1).
-  :port             The port to listen on (default 5555).
-  :max-size         The maximum datagram size (default 16384 bytes).
-  :so-rcvbuf        The socket option for receive buffer in bytes (SO_RCVBUF)
-  :channel-group    A ChannelGroup used to track all connections
-  :initializer      A ChannelInitializer"
+
+  - :host             The address to listen on (default 127.0.0.1).
+  - :port             The port to listen on (default 5555).
+  - :max-size         The maximum datagram size (default 16384 bytes).
+  - :so-rcvbuf        The socket option for receive buffer in bytes (SO_RCVBUF)
+  - :channel-group    A ChannelGroup used to track all connections
+  - :initializer      A ChannelInitializer"
   ([] (udp-server {}))
   ([opts]
    (let [core  (get opts :core (atom nil))

--- a/src/riemann/transport/websockets.clj
+++ b/src/riemann/transport/websockets.clj
@@ -228,8 +228,9 @@
   "Starts a new websocket server for a core. Starts immediately.
 
   Options:
-  :host   The address to listen on (default 127.0.0.1)
-  :port   The port to listen on (default 5556)"
+
+  - :host   The address to listen on (default 127.0.0.1)
+  - :port   The port to listen on (default 5556)"
   ([] (ws-server {}))
   ([opts]
    (WebsocketServer.

--- a/src/riemann/twilio.clj
+++ b/src/riemann/twilio.clj
@@ -52,53 +52,57 @@
   of phone numbers and returns a stream. That stream is a function which takes a
   single event, or a sequence of events, and sends a message about them.
 
+  ```clojure
   (def messenger (twilio))
   (def text (messenger \"+15005550006\" \"+15005550006\"))
+  ```
 
   This messenger sends sms out via twilio using the twilio http api. When used
   it outputs the http response recieved from twilio.
 
+  ```clojure
   (changed :state
     #(info \"twilio response\" (text %)))
+  ```
 
   The first argument is a map of the twilio options :account and :key.
   The second argument is a map of default message option.
 
+  ```clojure
   (def text (twilio {:account \"id\" :service-key \"key\"}
                     {:from \"+15005550006\"}))
+  ```
 
   Message options can be :
 
-  `:from`                    A twilio phone number
-
-  `:messaging-service-sid`   The 34 character unique id of the Messaging Service you want to associate with this Message
-
-  `:media-url`               The URL of the media you wish to send out with the message.
-
-  `:status-callback`         A URL that Twilio will POST to each time your message status changes to one of the following: queued, failed, sent, delivered, or undelivered
-
-  `:application-sid`         Twilio will POST MessageSid as well as MessageStatus=sent or MessageStatus=failed to the URL in the MessageStatusCallback property of this Application
-
-  `:max-price`               The total maximum price up to the fourth decimal (0.0001) in US dollars acceptable for the message to be delivered
-
-  `:provide-feedback`        Set this value to true if you are sending messages that have a trackable user action and you intend to confirm delivery of the message using the Message Feedback API
+  - `:from`                    A twilio phone number
+  - `:messaging-service-sid`   The 34 character unique id of the Messaging Service you want to associate with this Message
+  - `:media-url`               The URL of the media you wish to send out with the message.
+  - `:status-callback`         A URL that Twilio will POST to each time your message status changes to one of the following: queued, failed, sent, delivered, or undelivered
+  - `:application-sid`         Twilio will POST MessageSid as well as MessageStatus=sent or MessageStatus=failed to the URL in the MessageStatusCallback property of this Application
+  - `:max-price`               The total maximum price up to the fourth decimal (0.0001) in US dollars acceptable for the message to be delivered
+  - `:provide-feedback`        Set this value to true if you are sending messages that have a trackable user action and you intend to confirm delivery of the message using the Message Feedback API
 
   Full API documentation can be found here : https://www.twilio.com/docs/api/rest/sending-messages
 
   If you provide a single map, the messenger will split the twilio options out
   for you.
 
+  ```clojure
   (def text (twilio {:account \"id\"
                      :service-key \"key\"
                      :from \"+15005550006\"}))
+  ```
 
   By default, riemann uses (body events) to format messages.
   You can set your own body formatter functions by including :body in msg-opts.
   These formatting functions take a sequence of
   events and return a string.
 
+  ```clojure
   (def text (twilio {} {:body (fn [events]
-                                 (apply prn-str events))}))"
+                                 (apply prn-str events))}))
+  ```"
   ([] (twilio {}))
   ([opts]
         (let [twilio-keys #{:account :service-key}

--- a/src/riemann/victorops.clj
+++ b/src/riemann/victorops.clj
@@ -40,12 +40,14 @@
   \"<event host>/<event service>\". The state message will be the host, service, state
   and metric.
 
+  ```clojure
   (let [vo (victorops \"my-api-key\" \"my-routing-key\")]
     (changed-state
       (where (state \"info\") (:info vo))
       (where (state \"warning\") (:warning vo))
       (where (state \"critical\") (:critical vo))
-      (where (state \"ok\") (:recovery vo))))"
+      (where (state \"ok\") (:recovery vo))))
+  ```"
   [api-key routing-key]
   {:info            (fn [e] (post api-key routing-key (format-event :INFO e)))
    :warning         (fn [e] (post api-key routing-key (format-event :WARNING e)))


### PR DESCRIPTION
I updated all the docstring to have a better formatting on the API documentation. The Riemann API is very useful but had a some formatting issues. Some example before/after this PR:

InfluxDB:

![influxold](https://user-images.githubusercontent.com/4451204/37305923-617010d2-2636-11e8-9ff0-d1d6a1b959f5.png)
after:
![influxnew](https://user-images.githubusercontent.com/4451204/37305922-612082ba-2636-11e8-95fa-380f2533ddad.png)

Kafka consumer:

![kafkaold](https://user-images.githubusercontent.com/4451204/37305925-61ab36b2-2636-11e8-9d76-0b1c09b5a2f6.png)
after:
![kafkanew](https://user-images.githubusercontent.com/4451204/37305924-618b0856-2636-11e8-9cce-1ea0fcf5a650.png)

stable stream:

![stableold](https://user-images.githubusercontent.com/4451204/37305927-61f86bf8-2636-11e8-8f1e-5b4e192cc193.png)
after:
![stablenew](https://user-images.githubusercontent.com/4451204/37305926-61c6edc6-2636-11e8-932d-fe07d2f0dcb8.png)