### PR TITLE
Fix expectation/test order in the test section

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -903,11 +903,12 @@ java -Dlogback.configurationFile=file:///path/to/logback.xml \
 {% highlight clj %}
 (tests
   (deftest index-test
-    (is (= (inject! [{:service "test"
-                      :time    1}])
-           {:index [{:service "test"
+    (is (= {:index [{:service "test"
                      :time    1
-                     :ttl     3}]}))))
+                     :ttl     3}]}
+           (inject! [{:service "test"
+                      :time    1}])
+           ))))
 {% endhighlight %}
 
 {% highlight clj %}
@@ -922,9 +923,10 @@ java -Dlogback.configurationFile=file:///path/to/logback.xml \
                    [{:host "localhost"
                      :service "foo"
                      :metric 10}])]
-      (is (= (:foo result) [{:host "localhost"
-                             :service "foo"
-                             :metric 10}])))))
+      (is (= [{:host "localhost"
+               :service "foo"
+               :metric 10}]
+              (:foo result))))))
 {% endhighlight %}
 
 {% highlight sh %}


### PR DESCRIPTION
= expect the expected result as first argument and the actual code as
second argument, otherwise the test output is inconsistent:

```
FAIL in (index-test) (riemann.config:43)
expected: {}
  actual: {:index [{:service "test", :time 1, :ttl 3}]}
    diff: + {:index [{:service "test", :time 1, :ttl 3}]}
```

Switch argument position so that test output is correct:

```
FAIL in (index-test) (riemann.config:43)
expected: {:index [{:service "test", :time 1, :ttl 3}]}
  actual: {}
    diff: - {:index [{:service "test", :time 1, :ttl 3}]}
```
