### PR TITLE
Pass http options to elasticsearch

### DIFF
--- a/src/riemann/elasticsearch.clj
+++ b/src/riemann/elasticsearch.clj
@@ -47,6 +47,7 @@
   - :type            Type to send to index, default is \"event\".
   - :username        Username to authenticate with.
   - :password        Password to authenticate with.
+  - :http-options    Http options (like proxy). See https://github.com/dakrone/clj-http for option list.
 
   Example:
 
@@ -65,7 +66,8 @@
   (let [opts (merge {:es-endpoint "http://127.0.0.1:9200"
                      :es-index "riemann"
                      :index-suffix "-yyyy.MM.dd"
-                     :type "event"}
+                     :type "event"
+                     :http-options {}}
                     opts)
         event-formatter (if (first maybe-formatter) (first maybe-formatter) format-event)]
     (fn [event]
@@ -79,7 +81,7 @@
                                   ""
                                   (time-format/unparse (time-format/formatter (:index-suffix opts)) (datetime-from-event event)))
                                 (:type opts))
-            http-options {}]
+            http-options (:http-options opts)]
         (post
          credentials
          es-endpoint

--- a/test/riemann/elasticsearch_test.clj
+++ b/test/riemann/elasticsearch_test.clj
@@ -43,7 +43,8 @@
     (let [elastic (elasticsearch {:es-endpoint "https://example-elastic.com"
                                   :es-index "test-riemann"
                                   :index-suffix "-yyyy.MM"
-                                  :type "test-type"})
+                                  :type "test-type"
+                                  :http-options {:connection-manager 'cm}})
           json-event (json/generate-string output-event)]
 
       (testing "correct index/type formatting with custom elasticsearch opts"
@@ -54,7 +55,8 @@
                  :content-type :json
                  :conn-timeout 5000
                  :socket-timeout 5000
-                 :throw-entire-message? true}]))))))
+                 :throw-entire-message? true
+                 :connection-manager 'cm}]))))))
 
 (deftest ^:elasticsearch elasticsearch-event-formatter-test
   (with-mock [calls clj-http.client/post]

--- a/test/riemann/elasticsearch_test.clj
+++ b/test/riemann/elasticsearch_test.clj
@@ -2,6 +2,7 @@
   (:require [riemann.elasticsearch :refer :all]
             [riemann.logging :as logging]
             [riemann.test-utils :refer [with-mock]]
+            [riemann.time]
             [cheshire.core :as json]
             [clj-http.client :as http]
             [clojure.test :refer :all]))


### PR DESCRIPTION
Allow the user to pass http-options to elasticsearch.

This is used for configuring a proxy (example stolen from another part of the elasticsearch module), but configuring persistent connections might be the best use-case…

![Screenshot_2020-06-11 Riemann - Grafana](https://user-images.githubusercontent.com/148721/84456352-7a95cc80-abfb-11ea-8e7b-da8bdd5dce00.png)

