### PR TITLE
Adding external dependencies fails due to missing class EntityReplacementMap.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
     [com.cemerick/pomegranate "1.0.0"
      :exclusions [org.codehaus.plexus/plexus-utils]]
     ; for pomegranate
-    [org.codehaus.plexus/plexus-utils "3.0"]
+    [org.codehaus.plexus/plexus-utils "3.1.1"]
     [http-kit "2.2.0"]
     [clj-http "3.7.0"]
     [cheshire "5.8.0"]


### PR DESCRIPTION
My `riemann.config` just contains:
```
(add-dependencies :coordinates '[[de.active-group/vfei "0.6.0"]] :repositories {"clojars" "https://clojars.org/repo"})
```

This fails:
```
> lein run -- test riemann.config
INFO [2019-01-23 13:35:18,819] main - riemann.bin - Loading /Users/crestani/activegroup/riemann/riemann.config
Exception in thread "main" java.lang.NoClassDefFoundError: org/codehaus/plexus/util/xml/pull/EntityReplacementMap, compiling:(/Users/crestani/activegroup/riemann/riemann.config:1:1)
	at clojure.lang.Compiler.load(Compiler.java:7526)
	at clojure.lang.Compiler.loadFile(Compiler.java:7452)
	at clojure.lang.RT$3.invoke(RT.java:325)
	at riemann.config$include.invokeStatic(config.clj:449)
	at riemann.config$include.invoke(config.clj:426)
	at riemann.bin$_main$fn__14102.invoke(bin.clj:140)
	at clojure.core$with_redefs_fn.invokeStatic(core.clj:7434)
	at clojure.core$with_redefs_fn.invoke(core.clj:7418)
	at riemann.bin$_main.invokeStatic(bin.clj:138)
	at riemann.bin$_main.doInvoke(bin.clj:116)
	at clojure.lang.RestFn.invoke(RestFn.java:425)
	at clojure.lang.Var.invoke(Var.java:385)
	at user$eval233.invokeStatic(form-init690656258373220315.clj:1)
	at user$eval233.invoke(form-init690656258373220315.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:7062)
	at clojure.lang.Compiler.eval(Compiler.java:7052)
	at clojure.lang.Compiler.load(Compiler.java:7514)
	at clojure.lang.Compiler.loadFile(Compiler.java:7452)
	at clojure.main$load_script.invokeStatic(main.clj:278)
	at clojure.main$init_opt.invokeStatic(main.clj:280)
	at clojure.main$init_opt.invoke(main.clj:280)
	at clojure.main$initialize.invokeStatic(main.clj:311)
	at clojure.main$null_opt.invokeStatic(main.clj:345)
	at clojure.main$null_opt.invoke(main.clj:342)
	at clojure.main$main.invokeStatic(main.clj:424)
	at clojure.main$main.doInvoke(main.clj:387)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:702)
	at clojure.main.main(main.java:37)
Caused by: java.lang.NoClassDefFoundError: org/codehaus/plexus/util/xml/pull/EntityReplacementMap
	at org.apache.maven.model.io.xpp3.MavenXpp3Reader.read(MavenXpp3Reader.java:590)
	at org.apache.maven.model.io.DefaultModelReader.read(DefaultModelReader.java:109)
	at org.apache.maven.model.io.DefaultModelReader.read(DefaultModelReader.java:82)
	at org.apache.maven.model.building.DefaultModelProcessor.read(DefaultModelProcessor.java:81)
	at org.apache.maven.model.building.DefaultModelBuilder.readModel(DefaultModelBuilder.java:535)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:275)
	at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom(DefaultArtifactDescriptorReader.java:321)
	at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.readArtifactDescriptor(DefaultArtifactDescriptorReader.java:199)
	at org.eclipse.aether.internal.impl.DefaultDependencyCollector.resolveCachedArtifactDescriptor(DefaultDependencyCollector.java:544)
	at org.eclipse.aether.internal.impl.DefaultDependencyCollector.getArtifactDescriptorResult(DefaultDependencyCollector.java:528)
	at org.eclipse.aether.internal.impl.DefaultDependencyCollector.processDependency(DefaultDependencyCollector.java:418)
	at org.eclipse.aether.internal.impl.DefaultDependencyCollector.processDependency(DefaultDependencyCollector.java:372)
	at org.eclipse.aether.internal.impl.DefaultDependencyCollector.process(DefaultDependencyCollector.java:360)
	at org.eclipse.aether.internal.impl.DefaultDependencyCollector.collectDependencies(DefaultDependencyCollector.java:263)
	at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveDependencies(DefaultRepositorySystem.java:350)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at clojure.lang.Reflector.invokeMatchingMethod(Reflector.java:93)
	at clojure.lang.Reflector.invokeInstanceMethod(Reflector.java:28)
	at cemerick.pomegranate.aether$resolve_dependencies_STAR_.invokeStatic(aether.clj:806)
	at cemerick.pomegranate.aether$resolve_dependencies_STAR_.doInvoke(aether.clj:707)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:657)
	at clojure.core$apply.invoke(core.clj:652)
	at cemerick.pomegranate.aether$resolve_dependencies.invokeStatic(aether.clj:815)
	at cemerick.pomegranate.aether$resolve_dependencies.doInvoke(aether.clj:809)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:657)
	at clojure.core$apply.invoke(core.clj:652)
	at cemerick.pomegranate$add_dependencies.invokeStatic(pomegranate.clj:83)
	at cemerick.pomegranate$add_dependencies.doInvoke(pomegranate.clj:57)
	at clojure.lang.RestFn.invoke(RestFn.java:457)
	at riemann.config$eval271.invokeStatic(riemann.config:1)
	at riemann.config$eval271.invoke(riemann.config:1)
	at clojure.lang.Compiler.eval(Compiler.java:7062)
	at clojure.lang.Compiler.load(Compiler.java:7514)
	... 28 more
Caused by: java.lang.ClassNotFoundException: org.codehaus.plexus.util.xml.pull.EntityReplacementMap
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 66 more
```

This pull request fixes it.