### PR TITLE
Forced long to Thread/sleep duration to avoid reflection error

### DIFF
--- a/src/riemann/time.clj
+++ b/src/riemann/time.clj
@@ -179,7 +179,7 @@
     (reset! running false)
     (while (some #(.isAlive ^Thread %) @threadpool)
       ; Allow at most 1/10th park-interval to pass after all threads exit.
-      (Thread/sleep (* park-interval 100)))
+      (Thread/sleep (long (* park-interval 100))))
     (reset! threadpool [])))
 
 (defn start!


### PR DESCRIPTION
Adding Java 19+ introduces a reflection error with `Thread/sleep`

See the background [here](https://ask.clojure.org/index.php/12853/built-in-function-for-thread-sleep-to-avoid-type-hints).

To fix this I've forced the type to long.

```
lein test :only riemann.time-test/riemann.time-test

ERROR in (riemann.time-test) (Reflector.java:80)
Uncaught exception in test fixture
expected: nil
  actual: java.lang.IllegalArgumentException: No matching method found: sleep
 at clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:80)
    clojure.lang.Reflector.invokeStaticMethod (Reflector.java:207)
    riemann.time$stop_BANG_.invokeStatic (time.clj:182)
    riemann.time$stop_BANG_.invoke (time.clj:175)
    riemann.time_test$reset_time_BANG_.invokeStatic (time_test.clj:17)
    riemann.time_test$reset_time_BANG_.invoke (time_test.clj:11)
    clojure.test$compose_fixtures$fn__9203$fn__9204.invoke (test.clj:693)
    clojure.test$default_fixture.invokeStatic (test.clj:686)
    clojure.test$default_fixture.invoke (test.clj:682)
    clojure.test$compose_fixtures$fn__9203.invoke (test.clj:693)
    clojure.test$test_vars$fn__9235.invoke (test.clj:734)
    clojure.test$default_fixture.invokeStatic (test.clj:686)
    clojure.test$default_fixture.invoke (test.clj:682)
    clojure.test$test_vars.invokeStatic (test.clj:730)
    clojure.test$test_all_vars.invokeStatic (test.clj:736)
    clojure.test$test_ns.invokeStatic (test.clj:757)
    clojure.test$test_ns.invoke (test.clj:742)
    clojure.lang.AFn.applyToHelper (AFn.java:154)
    clojure.lang.AFn.applyTo (AFn.java:144)
    clojure.core$apply.invokeStatic (core.clj:657)
    clojure.core$apply.invoke (core.clj:652)
    test2junit.core$apply_junit_output_hook$fn__415$fn__434$fn__445$fn__446.invoke (core.clj:53)
    test2junit.core$apply_junit_output_hook$fn__415$fn__434$fn__445.invoke (core.clj:52)
    test2junit.core$apply_junit_output_hook$fn__415$fn__434.invoke (core.clj:51)
    test2junit.core$apply_junit_output_hook$fn__415.doInvoke (core.clj:51)
    clojure.lang.RestFn.applyTo (RestFn.java:139)
    clojure.core$apply.invokeStatic (core.clj:659)
    clojure.core$apply.invoke (core.clj:652)
    robert.hooke$compose_hooks$fn__173.doInvoke (hooke.clj:40)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:657)
    clojure.core$apply.invoke (core.clj:652)
    robert.hooke$run_hooks.invokeStatic (hooke.clj:46)
    robert.hooke$run_hooks.invoke (hooke.clj:45)
    robert.hooke$prepare_for_hooks$fn__178$fn__179.doInvoke (hooke.clj:54)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.AFunction$1.doInvoke (AFunction.java:29)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    user$eval551$fn__624.invoke (form-init11738097694151289376.clj:1)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.AFn.applyTo (AFn.java:144)
    clojure.core$apply.invokeStatic (core.clj:659)
    clojure.core$apply.invoke (core.clj:652)
    leiningen.core.injected$compose_hooks$fn__481.doInvoke (form-init11738097694151289376.clj:1)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:657)
    clojure.core$apply.invoke (core.clj:652)
    leiningen.core.injected$run_hooks.invokeStatic (form-init11738097694151289376.clj:1)
    leiningen.core.injected$run_hooks.invoke (form-init11738097694151289376.clj:1)
    leiningen.core.injected$prepare_for_hooks$fn__486$fn__487.doInvoke (form-init11738097694151289376.clj:1)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.AFunction$1.doInvoke (AFunction.java:29)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    clojure.core$map$fn__5587.invoke (core.clj:2747)
    clojure.lang.LazySeq.sval (LazySeq.java:40)
    clojure.lang.LazySeq.seq (LazySeq.java:49)
    clojure.lang.Cons.next (Cons.java:39)
    clojure.lang.RT.next (RT.java:706)
    clojure.core$next__5108.invokeStatic (core.clj:64)
    clojure.core$reduce1.invokeStatic (core.clj:936)
    clojure.core$reduce1.invokeStatic (core.clj:926)
    clojure.core$merge_with.invokeStatic (core.clj:3051)
    clojure.core$merge_with.doInvoke (core.clj:3043)
    clojure.lang.RestFn.applyTo (RestFn.java:139)
    clojure.core$apply.invokeStatic (core.clj:659)
    clojure.test$run_tests.invokeStatic (test.clj:767)
    clojure.test$run_tests.doInvoke (test.clj:767)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:657)
    clojure.core$apply.invoke (core.clj:652)
    user$eval551$fn__636$fn__673.invoke (form-init11738097694151289376.clj:1)
    user$eval551$fn__636$fn__637.invoke (form-init11738097694151289376.clj:1)
    user$eval551$fn__636.invoke (form-init11738097694151289376.clj:1)
    user$eval551.invokeStatic (form-init11738097694151289376.clj:1)
    user$eval551.invoke (form-init11738097694151289376.clj:1)
    clojure.lang.Compiler.eval (Compiler.java:7062)
    clojure.lang.Compiler.eval (Compiler.java:7052)
    clojure.lang.Compiler.load (Compiler.java:7514)
    clojure.lang.Compiler.loadFile (Compiler.java:7452)
    clojure.main$load_script.invokeStatic (main.clj:278)
    clojure.main$init_opt.invokeStatic (main.clj:280)
    clojure.main$init_opt.invoke (main.clj:280)
    clojure.main$initialize.invokeStatic (main.clj:311)
    clojure.main$null_opt.invokeStatic (main.clj:345)
    clojure.main$null_opt.invoke (main.clj:342)
    clojure.main$main.invokeStatic (main.clj:424)
    clojure.main$main.doInvoke (main.clj:387)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.Var.applyTo (Var.java:702)
    clojure.main.main (main.java:37)
```

