### PR TITLE
Do not record events if *results* is nil.

### DIFF
--- a/src/riemann/test.clj
+++ b/src/riemann/test.clj
@@ -36,9 +36,9 @@
   [name child]
   (fn stream [event]
     ; Record event
-    (-> *results*
-        (get name)
-        (swap! conj event))
+    (some-> *results*
+            (get name)
+            (swap! conj event))
 
     ; Forward downstream
     (child event)))


### PR DESCRIPTION
Behavior is explained on [1]

In short, unless (instrumentation) is explicitly set and tests has
time gap that will put Riemann in sleep, another thread will kick
instrumentation while tests are running, causing NullPointerException.

[1] https://github.com/riemann/riemann/issues/941#issuecomment-516172375