### PR TITLE
Update docs for tagged-all, tagged-any

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1294,7 +1294,6 @@
   Can be used as a predicate in a where form.
 
   ```clojure
-  (tagged-all \"foo\" prn)
   (tagged-all [\"foo\" \"bar\"] prn)
   ```"
   [tags & children]
@@ -1317,8 +1316,7 @@
   Can be used as a predicate in a where form.
 
   ```clojure
-  (tagged-any \"foo\" prn)
-  (tagged-all [\"foo\" \"bar\"] prn)
+  (tagged-any [\"foo\" \"bar\"] prn)
   ```"
   [tags & children]
   (let [tag-coll (flatten [tags])]


### PR DESCRIPTION
The docstrings for these streams had two issues:

- `tagged-any` contained an example of `tagged-all`
- Both suggested that the user can pass a string an an argument, but
  that will not work as expected.

Calling `(tagged-any "foo" prn)` will return a stream that prints events
that are tagged `(char 102)` or `(char 111)` (which are of type
`java.lang.Character`). It will not match the `java.lang.String` `"foo"`,
which is what the user would expect.

Refer: https://groups.google.com/g/riemann-users/c/KPnoqh8dC9M