### PR TITLE
Fix Linux detection for Netty

### DIFF
--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -92,7 +92,7 @@
 
 (def netty-implementation
   (let [mac-or-freebsd? (re-find #"(mac|freebsd)" (System/getProperty "os.name"))
-       linux? (re-find  #"linux" (System/getProperty "os.name"))
+       linux? (re-find  #"(linux|Linux)" (System/getProperty "os.name"))
        sfbit? (re-find #"(x86_64|amd64)" (System/getProperty "os.arch"))
        native?  (= (System/getProperty "netty.native.implementation") "true")]
     (cond (and native? sfbit? linux?) (epoll-netty-implementation)


### PR DESCRIPTION
Netty uses the epoll implementation only if Riemann detects
that the operating system is Linux based.

On my computer (Debian 10), `(System/getProperty "os.name")` returns
"Linux", which does not match the `#"linux"` regex.

This commit modifies the regex to also accept `Linux`.

Some REPL outputs:

(re-find  #"(linux|Linux)" (System/getProperty "os.name"))
["Linux" "Linux"]

(re-find  #"linux" (System/getProperty "os.name"))
nil