### PR TITLE
add stream untag (inverse of tag)

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1460,6 +1460,21 @@
                              (if metric (* metric factor))))]
     (apply smap scale-event children)))
 
+(defn untag
+  "Removes a tag, or set of tags, from events which flow through.
+
+  (untag \"foo\" index)
+  (untag [\"foo\" \"bar\"] index)"
+  [tags & children]
+  (let [tags (set (flatten [tags]))
+        blacklist #(not (tags %))]
+    (apply smap
+           (fn stream [event]
+             (update event
+                     :tags
+                     #(filter blacklist %)))
+           children)))
+
 (defn tag
   "Adds a new tag, or set of tags, to events which flow through.
 

--- a/test/riemann/streams_test.clj
+++ b/test/riemann/streams_test.clj
@@ -207,6 +207,29 @@
                [{}
                 {:host nil}]))
 
+(deftest untag-test
+         (testing "single tag"
+                  (test-stream (untag "foo")
+                               [{}
+                                {:service :a :tags []}
+                                {:service :a :tags ["foo"]}
+                                {:service :b :tags ["foo" "bar" "baz"]}]
+                               [{:tags []}
+                                {:service :a :tags []}
+                                {:service :a :tags []}
+                                {:service :b :tags ["bar" "baz"]}]))
+
+         (testing "multiple tags"
+                  (test-stream (untag ["foo" "bar"])
+                               [{}
+                                {:service :a :tags []}
+                                {:service :a :tags ["foo"]}
+                                {:service :b :tags ["foo" "bar" "baz"]}]
+                               [{:tags []}
+                                {:service :a :tags []}
+                                {:service :a :tags []}
+                                {:service :b :tags ["baz"]}])))
+
 (deftest tag-test
          ; Single tag
          (test-stream (tag "foo")


### PR DESCRIPTION
Simple functionality missing from `streams`, ability to `untag` a event.