### PR TITLE
feat(stream): rabbitmq stream is introduced

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -34,6 +34,7 @@
                      [plugin      :refer [load-plugin load-plugins]]
                      [pubsub      :as pubsub]
                      [pushover    :refer [pushover]]
+                     [rabbitmq    :refer [rabbitmq]]
                      [repl]
                      [service     :as service]
                      [shinken     :refer [shinken]]

--- a/src/riemann/rabbitmq.clj
+++ b/src/riemann/rabbitmq.clj
@@ -1,0 +1,60 @@
+(ns riemann.rabbitmq
+  "Forwards events to RabbitMQ."
+  (:require [langohr.core :as rmq]
+            [langohr.channel :as lch]
+            [langohr.exchange :as le]
+            [langohr.basic :as lb]
+            [cheshire.core :as json]))
+
+(def ^{:private true} json-formatter json/generate-string)
+
+(defn- deep-merge
+  [a & maps]
+  (if (map? a)
+    (apply merge-with deep-merge a maps)
+    (apply merge-with deep-merge maps)))
+
+(defn rabbitmq
+  "Accepts options described [here](http://clojurerabbitmq.info/articles/connecting.html) and returns a function
+  that, being invoked with options listed below, returns a stream which publishes events to RabbitMQ.
+
+  Options:
+
+  - :exchange-settings Settings an exchange is declared with, defaults are {:name \"riemann\" :type \"topic\" :durable false :auto-delete false :internal false}.
+  - :routing-key Routing key messages to be published with, default is \"riemann.events\".
+  - :message-properties Properties of messages to publish, defaults are {:content-type \"application/json\" :mandatory false}.
+  - :message-formatter A function to format event(s), default format is JSON.
+
+  ```clojure
+  (def rmq (rabbitmq {:host \"riemann.local\"
+                      :port 1234}))
+
+  (changed :state
+    (rmq {:exchange-settings {:durable true}
+          :routing-key \"riemann.events.hello\"}))
+  ```
+
+  For details on exchange declaration options and message properties refer to Langohr API reference for
+    - [declare](http://reference.clojurerabbitmq.info/langohr.exchange.html#var-declare) and
+    - [publish](http://reference.clojurerabbitmq.info/langohr.basic.html#var-publish)
+  "
+  ([] (rabbitmq {}))
+  ([opts]
+   (let [connection (rmq/connect opts)
+         channel (lch/open connection)]
+     (fn make-stream
+       ([] (make-stream {}))
+       ([opts]
+        (let [base {:exchange-settings {:name "riemann" :type "topic"}
+                    :routing-key "riemann.events"
+                    :message-properties {:content-type "application/json"}
+                    :message-formatter json-formatter}
+              {:keys [exchange-settings
+                      routing-key
+                      message-properties
+                      message-formatter]} (deep-merge base opts)
+              {ex-name :name ex-type :type} exchange-settings]
+          (le/declare channel ex-name ex-type exchange-settings)
+          (fn stream [e]
+            (let [payload (message-formatter e)]
+              (lb/publish channel ex-name routing-key payload message-properties)))))))))

--- a/src/riemann/rabbitmq.clj
+++ b/src/riemann/rabbitmq.clj
@@ -20,9 +20,24 @@
 
   Options:
 
-  - :exchange-settings Settings an exchange is declared with, defaults are {:name \"riemann\" :type \"topic\" :durable false :auto-delete false :internal false}.
+  - :exchange-settings Settings an exchange is declared with, defaults are:
+
+  ```clojure
+  {:name \"riemann\"
+   :type \"topic\"
+   :durable false
+   :auto-delete false
+   :internal false}
+  ```
+
   - :routing-key Routing key messages to be published with, default is \"riemann.events\".
-  - :message-properties Properties of messages to publish, defaults are {:content-type \"application/json\" :mandatory false}.
+  - :message-properties Properties of messages to publish, defaults are:
+  
+  ```clojure
+  {:content-type \"application/json\"
+   :mandatory false}
+  ```
+
   - :message-formatter A function to format event(s), default format is JSON.
 
   ```clojure
@@ -34,9 +49,9 @@
           :routing-key \"riemann.events.hello\"}))
   ```
 
-  For details on exchange declaration options and message properties refer to Langohr API reference for
-    - [declare](http://reference.clojurerabbitmq.info/langohr.exchange.html#var-declare) and
-    - [publish](http://reference.clojurerabbitmq.info/langohr.basic.html#var-publish)
+  For details on exchange declaration options and message properties refer to Langohr API reference for 
+  [declare](http://reference.clojurerabbitmq.info/langohr.exchange.html#var-declare) and 
+  [publish](http://reference.clojurerabbitmq.info/langohr.basic.html#var-publish).
   "
   ([] (rabbitmq {}))
   ([opts]

--- a/test/riemann/rabbitmq_test.clj
+++ b/test/riemann/rabbitmq_test.clj
@@ -1,0 +1,103 @@
+(ns riemann.rabbitmq-test
+  (:require [riemann.logging :as logging]
+            [riemann.rabbitmq :refer :all]
+            [riemann.test-utils :refer [with-mock]]
+            [clojure.test :refer :all]
+            [langohr.core :as rmq]
+            [langohr.queue :as lq]
+            [langohr.channel :as lch]
+            [langohr.exchange :as le]
+            [langohr.consumers :as lc]
+            [langohr.basic :as lb]))
+
+(logging/init)
+
+(defn- gen-query-result-handler
+  [query-result]
+  (fn [_ _ ^bytes payload]
+    (deliver query-result (String. payload "UTF-8"))))
+
+(deftest ^:rabbitmq ^:integration rabbitmq-stream-integration-test
+  (let [conn (atom nil)
+        ch (atom nil)]
+    (try
+      (let [host "rabbitmq.local"
+            rmq (rabbitmq {:host host})
+            ex-name "riemann-test"
+            routing-key "riemann.events.test"
+            s (rmq {:exchange-settings {:name ex-name :auto-delete true}
+                    :routing-key routing-key})
+            e {:host "localhost"
+               :service "busybee"
+               :metric 9000
+               :ttl 10}
+            query-result (promise)]
+        (reset! conn (rmq/connect {:host host}))
+        (reset! ch (lch/open @conn))
+        (le/declare @ch ex-name "topic" {:auto-delete true})
+        (let [q-name (.getQueue (lq/declare @ch "" {:exclusive true}))]
+          (lq/bind @ch q-name ex-name {:routing-key routing-key})
+          (lc/subscribe @ch q-name (gen-query-result-handler query-result) {:auto-ack true}))
+        (s e)
+        (let [result (deref query-result 1000 :timed-out)]
+          (is (= result "{\"host\":\"localhost\",\"service\":\"busybee\",\"metric\":9000,\"ttl\":10}"))))
+      (finally
+        (when @conn
+          (rmq/close @ch)
+          (rmq/close @conn))))))
+
+(deftest ^:rabbitmq rabbitmq-test
+  (with-mock [connect' rmq/connect]
+  (with-mock [open' lch/open]
+  (with-mock [declare' le/declare]
+  (with-mock [publish' lb/publish]
+    (testing "default options"
+      (let [rmq (rabbitmq)
+            s (rmq)
+            e {:host "a"
+               :service "b"
+               :description "c"
+               :metric 42
+               :state "ok"}]
+        (s e)
+        (is (= 1 (count @connect')))
+        (is (= 1 (count @open')))
+        (is (= 1 (count @declare')))
+        (is (= 1 (count @publish')))
+        (let [[_ ex-name ex-type _] (last @declare')]
+          (is (= ex-name "riemann"))
+          (is (= ex-type "topic")))
+        (let [[_ ex-name routing-key payload {:keys [content-type]}] (last @publish')]
+          (is (= ex-name "riemann"))
+          (is (= routing-key "riemann.events"))
+          (is (= payload "{\"host\":\"a\",\"service\":\"b\",\"description\":\"c\",\"metric\":42,\"state\":\"ok\"}"))
+          (is (= content-type "application/json")))))
+    (testing "custom options"
+      (let [rmq (rabbitmq {:host "example.com" :port 1234})
+            formatter #(:metric %)
+            s (rmq {:exchange-settings {:name "bus" :type "custom" :durable true}
+                    :routing-key "one.two.three"
+                    :message-properties {:content-type "test"}
+                    :message-formatter formatter})
+            e {:host "a"
+               :service "b"
+               :description "c"
+               :metric 42
+               :state "ok"}]
+        (s e)
+        (is (= 2 (count @connect')))
+        (is (= 2 (count @open')))
+        (is (= 2 (count @declare')))
+        (is (= 2 (count @publish')))
+        (let [[{:keys [host port]}] (last @connect')]
+          (is (= host "example.com"))
+          (is (= port 1234)))
+        (let [[_ ex-name ex-type {:keys [durable]}] (last @declare')]
+          (is (= ex-name "bus"))
+          (is (= ex-type "custom"))
+          (is (= durable true)))
+        (let [[_ ex-name routing-key payload {:keys [content-type]}] (last @publish')]
+          (is (= ex-name "bus"))
+          (is (= routing-key "one.two.three"))
+          (is (= payload 42))
+          (is (= content-type "test"))))))))))


### PR DESCRIPTION
It's useful if you want not only to receive events from RabbitMQ (via rabbitmq-transport) but send some, too.