### PR TITLE
riemann.bin: Refactor ensure-dynamic-classloader and call on reload

### DIFF
--- a/src/riemann/bin.clj
+++ b/src/riemann/bin.clj
@@ -53,10 +53,12 @@
 (defn ensure-dynamic-classloader
   []
   (let [thread (Thread/currentThread)
-        cl (or (.getContextClassLoader thread)
-               (.getClassLoader clojure.lang.Compiler))]
-    (when-not (instance? DynamicClassLoader cl)
-      (.setContextClassLoader thread (DynamicClassLoader. cl)))))
+        context-class-loader (.getContextClassLoader thread)
+        compiler-class-loader (.getClassLoader clojure.lang.Compiler)]
+    (when-not (instance? DynamicClassLoader context-class-loader)
+      (.setContextClassLoader
+        thread (DynamicClassLoader. (or context-class-loader
+                                        compiler-class-loader))))))
 
 (defn handle-signals
   "Sets up POSIX signal handlers."

--- a/src/riemann/bin.clj
+++ b/src/riemann/bin.clj
@@ -20,8 +20,7 @@
   [config-file]
   (let [dir (-> config-file
                 io/file
-                .getCanonicalPath
-                io/file
+                .getCanonicalFile
                 .getParent)]
     (pom/add-classpath dir)))
 

--- a/src/riemann/bin.clj
+++ b/src/riemann/bin.clj
@@ -16,6 +16,15 @@
   "The configuration file loaded by the bin tool"
   (promise))
 
+(defn add-config-dir-to-classpath
+  [config-file]
+  (let [dir (-> config-file
+                io/file
+                .getCanonicalPath
+                io/file
+                .getParent)]
+    (pom/add-classpath dir)))
+
 (defn set-config-file!
   "Sets the config file used by Riemann. Adds the config file's enclosing
   directory to the classpath as well."
@@ -24,12 +33,7 @@
   (assert (deliver config-file file)
           (str "Config file already set to " (pr-str @config-file)
                "--can't change it to " (pr-str file)))
-  (let [dir (-> file
-                io/file
-                .getCanonicalPath
-                io/file
-                .getParent)]
-    (pom/add-classpath dir)))
+  (add-config-dir-to-classpath file))
 
 (def reload-lock (Object.))
 
@@ -70,6 +74,7 @@
        (handle [sig]
          (info "Caught SIGHUP, reloading")
          (ensure-dynamic-classloader)
+         (add-config-dir-to-classpath @config-file)
          (reload!))))))
 
 (defn pom-version


### PR DESCRIPTION
Since upgrading Pomegranate to 1.0, issues have arose around the
classloader hierarchy that have triggered weird bugs around the use of
`add-dependencies` and strange behavior when handling the HUP signal.
This version of `ensure-dynamic-classloader` comes from studying how the
compiler and runtime find the approrpriate classloader and takes into
account differences across JDK versions in the classloader hierarchy
associated with the thread handling the HUP signal to ensure consistent
behavior.

I have tested these changes across OpenJDK 8, 9 and 10 using the `library/openjdk` container images found on DockerHub. See comments inline for a little more in-depth discussion about why I made some of the changes I made. This resolves many of the issues discussed in #950.