### PR TITLE
Cast the time in long in the pagerduty stream.

### DIFF
--- a/src/riemann/pagerduty.clj
+++ b/src/riemann/pagerduty.clj
@@ -45,7 +45,7 @@
                  (:metric event) ")")
    :source (:host event)
    :severity (:state event)
-   :timestamp (->> (or (:time event) (long (riemann.time/unix-time)))
+   :timestamp (->> (long (or (:time event) (long (riemann.time/unix-time))))
                    (coerce/from-long)
                    (f/unparse timestamp-formatter))
    :custom_details event})

--- a/test/riemann/pagerduty_test.clj
+++ b/test/riemann/pagerduty_test.clj
@@ -38,7 +38,14 @@
               :timestamp "1970-01-01T00:00:00.000Z"
               :custom_details event
               :severity "critical"}
-             (pg/format-event-v2 event))))))
+             (pg/format-event-v2 event))))
+    (testing "with time in double"
+      (is (= {:summary "riemann.io - req_per_sec is critical (100)"
+              :source "riemann.io"
+              :timestamp "1970-01-01T00:00:00.100Z"
+              :custom_details (assoc event :time 100.111)
+              :severity "critical"}
+             (pg/format-event-v2 (assoc event :time 100.111)))))))
 
 (deftest request-body-v1-test
   (let [service-key "fookey"


### PR DESCRIPTION
Riemann event `:time` can be a double (for example,
`(riemann.time/unix-time)` returns a double), and so produces an
exception in the pagerduty v2 steam (in the `(coerce/from-long)` function).