### PR TITLE
Update to Clojure 1.11.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
   :maintainer {:email "aphyr@aphyr.com"}
   :dependencies [
     [org.clojure/algo.generic "0.1.2"]
-    [org.clojure/clojure "1.9.0"]
+    [org.clojure/clojure "1.11.1"]
     [org.clojure/math.numeric-tower "0.0.4"]
     [org.clojure/tools.logging "1.2.1"]
     [org.clojure/tools.nrepl "0.2.13"]

--- a/test/riemann/test_test.clj
+++ b/test/riemann/test_test.clj
@@ -19,7 +19,7 @@
                        (tap :bar prn)
                        (tap :foo nil))))
               (catch RuntimeException e
-                (.getMessage e)))]
+                (.getMessage (ex-cause e))))]
     (is (re-find #"Tap :foo \(.+?:\) already defined at :" err))))
 
 (deftest tap-captures-events


### PR DESCRIPTION
https://github.com/riemann/riemann/issues/1038

Update Clojure version to 1.11.1 in project.clj.

Initially, this caused a test to fail:

```
Testing: riemann.test-test
Running tests in: riemann.test-test
  Running test: #'riemann.test-test/only-one-tap-per-context
    FAIL
      Expected: (re-find #"Tap :foo \(.+?:\) already defined at :" err)
      Actual: (not (re-find #"Tap :foo \(.+?:\) already defined at :" Unexpected error macroexpanding riemann.test/tap at (/tmp/form-init8155462538598659347.clj:1:6476).))
  Finished test: #'riemann.test-test/only-one-tap-per-context
```

The `riemann.test/tap` macro throws a RuntimeException if a tap with the given name already exists:

https://github.com/riemann/riemann/blob/25235d3fe001be5593ee28a8daaa876d2fd561b4/src/riemann/test.clj#L64-L69

Clojure changed how errors in macroexpansion are reported - it's now a CompilerException with the original RuntimeException as a cause, so the assertion needs to pull out the `ex-cause`.

I ran tests locally by mimicking the steps in `.github/workflows/test.yaml`. If there's a way to run the Gtihub test workflow on this PR, that would be great! 🙏 
