### PR TITLE
Support for Opsgenie v2 API

### DIFF
--- a/src/riemann/opsgenie.clj
+++ b/src/riemann/opsgenie.clj
@@ -3,21 +3,22 @@
   (:require [clj-http.client :as client])
   (:require [cheshire.core :as json]))
 
-(def ^:private alerts-url
-  "https://api.opsgenie.com/v1/json/alert")
+(def alerts-url
+  "https://api.opsgenie.com/v2/alerts")
 
-(defn- post
- "Post to OpsGenie"
- [url body]
+(defn post
+  "Post to OpsGenie"
+  [url body headers]
   (client/post url
-                {:body body
-                 :socket-timeout 5000
-                 :conn-timeout 5000
-                 :content-type :json
-                 :accept :json
-                 :throw-entire-message? true}))
+               {:body body
+                :headers headers
+                :socket-timeout 5000
+                :conn-timeout 5000
+                :content-type :json
+                :accept :json
+                :throw-entire-message? true}))
 
-(defn- message
+(defn message
   "Generate description based on event.
   Because service might be quite long and opsgenie limits message, it
   pulls more important info into beginning of the string"
@@ -26,7 +27,7 @@
        ": [" (:state event) "] "
        (:service event)))
 
-(defn- description
+(defn description
   "Generate message based on event"
   [event]
   (str
@@ -36,41 +37,58 @@
    " \nMetric: " (:metric event)
    " \nDescription: " (:description event)))
 
-(defn- api-alias
+(defn api-alias
   "Generate OpsGenie alias based on event"
   [event]
   (hash (str (:host event) \uffff (:service event) \uffff
        (clojure.string/join \uffff (sort (:tags event))))))
 
-(defn- create-alert
+(defn default-body
+  [event]
+  {:message (message event)
+   :description (description event)
+   :alias (api-alias event)
+   :user "Riemann"
+   :tags (:tags event [])})
+
+(defn create-alert
   "Create alert in OpsGenie"
-  [api-key event recipients]
-  (post alerts-url (json/generate-string
-                    {:message (message event)
-                     :description (description event)
-                     :apiKey api-key
-                     :alias (api-alias event)
-                     :tags (clojure.string/join "," (:tags event))
-                     :recipients recipients})))
-(defn- close-alert
+  [api-key event body-fn]
+  (post alerts-url
+        (json/generate-string (body-fn event))
+        {"Authorization" (str "GenieKey " api-key)}))
+
+(defn close-alert
   "Close alert in OpsGenie"
-  [api-key event]
-  (post (str alerts-url "/close")
-        (json/generate-string
-          {:apiKey api-key
-           :alias (api-alias event)})))
+  [api-key event body-fn]
+  (post (str alerts-url "/" (:alias (body-fn event)) "/close?identifierType=alias")
+        (json/generate-string {:user "Riemann"})
+        {"Authorization" (str "GenieKey " api-key)}))
+
+(def default-options
+  {:body-fn default-body})
 
 (defn opsgenie
-  "Creates an OpsGenie adapter. Takes your OG service key, and returns a map of
-  functions which trigger and resolve events. clojure/hash from event host, service and tags
-  will be used as the alias.
+  "Creates an OpsGenie adapter. Takes options, and returns a map of
+  functions which trigger and resolve events.
+  By default, Clojure/hash from event host, service and tags will be used as
+  the alias.
+
+  Options:
+
+  - :api-key    Your Opsgenie API key
+  - :body-fn    A function used to generate the HTTP request body. default to
+  `default-body`. This function should accept an event and return a map
+  containing at least the `:message` and `:alias` keys.
 
   ```clojure
-  (let [og (opsgenie \"my-service-key\" \"recipient@example.com\")]
+  (let [og (opsgenie {:api-key \"my-api-key\"})]
     (changed-state
       (where (state \"ok\") (:resolve og))
       (where (state \"critical\") (:trigger og))))
   ```"
-  [service-key recipients]
-  {:trigger     #(create-alert service-key % recipients)
-   :resolve     #(close-alert service-key %)})
+  [options]
+  (assert (:api-key options))
+  (let [{:keys [api-key body-fn]} (merge default-options options)]
+    {:trigger     #(create-alert api-key % body-fn)
+     :resolve     #(close-alert api-key % body-fn)}))

--- a/test/riemann/opsgenie_test.clj
+++ b/test/riemann/opsgenie_test.clj
@@ -1,31 +1,94 @@
 (ns riemann.opsgenie-test
   (:require [riemann.logging :as logging]
             [riemann.opsgenie :refer :all]
+            [riemann.test-utils :refer [with-mock]]
+            [cheshire.core :as json]
             [clojure.test :refer :all]))
 
 (def service-key (System/getenv "OPSGENIE_SERVICE_KEY"))
-(def recipients (System/getenv "OPSGENIE_RECIPIENTS"))
 
 (when-not service-key
   (println "export OPSGENIE_SERVICE_KEY=\"...\" to run these tests."))
 
-(when-not recipients
-  (println "export OPSGENIE_RECIPIENTS=\"...\" to run these tests."))
-
 (logging/init)
 
+(deftest ^:opsgenie ^:integration test-trigger
+  (let [og (opsgenie {:api-key service-key})]
+    ((:trigger og) {:host "localhost"
+                    :service "opsgenie notification"
+                    :description "Testing triggering event"
+                    :metric 20
+                    :state "error"})))
+
 (deftest ^:opsgenie ^:integration test-resolve
-  (let [og (opsgenie service-key recipients)]
+  (let [og (opsgenie {:api-key service-key})]
     ((:resolve og) {:host "localhost"
                     :service "opsgenie notification"
                     :description "Testing resolving event"
                     :metric 42
                     :state "ok"})))
 
-(deftest ^:opsgenie ^:integration test-trigger
-  (let [og (opsgenie service-key recipients)]
-    ((:trigger og) {:host "localhost"
-                    :service "opsgenie notification"
-                    :description "Testing triggering event"
-                    :metric 20
-                    :state "error"})))
+(deftest ^:opsgenie test-opsgenie
+  (testing "default body fn"
+    (let [og (opsgenie {:api-key "my_api_key"})
+          event {:host "localhost"
+                 :service "opsgenie notification"
+                 :description "Testing triggering event"
+                 :metric 20
+                 :state "error"}]
+      (with-mock [calls clj-http.client/post]
+        ((:trigger og) event)
+        (is (= (first (first @calls)) "https://api.opsgenie.com/v2/alerts"))
+        (is (= (second (first @calls))
+               {:body (json/generate-string (default-body event))
+                :headers {"Authorization" "GenieKey my_api_key"}
+                :socket-timeout 5000
+                :conn-timeout 5000
+                :content-type :json
+                :accept :json
+                :throw-entire-message? true}))
+        ((:resolve og) event)
+        (is (= (first (second @calls))
+               (str "https://api.opsgenie.com/v2/alerts/"
+                    (api-alias event)
+                    "/close?identifierType=alias")))
+        (is (= (second (second @calls))
+               {:body (json/generate-string {:user "Riemann"})
+                :headers {"Authorization" "GenieKey my_api_key"}
+                :socket-timeout 5000
+                :conn-timeout 5000
+                :content-type :json
+                :accept :json
+                :throw-entire-message? true})))))
+  (testing "custom body fn"
+    (let [body-fn (fn [e] {:message (:host e)
+                           :alias (:service e)})
+          og (opsgenie {:api-key "my_api_key"
+                        :body-fn body-fn})
+          event {:host "localhost"
+                 :service "opsgenie notification"}]
+      (with-mock [calls clj-http.client/post]
+        ((:trigger og) event)
+        (is (= (first (first @calls)) "https://api.opsgenie.com/v2/alerts"))
+        (is (= (second (first @calls))
+               {:body (json/generate-string (body-fn event))
+                :headers {"Authorization" "GenieKey my_api_key"}
+                :socket-timeout 5000
+                :conn-timeout 5000
+                :content-type :json
+                :accept :json
+                :throw-entire-message? true}))
+        ((:resolve og) event)
+        (is (= (first (second @calls))
+               (str "https://api.opsgenie.com/v2/alerts/"
+                    (:alias (body-fn event))
+                    "/close?identifierType=alias")))
+        (is (= (second (second @calls))
+               {:body (json/generate-string {:user "Riemann"})
+                :headers {"Authorization" "GenieKey my_api_key"}
+                :socket-timeout 5000
+                :conn-timeout 5000
+                :content-type :json
+                :accept :json
+                :throw-entire-message? true}))))))
+


### PR DESCRIPTION
Fix #918 

The alert creation call in the new API can be configured in multiple ways (https://docs.opsgenie.com/docs/alert-api#section-create-alert), so i added the possibility to customize the request body by passing a function generating the body to the stream.

This is a breaking change. I will add documentation about the opsgenie stream once the next Riemann version is released.