### PR TITLE
Also run the test suite on PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Riemann testing
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
We have CI running when code is pushed to the riemann repository.  For
external contribution, this only happen when a PR is merged, but
detecting issues earlier is advisable.

Instead of running CI when code is pushed in any branch of the repo, run
CI when the main branch is updated, and when a PR targeting the main
branch is updated.