### PR TITLE
Add garbage collection timeout to `by` streams

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,6 +36,7 @@
     [com.boundary/high-scale-lib "1.0.6"]
     [com.draines/postal "2.0.2"]
     [com.amazonaws/aws-java-sdk "1.11.116" :exclusions [joda-time]]
+    [expiring-map "0.1.9"]
     [interval-metrics "1.0.0"]
     [clj-antlr "0.2.4"]
     [io.netty/netty-all "4.1.41.Final"]

--- a/test/riemann/streams_test.clj
+++ b/test/riemann/streams_test.clj
@@ -740,9 +740,9 @@
                          (swap! per-fork-counter inc)
                          (swap! history conj @per-fork-counter))))
           inject (fn [] (stream {:host "localhost"}))]
-      (dotimes [n 5] (inject))
+      (dotimes [_ 5] (inject))
       (Thread/sleep 2000)
-      (dotimes [n 5] (inject))
+      (dotimes [_ 5] (inject))
       (is (= [1 2 3 4 5, 1 2 3 4 5] @history)))))
 
 (deftest by-multiple
@@ -848,15 +848,15 @@
 
   (testing "timeout option resets stream state"
     (let [history (atom [])
-          stream (by-builder [host :host] {:timeout 1} (identity host)
+          stream (by-builder [host :host] {:timeout 1}
                              (let [per-fork-counter (atom 0)]
                                (fn [event]
                                  (swap! per-fork-counter inc)
                                  (swap! history conj @per-fork-counter))))
           inject (fn [] (stream {:host "localhost"}))]
-      (dotimes [n 5] (inject))
+      (dotimes [_ 5] (inject))
       (Thread/sleep 2000)
-      (dotimes [n 5] (inject))
+      (dotimes [_ 5] (inject))
       (is (= [1 2 3 4 5, 1 2 3 4 5] @history)))))
 
 (deftest by-evaluates-children-once-per-branch


### PR DESCRIPTION
Add a capability to `by` and `by-builder` that lets them expire streams, allowing the streams to be garbage collected.

Without this capability, declaring a `by` stream over a dimension that continuously changes will eventually exhaust all heap space. For example, `(by :host prn)`, when processing events from a dynamic fleet of VMs or containers, represents a fatal memory leak.

It's tempting to set the new behaviour as the default, with a sensibly long expiry time, but I'm sure it would break something for somebody, somewhere.

cc @mcorbin, because I believe that Mirabelle uses the same implementation.