### PR TITLE
Fix cut-n-paste error in tagged-any docstring

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1318,7 +1318,7 @@
 
   ```clojure
   (tagged-any \"foo\" prn)
-  (tagged-all [\"foo\" \"bar\"] prn)
+  (tagged-any [\"foo\" \"bar\"] prn)
   ```"
   [tags & children]
   (let [tag-coll (flatten [tags])]


### PR DESCRIPTION
This looks like a simple copy/paste error in a docstring. I think it's worth fixing because, to a new reader, it looks like it's comparing syntactic differences between `tagged-all` and `tagged-any`.