### PR TITLE
Use jsoup version 1.14.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
     [slingshot "0.12.2"]
     [cljr-nsca "0.0.4"]
     [amazonica "0.3.95" :exclusions [joda-time]]
-    [spootnik/kinsky "0.1.20"]
+    [spootnik/kinsky "0.1.26"]
     [pjstadig/humane-test-output "0.8.3"]
     [com.novemberain/langohr "5.1.0"]
     [com.fasterxml.jackson.core/jackson-core "2.10.0"]

--- a/project.clj
+++ b/project.clj
@@ -49,6 +49,7 @@
     [com.novemberain/langohr "5.1.0"]
     [com.fasterxml.jackson.core/jackson-core "2.10.0"]
     [com.fasterxml.jackson.core/jackson-databind "2.10.0"]]
+  :managed-dependencies [[org.jsoup/jsoup "1.14.3"]]
   :plugins [[lein-codox "0.10.6"]
             [lein-difftest "2.0.0"]
             [lein-ancient "0.6.15"]


### PR DESCRIPTION
There is a transitive dependency on `jsoup` coming from `pomegranate` which has security issues

https://mvnrepository.com/artifact/org.jsoup/jsoup/1.7.2

Upgrading to this particular version fixes it