### PR TITLE
Docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /riemann
 ADD . .
 
 RUN lein uberjar && \
-    mv target/riemann-*-standalone.jar target/riemann.jar
+    mv target/riemann-*-standalone.jar target/riemann.jar && \
+    sed -i 's/127.0.0.1/0.0.0.0/g' pkg/tar/riemann.config
 
 FROM openjdk:10.0-jre
 MAINTAINER james+riemann@lovedthanlost.net

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN lein uberjar && \
     mv target/riemann-*-standalone.jar target/riemann.jar && \
     sed -i 's/127.0.0.1/0.0.0.0/g' pkg/tar/riemann.config
 
-FROM openjdk:10.0-jre
+FROM openjdk:10.0-jre-slim
 MAINTAINER james+riemann@lovedthanlost.net
 
 EXPOSE 5555/tcp 5555/udp 5556


### PR DESCRIPTION
I forgot two things in my initial MR:

* The default configuration should listen on all network interfaces. This makes testing Riemann easier. It would be even easier if the stock config would have a `prn` in addition to the `index`, but I don't know what trouble that might cause of the other package formats.
* Using the slim OpenJDK image should save some disk space. Riemann probably never needs fancy UI libraries to work.