### PR TITLE
Add syntax highlighting to datadog example in docs

### DIFF
--- a/src/riemann/datadog.clj
+++ b/src/riemann/datadog.clj
@@ -48,6 +48,7 @@
 
   Example:
 
+  ```clojure
   (def datadog-forwarder
     (batch 100 1/10
       (async-queue!
@@ -55,7 +56,8 @@
         {:queue-size     1e4  ; 10,000 events max
          :core-pool-size 5    ; Minimum 5 threads
          :max-pools-size 100} ; Maxium 100 threads
-        (datadog {:api-key \"bn14a6ac2e3b5h795085217d49cde7eb\"}))))"
+        (datadog {:api-key \"bn14a6ac2e3b5h795085217d49cde7eb\"}))))
+  ```"
   [opts]
   (let [opts (merge {:api-key "datadog-api-key"} opts)]
     (fn [event]


### PR DESCRIPTION
Not sure how to generate the docs html from comments, but I largely just followed the way that the druid example looked with the `clojure` backticks. I'm _assuming_ this will make the below example a smidge more readable on the docs site.