### PR TITLE
add prefix to graphite tags

### DIFF
--- a/src/riemann/transport/graphite.clj
+++ b/src/riemann/transport/graphite.clj
@@ -23,7 +23,7 @@
   [tags]
   (reduce (fn [state tag]
          (let [[name value] (split tag #"=")]
-           (assoc state (keyword name) value)))
+           (assoc state (keyword (join [ "tag_" name ])) value)))
           {}
           tags))
 


### PR DESCRIPTION
if graphite tags are `service` or something like, it's just silently disappears 