### PR TITLE
Provide a Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM clojure:lein AS builder
+
+WORKDIR /riemann
+ADD . .
+
+RUN lein uberjar && \
+    mv target/riemann-*-standalone.jar target/riemann.jar
+
+FROM openjdk:10.0-jre
+MAINTAINER Christoph Mewes <git@xrstf.de>
+
+EXPOSE 5555/tcp 5555/udp 5556
+CMD ["/bin/riemann", "/etc/riemann.config"]
+
+COPY --from=builder /riemann/pkg/tar/riemann.config /etc/riemann.config
+COPY --from=builder /riemann/pkg/tar/riemann /bin/riemann
+COPY --from=builder /riemann/target/riemann.jar /lib/riemann.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN lein uberjar && \
     mv target/riemann-*-standalone.jar target/riemann.jar
 
 FROM openjdk:10.0-jre
-MAINTAINER Christoph Mewes <git@xrstf.de>
+MAINTAINER james+riemann@lovedthanlost.net
 
 EXPOSE 5555/tcp 5555/udp 5556
 CMD ["/bin/riemann", "/etc/riemann.config"]


### PR DESCRIPTION
This PR adds a simple Dockerfile that can be used to build a ready-to-use Docker image for Riemann. After running

    docker build -t riemann .

the user ends up with an image that can be run via

    docker run --rm riemann

I don't know why, but using Java 9 or 10 results in the following warnings being printed when starting the container:

    WARNING: An illegal reflective access operation has occurred
    WARNING: Illegal reflective access by io.netty.util.internal.ReflectionUtil (file:/usr/lib/riemann.jar) to constructor java.nio.DirectByteBuffer(long,int)
    WARNING: Please consider reporting this to the maintainers of io.netty.util.internal.ReflectionUtil
    WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
    WARNING: All illegal access operations will be denied in a future release

If possible, I would very much appreciate an official image on Docker Hub, but this involves setting up an account and the neccessary Github integration, which is out of scope for this PR.

Concerning the `MAINTAINER`, I didn't know which name to put in there. I'm open to suggestions :-)