### PR TITLE
Integrated clj-kondo and addressed many lint warnings and errors

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -7,8 +7,12 @@
 
  :skip-comments true
 
- :lint-as
- {riemann.streams/where clojure.core/when}
+ ;:lint-as
+ ;{riemann.streams/where clojure.core/when}
+
+ :hooks
+ {:analyze-call
+  {riemann.streams/where hooks.streams/where}}
 
  :ns-groups [{:pattern "riemann\\.config*" :name riemann-config}]
 

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -21,7 +21,8 @@
   ;; macros are stored in 'macros' folder and should match namespace where
   ;; where original macro is defined
   :macroexpand
-  {riemann.pool/with-pool riemann.pool/with-pool}}
+  {riemann.pool/with-pool riemann.pool/with-pool
+   riemann.service/all-equal? riemann.service/all-equal?}}
 
  :ns-groups [{:pattern "riemann\\.config*" :name riemann-config}]
 

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,9 +1,10 @@
 {:config-paths ["macros"]
 
  :linters
- {:unresolved-symbol {:exclude [_]}
-  :unused-binding    {:exclude-patterns ["^this"]}
-  :redundant-do      {:level :off}}
+ {:unresolved-symbol            {:exclude [_]}
+  :unused-binding               {:exclude-patterns ["^this"]}
+  :non-arg-vec-return-type-hint {:level :off}
+  :redundant-do                 {:level :off}}
 
  ;:unresolved-var {:exclude []}
 

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -6,20 +6,12 @@
   :non-arg-vec-return-type-hint {:level :off}
   :redundant-do                 {:level :off}}
 
- ;:unresolved-var {:exclude []}
-
  :skip-comments true
-
- :lint-as
- {;riemann.pool/with-pool clj-kondo.lint-as/def-catch-all
-  ;riemann.pool/with-pool clojure.core/with-open
-  }
 
  :hooks
  {:analyze-call
   {riemann.streams/where           hooks.streams/where
-   org.httpkit.server/with-channel hooks.httpkit/with-channel
-   }
+   org.httpkit.server/with-channel hooks.httpkit/with-channel}
 
   ;; macros are stored in 'macros' folder and should match namespace where
   ;; where original macro is defined

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,13 @@
+{:linters
+ {:unresolved-symbol
+  {:exclude [_
+             ]}
+
+  :redundant-do {:level :off}}
+
+ :unresolved-var
+  {:exclude []}
+
+ :skip-comments true
+ :lint-as {riemann.streams/where clojure.core/when}
+ }

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -17,7 +17,9 @@
 
  :hooks
  {:analyze-call
-  {riemann.streams/where  hooks.streams/where}
+  {riemann.streams/where           hooks.streams/where
+   org.httpkit.server/with-channel hooks.httpkit/with-channel
+   }
 
   ;; macros are stored in 'macros' folder and should match namespace where
   ;; where original macro is defined

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -22,8 +22,9 @@
   ;; macros are stored in 'macros' folder and should match namespace where
   ;; where original macro is defined
   :macroexpand
-  {riemann.pool/with-pool riemann.pool/with-pool
-   riemann.service/all-equal? riemann.service/all-equal?}}
+  {riemann.pool/with-pool                riemann.pool/with-pool
+   riemann.service/all-equal?            riemann.service/all-equal?
+   riemann.transport/channel-initializer riemann.transport/channel-initializer}}
 
  :ns-groups [{:pattern "riemann\\.config*" :name riemann-config}]
 

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,6 +1,7 @@
 {:linters
  {:unresolved-symbol {:exclude [_]}
-  :redundant-do {:level :off}}
+  :unused-binding    {:exclude-patterns ["^this"]}
+  :redundant-do      {:level :off}}
 
  ;:unresolved-var {:exclude []}
 

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,13 +1,106 @@
 {:linters
- {:unresolved-symbol
-  {:exclude [_
-             ]}
-
+ {:unresolved-symbol {:exclude [_]}
   :redundant-do {:level :off}}
 
- :unresolved-var
-  {:exclude []}
+ ;:unresolved-var {:exclude []}
 
  :skip-comments true
- :lint-as {riemann.streams/where clojure.core/when}
- }
+
+ :lint-as
+ {riemann.streams/where clojure.core/when}
+
+ :ns-groups [{:pattern "riemann\\.config*" :name riemann-config}]
+
+ :config-in-ns
+ {;; riemann.config* is a special namespace, because it imports a lot
+  ;; of functions so they are visible in riemann.config as part of DSL. This also
+  ;; disable (require :refer :all) linter, because some namespaces imports all
+  ;; symbols inside riemann.config
+  riemann-config
+  {:linters
+   {:refer-all {:level :off}
+    :unused-namespace
+    {:exclude [clojure.tools.nrepl.server
+               riemann.boundary
+               riemann.client
+               riemann.clickhouse
+               riemann.cloudwatch
+               riemann.datadog
+               riemann.druid
+               riemann.email
+               riemann.folds
+               riemann.graphite
+               riemann.hipchat
+               riemann.influxdb
+               riemann.influxdb2
+               riemann.kairosdb
+               riemann.keenio
+               riemann.librato
+               riemann.logentries
+               riemann.logstash
+               riemann.mailgun
+               riemann.msteams
+               riemann.nagios
+               riemann.netuitive
+               riemann.opentsdb
+               riemann.opsgenie
+               riemann.pagerduty
+               riemann.pushover
+               riemann.rabbitmq
+               riemann.shinken
+               riemann.slack
+               riemann.sns
+               riemann.stackdriver
+               riemann.prometheus
+               riemann.elasticsearch
+               riemann.telegram
+               riemann.test
+               riemann.time
+               riemann.twilio
+               riemann.victorops
+               riemann.xymon
+               riemann.zabbix]}
+
+    :unused-referred-var
+    {:exclude {riemann.boundary [boundary]
+               riemann.client [udp-client tcp-client multi-client]
+               riemann.clickhouse [clickhouse]
+               riemann.cloudwatch [cloudwatch]
+               riemann.common [event]
+               riemann.datadog [datadog]
+               riemann.druid [druid]
+               riemann.email [mailer]
+               riemann.graphite [graphite]
+               riemann.hipchat [hipchat]
+               riemann.influxdb [influxdb]
+               riemann.influxdb2 [influxdb2]
+               riemann.kafka [kafka]
+               riemann.kairosdb [kairosdb]
+               riemann.keenio [keenio]
+               riemann.librato [librato-metrics]
+               riemann.logentries [logentries]
+               riemann.logstash [logstash]
+               riemann.mailgun [mailgun]
+               riemann.msteams [msteams]
+               riemann.nagios [nagios]
+               riemann.netuitive [netuitive]
+               riemann.opentsdb [opentsdb]
+               riemann.opsgenie [opsgenie]
+               riemann.pagerduty [pagerduty]
+               riemann.plugin [load-plugins]
+               riemann.pushover [pushover]
+               riemann.rabbitmq [rabbitmq]
+               riemann.shinken [shinken]
+               riemann.slack [slack]
+               riemann.sns [sns-publisher]
+               riemann.stackdriver [stackdriver]
+               riemann.prometheus [prometheus]
+               riemann.elasticsearch [elasticsearch default-bulk-formatter elasticsearch-bulk]
+               riemann.telegram [telegram]
+               riemann.test [tap io tests]
+               riemann.time [unix-time linear-time once! every!]
+               riemann.twilio [twilio]
+               riemann.victorops [victorops]
+               riemann.xymon [xymon]
+               riemann.zabbix [zabbix]}}}}}
+}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,6 @@
-{:linters
+{:config-paths ["macros"]
+
+ :linters
  {:unresolved-symbol {:exclude [_]}
   :unused-binding    {:exclude-patterns ["^this"]}
   :redundant-do      {:level :off}}
@@ -7,12 +9,19 @@
 
  :skip-comments true
 
- ;:lint-as
- ;{riemann.streams/where clojure.core/when}
+ :lint-as
+ {;riemann.pool/with-pool clj-kondo.lint-as/def-catch-all
+  ;riemann.pool/with-pool clojure.core/with-open
+  }
 
  :hooks
  {:analyze-call
-  {riemann.streams/where hooks.streams/where}}
+  {riemann.streams/where  hooks.streams/where}
+
+  ;; macros are stored in 'macros' folder and should match namespace where
+  ;; where original macro is defined
+  :macroexpand
+  {riemann.pool/with-pool riemann.pool/with-pool}}
 
  :ns-groups [{:pattern "riemann\\.config*" :name riemann-config}]
 

--- a/.clj-kondo/hooks/httpkit.clj
+++ b/.clj-kondo/hooks/httpkit.clj
@@ -1,0 +1,15 @@
+(ns hooks.httpkit
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn with-channel
+  "Analyze (org.httpkit.server/with-channel)."
+  [{node :node}]
+  (let [[_ req chan & body] (:children node)]
+    (when-not (and req chan)
+      (throw (ex-info "Missing request or channel args" {})))
+    {:node (api/list-node
+            (list*
+              (api/token-node 'let)
+              (api/vector-node [chan (api/token-node 'nil)])
+              req
+              body))}))

--- a/.clj-kondo/hooks/streams.clj
+++ b/.clj-kondo/hooks/streams.clj
@@ -1,0 +1,14 @@
+(ns hooks.streams
+  (:require [clj-kondo.hooks-api :as api]))
+
+;; allowed symbols in (where) block
+(def where-syms '#{host service state metric metric_f time
+                   ttl description tags tagged tagged-all tagged-any})
+
+(defn where
+  "Analyze (riemann.streams/where)"
+  [{:keys [node]}]
+  (let [[_ sym & body] (:children node)]
+    (when-not (contains? where-syms (:value sym))
+      (throw (ex-info (str "(where) accepts one of: " where-syms) {})))
+    {:node (first body)}))

--- a/.clj-kondo/macros/riemann/pool.clj
+++ b/.clj-kondo/macros/riemann/pool.clj
@@ -1,0 +1,13 @@
+(ns riemann.pool)
+
+(defmacro with-pool
+  [[thingy pool timeout] & body]
+  `(let [thingy# (claim ~pool ~timeout)
+         ~thingy thingy#]
+     (try
+       (let [res# (do ~@body)]
+         (release ~pool thingy#)
+         res#)
+       (catch Exception t#
+         (invalidate ~pool thingy#)
+         (throw t#)))))

--- a/.clj-kondo/macros/riemann/service.clj
+++ b/.clj-kondo/macros/riemann/service.clj
@@ -1,0 +1,11 @@
+(ns riemann.service)
+
+(defmacro all-equal?
+  [a b & forms]
+  (let [asym (gensym "a__")
+        bsym (gensym "b__")]
+  `(let [~asym ~a
+         ~bsym ~b]
+     (and ~@(map (fn [[fun & args]]
+                  `(= (~fun ~asym ~@args) (~fun ~bsym ~@args)))
+                forms)))))

--- a/.clj-kondo/macros/riemann/transport.clj
+++ b/.clj-kondo/macros/riemann/transport.clj
@@ -1,0 +1,23 @@
+(ns riemann.transport)
+
+(defmacro channel-initializer [& names-and-exprs]
+  (let [handlers (partition 2 names-and-exprs)
+        shared (filter (comp :shared meta first) handlers)
+        pipeline-name (vary-meta (gensym "pipeline")
+                                 assoc :tag `ChannelPipeline)
+        forms (map (fn [[h-name h-expr]]
+                     `(.addLast ~pipeline-name
+                                ~(when-let [e (:executor (meta h-name))]
+                                   e)
+                                ~(str h-name)
+                                ~(if (:shared (meta h-name))
+                                   h-name
+                                   h-expr)))
+                   handlers)]
+    `(let [~@(apply concat shared)]
+       (proxy [ChannelInitializer] []
+         (initChannel [~'ch]
+           (let [~pipeline-name (.pipeline ^Channel ~'ch)]
+             ~@forms
+             ~pipeline-name))))))
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ matrix.java }}-maven-${{ hashFiles('**/project.clj') }}
+      - name: Run lint
+        run: lein lint
       - name: Run test2junit
         run: lein test2junit
       - name: Upload Test Results

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,3 @@ target/**
 config.edn
 riemann.config
 .vscode
-/.clj-kondo/.cache

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ site/**
 bench/**
 target/**
 /target/
-/config.edn
 riemann.config
 .vscode
+/config.edn
 /.clj-kondo/.cache

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ site/**
 bench/**
 target/**
 /target/
-config.edn
+/config.edn
 riemann.config
 .vscode
+/.clj-kondo/.cache

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ target/**
 config.edn
 riemann.config
 .vscode
+/.clj-kondo/.cache

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,5 @@
 (defproject riemann "0.3.11"
-  :description
-"A network event stream processor. Intended for analytics, metrics, and alerting; and to glue various monitoring systems together."
+  :description "A network event stream processor. Intended for analytics, metrics, and alerting; and to glue various monitoring systems together."
   :url "https://github.com/riemann/riemann"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
@@ -68,11 +67,16 @@
             [classworlds "1.1"]
             [test2junit "1.3.3"]]
   :test2junit-output-dir "target/test2junit"
+  :aliases {"lint" ["with-profile" "lint" "run" "-m" "clj-kondo.main" "--lint" "src"]}
   :profiles {:dev {:jvm-opts ["-XX:-OmitStackTraceInFastThrow"]
 ;                              "-Dcom.sun.management.jmxremote"
 ;                              "-XX:+UnlockCommercialFeatures"
 ;                              "-XX:+FlightRecorder"]
                    :dependencies [[criterium "0.4.4"]]}
+
+             :lint {:dependencies [[clj-kondo/clj-kondo "2024.05.24"]]
+                    ;; do not spin another JVM instance, faster startup
+                    :eval-in :classloader}
              :uberjar {:aot :all}}
   :test-selectors {:default (fn [x] (not (or (:integration x)
                                              (:time x)

--- a/project.clj
+++ b/project.clj
@@ -74,9 +74,7 @@
 ;                              "-XX:+FlightRecorder"]
                    :dependencies [[criterium "0.4.4"]]}
 
-             :lint {:dependencies [[clj-kondo/clj-kondo "2024.05.24"]]
-                    ;; do not spin another JVM instance, faster startup
-                    :eval-in :classloader}
+             :lint {:dependencies [[clj-kondo/clj-kondo "2024.08.01"]]}
              :uberjar {:aot :all}}
   :test-selectors {:default (fn [x] (not (or (:integration x)
                                              (:time x)

--- a/src/riemann/blueflood.clj
+++ b/src/riemann/blueflood.clj
@@ -45,7 +45,7 @@
       :throw-entire-message? true})
     (streams/call-rescue evs children)))
 
-(defn blueflood-ingest [opts & children]
+(defn blueflood-ingest
   "A stream which creates a batch, optionally asynchronous, of events to 
   forward to BF
 
@@ -71,6 +71,7 @@
   or for synchronous, just:
      (blueflood-ingest {:host \"blueflood-server\" 
                         :tenant-id \"tenant\"})"
+  [opts & children]
   (let [opts (merge defaults opts)
         {:keys [n dt host port tenant-id
                 async-queue-name threadpool-service-opts]} opts

--- a/src/riemann/clickhouse.clj
+++ b/src/riemann/clickhouse.clj
@@ -119,5 +119,5 @@
     (fn [events]
       (let [insert-url (generate-insert-url opts)
             datapoint (generate-datapoint-batch events)]
-        (if-not (nil? datapoint)
+        (when-not (nil? datapoint)
           (post-datapoint insert-url datapoint))))))

--- a/src/riemann/cloudwatch.clj
+++ b/src/riemann/cloudwatch.clj
@@ -1,8 +1,7 @@
 (ns riemann.cloudwatch
   "Forwards riemann events to Amazon CloudWatch"
   (:import org.joda.time.DateTime)
-  (:require [amazonica.core :as core]
-            [amazonica.aws.cloudwatch :as cloudwatch]))
+  (:require [amazonica.aws.cloudwatch :as cloudwatch]))
 
 (defn generate-datapoint
   "Accepts riemann event and converts it into cloudwatch datapoint."

--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -252,7 +252,7 @@
 (defn update-index
   "Updates the given index with all events received. Also publishes to the
   index pubsub channel."
-  [index]
+  [_]
   (common/deprecated "(update-index idx) is unnecessary; use idx directly instead. Indexes are now streams themselves, so it's not necessary to wrap them in update-index."
     (fn update [event] (core/update-index @core event))))
 
@@ -339,7 +339,7 @@
   as your other streams, like (publish)."
   [channel f]
   (let [sub (pubsub/subscribe! (:pubsub @core) channel f)]
-    (fn discard [event] sub)))
+    (fn discard [_] sub)))
 
 (defn clear!
   "Resets the next core."

--- a/src/riemann/core.clj
+++ b/src/riemann/core.clj
@@ -1,15 +1,14 @@
 (ns riemann.core
   "Binds together an index, servers, and streams."
-  (:use [riemann.time :only [unix-time]]
-        [riemann.common :only [deprecated localhost event]]
-        clojure.tools.logging
-        [riemann.instrumentation :only [Instrumented]])
-  (:require riemann.streams
+  (:require [riemann.time :refer [unix-time]]
+            [riemann.common :refer [deprecated localhost event]]
+            riemann.streams
             [riemann.service :as service :refer [Service ServiceEquiv]]
             [riemann.index :as index :refer [Index]]
             [riemann.pubsub :as ps]
             [riemann.test :as test]
-            [riemann.instrumentation :as instrumentation]
+            [riemann.instrumentation :as instrumentation :refer [Instrumented]]
+            [clojure.tools.logging :refer [warn info]]
             clojure.set))
 
 (defn stream!

--- a/src/riemann/datadog.clj
+++ b/src/riemann/datadog.clj
@@ -1,7 +1,7 @@
 (ns riemann.datadog
   "Forward events to Datadog."
-  (:use [clojure.string :only [join split]])
-  (:require [clj-http.client :as client]
+  (:require [clojure.string :refer [join split]]
+            [clj-http.client :as client]
             [cheshire.core :refer [generate-string]]))
 
 (def ^:private gateway-url "https://app.datadoghq.com/api/v1/series")

--- a/src/riemann/deps.clj
+++ b/src/riemann/deps.clj
@@ -70,10 +70,11 @@
 (defn depends [a & bs]
   (Depends. a (All. bs)))
 
-(defn deps-tag [index rule & children]
+(defn deps-tag
   "Returns a stream which accepts events, checks whether they satisfy the given
   rule, and associates those which have their dependencies satisfied with
   {:deps-satisfied true}, and false for those which are satisfied."
+  [index rule & children]
   (fn [event]
     (streams/call-rescue
       (assoc event :deps-satisfied? (match rule index event))

--- a/src/riemann/email.clj
+++ b/src/riemann/email.clj
@@ -2,9 +2,8 @@
   "Send email about events. Create a mailer with (mailer opts), then create
   streams which send email with (your-mailer \"shodan@tau.ceti.five\"). Or
   simply call email-event directly."
-  (:use [riemann.common :only [deprecated body subject human-uniq]])
-  (:use postal.core)
-  (:use [clojure.string :only [join]]))
+  (:require [riemann.common :refer [body subject]]
+            [postal.core :refer [send-message]]))
 
 (defn email-event
   "Send an event, or a sequence of events, with the given smtp and msg

--- a/src/riemann/folds.clj
+++ b/src/riemann/folds.clj
@@ -10,7 +10,7 @@
 
   Called with an empty list, folds which would return a single event return
   nil."
-  (:use [riemann.common])
+  (:require [riemann.common :as c])
   (:refer-clojure :exclude [count]))
 
 (defn sorted-sample-extract
@@ -84,7 +84,7 @@
   (when-let [e (first events)]
     (try
       (assoc e :metric (reduce f (map :metric events)))
-      (catch NullPointerException ex
+      (catch NullPointerException _
         (merge e
                {:metric nil
                 :description "An event or metric was nil."})))))
@@ -139,7 +139,7 @@
   (when-let [event (first events)]
     (try
       (fold-all / events)
-      (catch ArithmeticException e
+      (catch ArithmeticException _
         (merge event
                {:metric nil
                 :description "Can't divide by zero"})))))
@@ -213,11 +213,10 @@
   "calculates standard deviation across a seq of events"
   [events]
   (when-let [e (some identity events)]
-    (let [
-      samples (non-nil-metrics events)
-      n (clojure.core/count samples)
-      mean (/ (reduce + samples) n)
-      intermediate (map #(Math/pow (- %1 mean) 2) samples)]
+    (let [samples (non-nil-metrics events)
+          n (clojure.core/count samples)
+          mean (/ (reduce + samples) n)
+          intermediate (map #(Math/pow (- %1 mean) 2) samples)]
       (assoc e :metric (Math/sqrt (/ (reduce + intermediate) n))))))
 
 (defn count
@@ -226,4 +225,4 @@
   (let [events (remove nil? events)]
     (if-let [e (first events)]
       (assoc e :metric (clojure.core/count events))
-      (event {:metric 0}))))
+      (c/event {:metric 0}))))

--- a/src/riemann/graphite.clj
+++ b/src/riemann/graphite.clj
@@ -1,17 +1,17 @@
 (ns riemann.graphite
   "Forwards events to Graphite."
   (:refer-clojure :exclude [replace])
-  (:import
-   (java.net Socket
-             DatagramSocket
-             DatagramPacket
-             InetAddress)
-   (java.io Writer OutputStreamWriter))
-  (:use [clojure.string :only [split join replace]]
+  (:require [clojure.string :refer [split join replace]]
+            [riemann.transport :refer [resolve-host]]
+            [riemann.pool :refer [fixed-pool with-pool]]
+            [clojure.tools.logging :refer [info]]
+            #_[riemann.common :refer [client]])
+  (:import [java.net Socket DatagramSocket DatagramPacket InetAddress]
+           [java.io OutputStreamWriter])
+  #_(:use 
         clojure.tools.logging
-        riemann.pool
         riemann.common
-        [riemann.transport :only [resolve-host]]))
+        ))
 
 (defprotocol GraphiteClient
   (open [client]

--- a/src/riemann/graphite.clj
+++ b/src/riemann/graphite.clj
@@ -79,11 +79,11 @@
   (graphite-path-basic
     (if-let [service (:service event)]
       (assoc event :service
-             ; hack hack hack hack
              (replace service
                       #"(\d+)\.(\d+)$"
-                      (fn [[_ whole frac]] (str (when-not (= "0" whole))
-                                                frac))))
+                      (fn [[_ whole frac]]
+                        (str (when-not (= "0" whole) whole)
+                             frac))))
       event)))
 
 (defn graphite-path-tags

--- a/src/riemann/hipchat.clj
+++ b/src/riemann/hipchat.clj
@@ -4,9 +4,10 @@
   (:require [clj-http.client :as client]
             [clojure.string :refer [join]]))
 
-(defn- message-colour [ev]
+(defn- message-colour
   "Set the colour to be used in the
   hipchat message."
+  [ev]
   (let [state (or (:state ev) (:state (first ev)))]
     (get {"ok"        "green"
           "critical"  "red"
@@ -17,9 +18,10 @@
 (defn ^:private chat-url [server room]
   (str "https://" server "/v2/room/" room "/notification"))
 
-(defn- format-message [ev]
+(defn- format-message
   "Formats a message, accepts a single
   event or a sequence of events."
+  [ev]
   (join "\n\n"
         (map
           (fn [e]
@@ -30,8 +32,9 @@
               " \nMetric: " (:metric e)
               " \nDescription: " (:description e))) ev)))
 
-(defn- format-event [{:keys [message] :as conf} event]
+(defn- format-event
   "Creates an event suitable for posting to hipchat."
+  [{:keys [message] :as conf} event]
   (merge {:color (message-colour event) :from "riemann"}
          (dissoc conf :server :room_id)
          (when-not message
@@ -67,7 +70,7 @@
     (changed-state hc))
   ```"
   [{:keys [server token room notify]}]
-  (if (not (= 40 (count token)))
+  (when-not (= 40 (count token))
     (throw (IllegalArgumentException. "This adapter now requires a v2 API key")))
   (fn [e] (post token
                 {:server  (or server "api.hipchat.com")

--- a/src/riemann/index.clj
+++ b/src/riemann/index.clj
@@ -14,10 +14,10 @@
   (:require [riemann.query :as query]
             [riemann.common :refer [deprecated]]
             [riemann.instrumentation :refer [Instrumented]]
-            [clojure.tools.logging :refer [error]])
-  (:use [riemann.time :only [unix-time]]
-         riemann.service)
-  (:import (org.cliffc.high_scale_lib NonBlockingHashMap)))
+            [clojure.tools.logging :refer [error]]
+            [riemann.time :refer [unix-time]]
+            [riemann.service :refer [Service ServiceEquiv]])
+  (:import [org.cliffc.high_scale_lib NonBlockingHashMap]))
 
 (defprotocol Index
   (clear [this]
@@ -44,15 +44,15 @@
 (defn query-for-host-and-service
   "Check if the AST is only searching for the host and service"
   [query-ast]
-  (if (and (list? query-ast)
-           (= 'and (first query-ast)))
+  (when (and (list? query-ast)
+             (= 'and (first query-ast)))
     (let [and-exprs (rest query-ast)]
-      (if (and (= 2 (count and-exprs))
-               (every? list? and-exprs)
-               (= 2 (count (filter #(= (first %) '=) and-exprs))))
+      (when (and (= 2 (count and-exprs))
+                 (every? list? and-exprs)
+                 (= 2 (count (filter #(= (first %) '=) and-exprs))))
         (let [host    (first (filter #(= (second %) :host) and-exprs))
               service (first (filter #(= (second %) :service) and-exprs))]
-          (if (and host service)
+          (when (and host service)
             [(last host) (last service)]))))))
 
 (defn nbhm-index
@@ -120,8 +120,8 @@
       (equiv? [this other] (= (class this) (class other)))
 
       Service
-      (conflict? [this other] false)
-      (reload! [this new-core])
+      (conflict? [this _other] false)
+      (reload! [this _new-core])
       (start! [this])
       (stop! [this]))))
 

--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -27,7 +27,7 @@
   a string key/value entry in the tag map."
   [tag-fields event]
   (->> (select-keys event tag-fields)
-       (remove (fn [[k v]] (nil-or-empty-str v)))
+       (remove (fn [[_ v]] (nil-or-empty-str v)))
        (map #(vector (name (key %)) (str (val %))))
        (into {})))
 
@@ -41,7 +41,7 @@
   (let [ignored-fields (set/union special-fields tag-fields)]
     (-> event
         (->> (remove (comp ignored-fields key))
-             (remove (fn [[k v]] (nil-or-empty-str v)))
+             (remove (fn [[_ v]] (nil-or-empty-str v)))
              (map #(vector (name (key %)) (val %)))
              (into {}))
         (assoc "value" (:metric event)))))
@@ -109,7 +109,7 @@
     (= precision :milliseconds) TimeUnit/MILLISECONDS
     (= precision :microseconds) TimeUnit/MICROSECONDS
     (= precision :seconds) TimeUnit/SECONDS
-    true TimeUnit/SECONDS))
+    :else TimeUnit/SECONDS))
 
 (defn convert-time
   "Converts the `time-event` parameter (which is time second) in a new time unit specified by the `precision` parameter. It also converts the time to long.
@@ -122,7 +122,7 @@
     (= precision :milliseconds) (long (* 1000 time-event))
     (= precision :microseconds) (long (* 1000000 time-event))
     (= precision :seconds) (long time-event)
-    true (long time-event)))
+    :else (long time-event)))
 
 (defn converts-double
   "if n if a ratio or a BigInt, converts it to double. Returns n otherwise."

--- a/src/riemann/influxdb2.clj
+++ b/src/riemann/influxdb2.clj
@@ -1,13 +1,12 @@
 (ns riemann.influxdb2
   "Forwards events to InfluxDB v2."
-  (:import
-    (com.influxdb.client InfluxDBClient InfluxDBClientFactory WriteApi)
-    (com.influxdb.client.domain WritePrecision)
-    (com.influxdb.client.write Point)))
+  (:import [com.influxdb.client InfluxDBClientFactory]
+           [com.influxdb.client.domain WritePrecision]
+           [com.influxdb.client.write Point]))
 
 (defn create-client
   "Returns a `com.influxdb.client.InfluxDBClient` instance."
-  [{:keys [organization bucket scheme host port token] :as opts}]
+  [{:keys [organization bucket scheme host port token]}]
   (let [url (str scheme "://" host ":" port)]
     (InfluxDBClientFactory/create url (char-array token) organization bucket)))
 
@@ -18,7 +17,7 @@
     (= precision :microseconds) WritePrecision/US
     (= precision :nanoseconds) WritePrecision/NS
     (= precision :seconds) WritePrecision/S
-    true WritePrecision/S))
+    :else WritePrecision/S))
 
 (defn convert-time
   [time-event precision]
@@ -27,7 +26,7 @@
     (= precision :microseconds) (long (* 1000000 time-event))
     (= precision :nanoseconds) (long (* 1000000000 time-event))
     (= precision :seconds) (long time-event)
-    true (long time-event)))
+    :else (long time-event)))
 
 (defn event->point
   "Returns a `com.influxdb.client.write.Point` instance."

--- a/src/riemann/instrumentation.clj
+++ b/src/riemann/instrumentation.clj
@@ -1,13 +1,12 @@
 (ns riemann.instrumentation
   "Tracks Riemann performance data"
-  (:use [riemann.time :only [unix-time]]
-        [riemann.common :only [event localhost]]
-        [interval-metrics.core :only [Metric
-                                      update!
-                                      snapshot!
-                                      rate
-                                      quantile
-                                      uniform-reservoir]]))
+  (:require [riemann.time :refer [unix-time]]
+            [interval-metrics.core :refer [Metric
+                                           update!
+                                           snapshot!
+                                           rate
+                                           quantile
+                                           uniform-reservoir]]))
 
 (defprotocol Instrumented
   "These things can be asked to report events about their performance and

--- a/src/riemann/kafka.clj
+++ b/src/riemann/kafka.clj
@@ -2,11 +2,11 @@
   "Receives events from and forwards events to Kafka."
   (:require [kinsky.client :as client]
             [cheshire.core :as json]
-            [riemann.test :as test])
-  (:use [riemann.common        :only [event]]
-        [riemann.core          :only [stream!]]
-        [riemann.service       :only [Service ServiceEquiv ServiceStatus]]
-        [clojure.tools.logging :only [debug info error]]))
+            [riemann.test :as test]
+            [riemann.common :refer [event]]
+            [riemann.core :refer [stream!]]
+            [riemann.service :refer [Service ServiceEquiv ServiceStatus]]
+            [clojure.tools.logging :refer [debug info error]]))
 
 (defn kafka
   "Returns a function that is invoked with a topic name and an optional message key and returns a stream. That stream is a function which takes an event or a sequence of events and sends them to Kafka.
@@ -85,7 +85,7 @@
               (try
                 (let [event (event (get record :value))]
                   (stream! @core event))
-                (catch java.lang.NullPointerException e
+                (catch java.lang.NullPointerException _
                   (debug (str "Invalid message: " record)))))))
         (catch Exception e
           (do

--- a/src/riemann/librato.clj
+++ b/src/riemann/librato.clj
@@ -1,10 +1,10 @@
 (ns riemann.librato
   "Forwards events to Librato Metrics."
-  (:require [clojure.string :as string])
-  (:use [clj-librato.metrics :only [collate annotate connection-manager
-                                    update-annotation]]
-        [clojure.tools.logging :only [error]]
-        clojure.math.numeric-tower))
+  (:require [clojure.string :as string]
+            [clj-librato.metrics :refer [collate annotate connection-manager
+                                         update-annotation]]
+            [clojure.tools.logging :refer [error]]
+            [clojure.math.numeric-tower :refer [round]]))
 
 (defn safe-name
   "Converts a string into a safe name for Librato's metrics and streams.

--- a/src/riemann/logentries.clj
+++ b/src/riemann/logentries.clj
@@ -1,11 +1,10 @@
 (ns riemann.logentries
   "Forwards events to Logentries."
   (:import
-   (java.net Socket)
-   (java.io OutputStreamWriter))
-  (:use clojure.tools.logging
-        riemann.pool
-        riemann.common))
+   [java.net Socket]
+   [java.io OutputStreamWriter])
+  (:require [riemann.pool :refer [fixed-pool with-pool]]
+            [clojure.tools.logging :refer [info]]))
 
 (defn format-event-data [data]
   (apply str

--- a/src/riemann/logging.clj
+++ b/src/riemann/logging.clj
@@ -5,8 +5,7 @@
              Level
              Logger)
            (ch.qos.logback.core
-             ConsoleAppender
-             FileAppender)
+             ConsoleAppender)
            (ch.qos.logback.core.util
              FileSize)
            (ch.qos.logback.core.encoder
@@ -41,25 +40,25 @@
 (defmulti encoder identity)
 
 (defmethod encoder :json
-  [type]
+  [_]
   (LogstashEncoder.))
 
 (defmethod encoder :json-event
-  [type]
+  [_]
   (encoder :json-event-v0))
 
 (defmethod encoder :json-event-v0
-  [type]
+  [_]
   (doto (LayoutWrappingEncoder.)
     (.setLayout (JSONEventLayoutV0.))))
 
 (defmethod encoder :json-event-v1
-  [type]
+  [_]
   (doto (LayoutWrappingEncoder.)
     (.setLayout (JSONEventLayoutV1.))))
 
 (defmethod encoder :riemann
-  [type]
+  [_]
   (doto (PatternLayoutEncoder.)
     (.setPattern "%p [%d] %t - %c - %m%n%throwable")))
 

--- a/src/riemann/logstash.clj
+++ b/src/riemann/logstash.clj
@@ -1,17 +1,12 @@
 (ns riemann.logstash
   "Forwards events to LogStash."
   (:refer-clojure :exclude [replace])
-  (:import
-   (java.net Socket
-             DatagramSocket
-             DatagramPacket
-             InetAddress)
-   (java.io Writer OutputStreamWriter BufferedWriter))
-  (:use [clojure.string :only [split join replace]]
-        clojure.tools.logging
-        riemann.pool
-        riemann.common
-        less.awful.ssl))
+  (:import [java.net Socket DatagramSocket DatagramPacket InetAddress]
+           [java.io OutputStreamWriter BufferedWriter])
+  (:require [riemann.pool :refer [fixed-pool with-pool]]
+            [riemann.common :refer [event-to-json]]
+            [clojure.tools.logging :refer [info]]
+            [less.awful.ssl :refer [socket ssl-context]]))
 
 (defprotocol LogStashClient
   (open [client]

--- a/src/riemann/msteams.clj
+++ b/src/riemann/msteams.clj
@@ -1,8 +1,8 @@
 (ns riemann.msteams
   "Post alerts to Microsoft Teams"
   (:require [clj-http.client :as client]
-            [cheshire.core :as json])
-  (:use [clojure.string :only [join]]))
+            [cheshire.core :as json]
+            [clojure.string :refer [join]]))
 
 (defn- default-formatter
   "Default formatter for rendering events as a message card."

--- a/src/riemann/netuitive.clj
+++ b/src/riemann/netuitive.clj
@@ -1,8 +1,9 @@
 (ns riemann.netuitive
   "Forward events to Netuitive."
-  (:use [clojure.string :only [join split]])
   (:require [clj-http.client :as client]
-            [cheshire.core :refer [generate-string]]))
+            [cheshire.core :refer [generate-string]]
+            [clojure.set :as set]
+            [clojure.string :refer [join split]]))
 
 (def ^:private gateway-url "https://api.app.netuitive.com/ingest/")
 
@@ -33,9 +34,9 @@
 (defn combine-elements
    "Combine two elements"
    [element1 element2]
-   (assoc element1 :metrics (clojure.set/union (:metrics element1) (:metrics element2))
+   (assoc element1 :metrics (set/union (:metrics element1) (:metrics element2))
                    :samples (concat (:samples element1) (:samples element2))
-                   :tags    (clojure.set/union (:tags element1) (:tags element2))))
+                   :tags    (set/union (:tags element1) (:tags element2))))
 
 (defn generate-event
    "Structure for ingest to Netuitive as JSON"

--- a/src/riemann/opentsdb.clj
+++ b/src/riemann/opentsdb.clj
@@ -1,16 +1,11 @@
 (ns riemann.opentsdb
   "Forwards events to OpenTSDB."
   (:refer-clojure :exclude [replace])
-  (:import
-   (java.net Socket
-             DatagramSocket
-             DatagramPacket
-             InetAddress)
-   (java.io Writer OutputStreamWriter))
-  (:use [clojure.string :only [split join replace]]
-        clojure.tools.logging
-        riemann.pool
-        riemann.common))
+  (:import [java.net Socket]
+           [java.io OutputStreamWriter])
+  (:require [clojure.string :refer [split join]]
+            [riemann.pool :refer [fixed-pool with-pool]]
+            [clojure.tools.logging :refer [info]]))
 
 (defprotocol OpenTSDBClient
   (open [client]

--- a/src/riemann/opsgenie.clj
+++ b/src/riemann/opsgenie.clj
@@ -1,7 +1,8 @@
 (ns riemann.opsgenie
   "Forwards events to OpsGenie"
-  (:require [clj-http.client :as client])
-  (:require [cheshire.core :as json]))
+  (:require [clj-http.client :as client]
+            [cheshire.core :as json]
+            [clojure.string :refer [join]]))
 
 (def alerts-url
   "https://api.opsgenie.com/v2/alerts")
@@ -41,7 +42,7 @@
   "Generate OpsGenie alias based on event"
   [event]
   (hash (str (:host event) \uffff (:service event) \uffff
-       (clojure.string/join \uffff (sort (:tags event))))))
+       (join \uffff (sort (:tags event))))))
 
 (defn default-body
   [event]

--- a/src/riemann/pagerduty.clj
+++ b/src/riemann/pagerduty.clj
@@ -3,7 +3,8 @@
   (:require [clj-http.client :as client]
             [cheshire.core :as json]
             [clj-time.format :as f]
-            [clj-time.coerce :as coerce]))
+            [clj-time.coerce :as coerce]
+            [riemann.time :refer [unix-time]]))
 
 (def ^:private event-url-v1
   "https://events.pagerduty.com/generic/2010-04-15/create_event.json")
@@ -45,7 +46,7 @@
                  (:metric event) ")")
    :source (:host event)
    :severity (:state event)
-   :timestamp (->> (long (or (:time event) (long (riemann.time/unix-time))))
+   :timestamp (->> (long (or (:time event) (long (unix-time))))
                    (coerce/from-long)
                    (f/unparse timestamp-formatter))
    :custom_details event})

--- a/src/riemann/pool.clj
+++ b/src/riemann/pool.clj
@@ -1,7 +1,7 @@
 (ns riemann.pool
   "A generic thread-safe resource pool."
-  (:use clojure.tools.logging
-        [slingshot.slingshot :only [throw+]])
+  (:require [slingshot.slingshot :refer [throw+]]
+            [clojure.tools.logging :refer [warn]])
   (:import [java.util.concurrent LinkedBlockingQueue TimeUnit]))
 
 ; THIS IS A MUTABLE STATE OF AFFAIRS. WHICH IS TO SAY, IT IS FUCKING TERRIBLE.
@@ -21,7 +21,7 @@
   Pool
   (grow [this]
         (loop []
-          (if-let [thingy (try (open) (catch Exception t nil))]
+          (if-let [thingy (try (open) (catch Exception _ nil))]
             (.put ^LinkedBlockingQueue queue thingy)
             (do
               (Thread/sleep (* 1000 regenerate-interval))
@@ -35,7 +35,7 @@
            (or
              (try
                (.poll ^LinkedBlockingQueue queue timeout TimeUnit/MILLISECONDS)
-               (catch java.lang.InterruptedException e
+               (catch java.lang.InterruptedException _
                  nil))
              (throw+
                {:type ::timeout

--- a/src/riemann/prometheus.clj
+++ b/src/riemann/prometheus.clj
@@ -13,7 +13,7 @@
   "Filter attributes from a Riemann event."
   [opts event]
   (->> (keys event)
-       (filter #(if-not (contains? (:exclude-fields opts) %) %))
+       (filter #(when-not (contains? (:exclude-fields opts) %) %))
        (select-keys event)))
 
 (defn replace-disallowed
@@ -25,7 +25,7 @@
   "Creates a Prometheus label out of a Riemann event."
   [filtered-event]
   (->> filtered-event
-       (map #(if-not (nil? (second %)) (str (replace-disallowed (name (first %))) "=" (second %))))
+       (map #(when-not (nil? (second %)) (str (replace-disallowed (name (first %))) "=" (second %))))
        (str/join ",")))
 
 (defn generate-labels-batch
@@ -65,7 +65,7 @@
   "Creates a Prometheus label out of a Riemann event."
   [filtered-event]
   (->> filtered-event
-       (map #(if-not (nil? (second %)) (str "/" (replace-disallowed (name (first %))) "/" (second %))))
+       (map #(when-not (nil? (second %)) (str "/" (replace-disallowed (name (first %))) "/" (second %))))
        (str/join "")))
 
 (defn generate-labels
@@ -74,11 +74,11 @@
   (let [instance (->> opts
                       :host
                       (str "/instance/"))
-        tags (if-not (-> event
-                         :tags
-                         empty?) (->> (:tags event)
-                                      (str/join (:separator opts))
-                                      (str "/tags/")))
+        tags (when-not (-> event
+                           :tags
+                           empty?) (->> (:tags event)
+                                        (str/join (:separator opts))
+                                        (str "/tags/")))
         labels (->> event
                     (filter-event opts)
                     create-label)]
@@ -140,7 +140,7 @@
     (fn [event]
       (let [url (generate-url opts event)
             datapoint (generate-datapoint event)]
-        (if-not (nil? datapoint)
+        (when-not (nil? datapoint)
           (post-datapoint url datapoint))))))
 
 (defn prometheus-batch
@@ -167,5 +167,5 @@
     (fn [events]
       (let [url (generate-url-batch opts)
             datapoint (generate-datapoint-batch opts events)]
-        (if-not (nil? datapoint)
+        (when-not (nil? datapoint)
           (post-datapoint url datapoint))))))

--- a/src/riemann/pubsub.clj
+++ b/src/riemann/pubsub.clj
@@ -3,15 +3,15 @@
   channel, which has n subscribers. Each subscriber subscribes to a channel
   with an optional predicate function. Events which match the predicate are
   sent to the subscriber."
-  (:use clojure.tools.logging)
-  (:import (riemann.service Service
-                            ServiceEquiv)))
+  (:require [clojure.tools.logging :refer [info]])
+  (:import [riemann.service Service
+                            ServiceEquiv]))
 
 (defn dissoc-in
   "Dissociates an entry from a nested associative structure returning a new
   nested structure. keys is a sequence of keys. Any empty maps that result
   will not be present in the new structure."
-  [m [k & ks :as keys]]
+  [m [k & ks]]
   (if ks
     (if-let [nextmap (get m k)]
       (let [newmap (dissoc-in nextmap ks)]
@@ -66,7 +66,7 @@
                 (swap! channels dissoc-in [(:channel sub) (:id sub)]))
 
   (publish! [this channel event]
-            (doseq [[id ^Subscription sub] (get @channels channel)]
+            (doseq [[_ ^Subscription sub] (get @channels channel)]
               ((.f sub) event)))
 
   (sweep! [this]
@@ -89,7 +89,7 @@
   (equiv? [a b] (= (class a) (class b)))
 
   Service
-  (conflict? [a b] false)
+  (conflict? [_ _] false)
 
   (start! [this])
 

--- a/src/riemann/query.clj
+++ b/src/riemann/query.clj
@@ -5,8 +5,7 @@
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clj-antlr.core :as antlr]
-            [riemann.common :refer :all]
-            [slingshot.slingshot :refer [throw+ try+]]))
+            [slingshot.slingshot :refer [throw+]]))
 
 (def antlr-parser (-> "query.g4" io/resource slurp antlr/parser))
 
@@ -36,7 +35,7 @@
               (list 'and (antlr->ast t1) (antlr->ast t2))))
 
         ; The grammar should never generate these trees, but for completeness...
-        true
+        :else
         (throw+ {:type ::parse-error
                  :message (str "Unexpected predicate structure: "
                                (pr-str terms))})))
@@ -178,7 +177,7 @@
     ast
 
     ; Lists, on the other hand
-    true
+    :else
     (let [[node-type & terms] ast]
       (case node-type
         =               (apply list '= (map clj-ast terms))

--- a/src/riemann/repl.clj
+++ b/src/riemann/repl.clj
@@ -4,8 +4,8 @@
   above them. While you usually *start* a repl server from the config file, it
   is not bound to the usual config lifecycle and won't be shut down or
   interrupted during config reload."
-  (:use clojure.tools.logging)
-  (:require [clojure.tools.nrepl.server :as nrepl]))
+  (:require [clojure.tools.nrepl.server :as nrepl]
+            [clojure.tools.logging :refer [info]]))
 
 (def server nil)
 
@@ -14,6 +14,7 @@
   []
   (when-let [s server]
     (nrepl/stop-server s))
+  #_{:clj-kondo/ignore [:inline-def]}
   (def server nil))
 
 (defn start-server!
@@ -24,6 +25,7 @@
   [opts]
   (stop-server!)
   (let [opts (merge {:port 5557 :host "127.0.0.1"} opts)]
+    #_{:clj-kondo/ignore [:inline-def]}
     (def server (nrepl/start-server
                   :port (:port opts)
                   :bind (:host opts)))

--- a/src/riemann/service.clj
+++ b/src/riemann/service.clj
@@ -1,20 +1,15 @@
 (ns riemann.service
   "Lifecycle protocol for stateful services bound to a core."
   (:require wall.hack
-            riemann.instrumentation)
-  (:use clojure.tools.logging
-        [riemann.time :only [unix-time every! cancel]])
+            riemann.instrumentation
+            [riemann.time :refer [unix-time every! cancel]]
+            [clojure.tools.logging :refer [info]])
   (:import (riemann.instrumentation Instrumented)
            (java.util.concurrent TimeUnit
-                                 ThreadFactory
-                                 AbstractExecutorService
                                  Executor
                                  ExecutorService
-                                 BlockingQueue
                                  LinkedBlockingQueue
                                  RejectedExecutionException
-                                 ArrayBlockingQueue
-                                 SynchronousQueue
                                  ThreadPoolExecutor)))
 
 (defprotocol Service
@@ -41,7 +36,7 @@
 
 (extend-protocol ServiceEquiv
   nil
-  (equiv? [s1 s2]
+  (equiv? [_ s2]
     (nil? s2)))
 
 (defprotocol ServiceStatus
@@ -103,7 +98,7 @@
                                  (while @running
                                    (try
                                      (f @core)
-                                     (catch InterruptedException e
+                                     (catch InterruptedException _
                                        :interrupted)))))]
                 (reset! thread t)
                 (.start t)))))
@@ -188,7 +183,7 @@
                          (class)
                          (.name)))
 
-  (reload! [this new-core])
+  (reload! [this _])
 
   (start! [this]
           (locking this

--- a/src/riemann/slack.clj
+++ b/src/riemann/slack.clj
@@ -1,8 +1,8 @@
 (ns riemann.slack
   "Post alerts to slack.com"
   (:require [clj-http.client :as client]
-            [cheshire.core :as json])
-  (:use [clojure.string :only [escape join upper-case]]))
+            [cheshire.core :as json]
+            [clojure.string :refer [escape]]))
 
 
 (defn slack-escape
@@ -124,7 +124,7 @@
     {:keys [username channel icon formatter] :or {formatter default-formatter}}
     http-params]
    (fn [events]
-     (let [{:keys [text attachments] :as result} (formatter events)
+     (let [{:keys [text _] :as result} (formatter events)
            icon (:icon result (or icon ":warning:"))
            channel (:channel result channel)
            username (:username result username)]

--- a/src/riemann/sns.clj
+++ b/src/riemann/sns.clj
@@ -3,6 +3,8 @@
   (sns-publisher opts), then create streams which publish to topic(s) with
   (your-publisher \"your::arn\"). Or simply call sns-publish or
   sns-publish-async directly."
+  (:require [clojure.set :refer [union]]
+            [riemann.common :refer [truncate-bytes]])
   (:import (com.amazonaws AmazonWebServiceClient)
            (com.amazonaws.auth BasicAWSCredentials
                                DefaultAWSCredentialsProviderChain)
@@ -11,10 +13,7 @@
            (com.amazonaws.services.sns AmazonSNS
                                        AmazonSNSClient
                                        AmazonSNSAsyncClient)
-           [com.amazonaws.services.sns.model PublishRequest])
-  (:use [clojure.set :only [union]]
-        [clojure.string :only [join]]
-        riemann.common))
+           [com.amazonaws.services.sns.model PublishRequest]))
 
 (def max-subject-bytes 100)
 (def max-body-bytes 8092)
@@ -184,7 +183,7 @@
             msg-opts   :msg-opts} (sift-opts opts)]
        (sns-publisher aws-opts msg-opts async-opts)))
   ([aws-opts msg-opts & [async-opts]]
-     (if (and async-opts (:async async-opts))
+     (when (and async-opts (:async async-opts))
        (assert (or
                 (and (nil? (:error async-opts)) (nil? (:success async-opts)))
                 (and (:error async-opts) (:success async-opts)))

--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -24,8 +24,9 @@
 
   Some common patterns for defining child streams are (fn [e] (println e))
   and (partial log :info)."
-  (:require [riemann.common :refer [member? expire deprecated] :exclude [match]]
-            [clojure.math.numeric-tower :refer [middle expt]]
+  (:require [riemann.common :refer [member? expire deprecated middle exception->event]]
+            [clojure.math.numeric-tower :refer [expt]]
+            [clojure.tools.logging :refer [warn]]
             [riemann.folds :as folds]
             [riemann.index :as index]
             riemann.client

--- a/src/riemann/telegram.clj
+++ b/src/riemann/telegram.clj
@@ -1,7 +1,6 @@
 (ns ^{:doc "Send events to Telegram"}
   riemann.telegram
-  (:require [clj-http.client :as client]
-            [clojure.string :refer [escape join]]))
+  (:require [clj-http.client :as client]))
 
 (def ^:private api-url "https://api.telegram.org/bot%s/%s")
 
@@ -31,7 +30,7 @@
   (cond
     message-formatter (message-formatter event)
     (= "HTML" parse-mode) (html-parse-mode event)
-    :default (markdown-parse-mode event)))
+    :else (markdown-parse-mode event)))
 
 (defn- post
   "POST to the Telegram API."

--- a/src/riemann/time.clj
+++ b/src/riemann/time.clj
@@ -4,9 +4,8 @@
   threadpool for task execution, controlled by (start!) and (stop!)."
   (:import [java.util.concurrent ConcurrentSkipListSet]
            [java.util.concurrent.locks LockSupport])
-  (:use [clojure.math.numeric-tower :only [ceil]]
-        [clojure.stacktrace         :only [print-stack-trace]]
-        [clojure.tools.logging      :only [warn]]))
+  (:require [clojure.math.numeric-tower :refer [ceil]]
+            [clojure.tools.logging      :refer [warn]]))
 
 (defprotocol Task
   (succ [task]
@@ -142,7 +141,7 @@
 (defn run-tasks!
   "While running, takes tasks from the queue and executes them when ready. Will
   park the current thread when no tasks are available."
-  [i]
+  [_]
   (while @running
     (try
       (if-let [task (poll-task!)]

--- a/src/riemann/time/controlled.clj
+++ b/src/riemann/time/controlled.clj
@@ -2,8 +2,7 @@
   "Provides controllable periodic and deferred execution. Calling (advance!
   delta-in-seconds) moves the clock forward, triggering events that would have
   occurred, in sequence."
-  (:use riemann.time
-        clojure.math.numeric-tower))
+  (:require [riemann.time :refer [poll-task! reset-tasks! run schedule-sneaky! succ]]))
 
 (def clock
   "Reference to the current time, in seconds."
@@ -67,4 +66,3 @@
   come to think of it. Only for testing purposes."
   [f]
   (with-controlled-time! (f)))
-

--- a/src/riemann/transport.clj
+++ b/src/riemann/transport.clj
@@ -1,28 +1,23 @@
 (ns riemann.transport
   "Functions used in several transports. Some netty parts transpire
   here since netty is the preferred method of providing transports"
-  (:use [slingshot.slingshot :only [try+]]
-        [riemann.core        :only [stream!]]
-        [riemann.common      :only [decode-msg]]
-        [riemann.codec       :only [encode-pb-msg]]
-        [riemann.index       :only [search]]
-        [riemann.instrumentation :only [Instrumented]]
-        [riemann.time         :only [unix-time]]
-        clojure.tools.logging)
-  (:require [riemann.query       :as query])
+  (:require [slingshot.slingshot     :refer [try+]]
+            [riemann.core            :refer [stream!]]
+            [riemann.common          :refer [decode-msg]]
+            [riemann.codec           :refer [encode-pb-msg]]
+            [riemann.index           :refer [search]]
+            [riemann.instrumentation :refer [Instrumented]]
+            [riemann.time            :refer [unix-time]]
+            [riemann.query           :as query])
   (:import
     (java.util List)
-    (java.util.concurrent TimeUnit
-                          Executors)
+    (java.util.concurrent TimeUnit)
     (io.riemann.riemann Proto$Msg)
     (io.netty.channel ChannelInitializer
                       Channel
-                      ChannelPipeline
-                      ChannelHandler)
-    (io.netty.channel.group ChannelGroup
-                            DefaultChannelGroup)
+                      ChannelPipeline)
+    (io.netty.channel.group DefaultChannelGroup)
     (io.netty.channel.socket DatagramPacket)
-    (io.netty.buffer ByteBufInputStream)
     (io.netty.handler.codec MessageToMessageDecoder
                             MessageToMessageEncoder)
     (io.netty.handler.codec.protobuf ProtobufDecoder
@@ -182,9 +177,12 @@
       ; Otherwise just return an ack
       {:ok true})
 
+    ;; let clj-kondo ignore unresolved-symbol without rewritting try+ macro
+    #_{:clj-kondo/ignore [:unresolved-symbol]}
     ;; Some kind of error happened
     (catch [:type :riemann.query/parse-error] {:keys [message]}
       {:ok false :error (str "parse error: " message)})
+    #_{:clj-kondo/ignore [:unresolved-symbol]}
     (catch Exception ^Exception e
       {:ok false :error (.getMessage e)})))
 
@@ -193,5 +191,5 @@
   [host]
   (try
     (.getHostAddress (rand-nth (InetAddress/getAllByName host)))
-    (catch UnknownHostException e
+    (catch UnknownHostException _
       host)))

--- a/src/riemann/transport/debug.clj
+++ b/src/riemann/transport/debug.clj
@@ -1,6 +1,7 @@
 (ns riemann.transport.debug
   "It is very dark. You are likely to be eaten a grue."
-  (:require [riemann.transport :refer [retain]])
+  (:require [riemann.transport :refer [retain]]
+            [clojure.tools.logging :refer [warn]])
   (:import [io.netty.channel ChannelHandler
                              ChannelInboundHandler
                              ChannelOutboundHandler]

--- a/src/riemann/transport/debug.clj
+++ b/src/riemann/transport/debug.clj
@@ -1,7 +1,6 @@
 (ns riemann.transport.debug
   "It is very dark. You are likely to be eaten a grue."
-  (:require [clojure.tools.logging :refer :all]
-            [riemann.transport :refer [retain]])
+  (:require [riemann.transport :refer [retain]])
   (:import [io.netty.channel ChannelHandler
                              ChannelInboundHandler
                              ChannelOutboundHandler]
@@ -35,8 +34,9 @@
 
     (isSharable [] true)))
 
-(defn tap [n]
+(defn tap
   "Log fucking everything, prefixed by `n`."
+  [n]
   (reify
     ChannelHandler
     ChannelInboundHandler

--- a/src/riemann/transport/graphite.clj
+++ b/src/riemann/transport/graphite.clj
@@ -4,19 +4,18 @@
            [io.netty.handler.codec.string StringDecoder StringEncoder]
            [io.netty.handler.codec DelimiterBasedFrameDecoder
                                    Delimiters])
-  (:use [riemann.core :only [stream!]]
-        [riemann.codec :only [->Event]]
-        [riemann.transport.tcp :only [tcp-server
-                                      gen-tcp-handler]]
-        [riemann.transport.udp :only [udp-server
-                                      gen-udp-handler]]
-        [riemann.transport :only [channel-initializer
-                                  channel-group
-                                  shared-event-executor]]
-        [slingshot.slingshot :only [try+ throw+]]
-        [clojure.string :only [split
-                               join]]
-        [clojure.tools.logging :only [warn]]))
+  (:require [riemann.core :refer [stream!]]
+            [riemann.codec :refer [->Event]]
+            [riemann.transport.tcp :refer [tcp-server
+                                           gen-tcp-handler]]
+            [riemann.transport.udp :refer [udp-server
+                                           gen-udp-handler]]
+            [riemann.transport :refer [channel-initializer
+                                       channel-group
+                                       shared-event-executor]]
+            [slingshot.slingshot :refer [try+ throw+]]
+            [clojure.string :refer [split]]
+            [clojure.tools.logging :refer [warn]]))
 
 (defn tags->attributes
   "Converts a sequence of Graphite tag (key=val) into a Clojure map."
@@ -66,10 +65,10 @@
 
     ; Parse numbers
     (let [metric (try (Double. metric)
-                      (catch NumberFormatException e
+                      (catch NumberFormatException _
                         (throw+ "invalid metric")))
           timestamp (try (Long. timestamp)
-                         (catch NumberFormatException e
+                         (catch NumberFormatException _
                            (throw+ "invalid timestamp")))
           ; Construct event
           event (->Event nil
@@ -114,7 +113,7 @@
 
 (defn graphite-handler
   "Given a core, channel, and a message, applies the message to core."
-  [core stats ctx message]
+  [core _stats _ctx message]
   (stream! core message))
 
 (defn graphite-server

--- a/src/riemann/transport/opentsdb.clj
+++ b/src/riemann/transport/opentsdb.clj
@@ -1,25 +1,23 @@
 (ns riemann.transport.opentsdb
   (:import
-    [io.netty.util CharsetUtil]
-    [io.netty.handler.codec MessageToMessageDecoder]
-    [io.netty.handler.codec.string StringDecoder
-                                   StringEncoder]
-    [io.netty.handler.codec DelimiterBasedFrameDecoder
-                            Delimiters]
-    [io.netty.channel ChannelHandlerContext])
-  (:require [interval-metrics.core :as metrics])
-  (:use [riemann.core :only [stream!]]
-        [riemann.common :only [event]]
-        [riemann.transport.tcp :only [tcp-server
-                                      gen-tcp-handler]]
-        [riemann.transport :only [channel-initializer
-                                  channel-group
-                                  shared-event-executor]]
-        [interval-metrics.measure :only [measure-latency]]
-        [slingshot.slingshot :only [try+ throw+]]
-        [clojure.string :only [split join replace-first trimr]]
-        [clojure.walk :only [keywordize-keys]]
-        [clojure.tools.logging :only [warn]]))
+   [io.netty.util CharsetUtil]
+   [io.netty.handler.codec MessageToMessageDecoder]
+   [io.netty.handler.codec.string StringDecoder
+    StringEncoder]
+   [io.netty.handler.codec DelimiterBasedFrameDecoder
+    Delimiters]
+   [io.netty.channel ChannelHandlerContext])
+  (:require [interval-metrics.core :as metrics]
+            [riemann.core :refer [stream!]]
+            [riemann.common :refer [event]]
+            [riemann.transport.tcp :refer [tcp-server
+                                           gen-tcp-handler]]
+            [riemann.transport :refer [channel-initializer
+                                       channel-group
+                                       shared-event-executor]]
+            [slingshot.slingshot :refer [try+ throw+]]
+            [clojure.string :refer [split join replace-first trimr]]
+            [clojure.walk :refer [keywordize-keys]]))
 
 (defn decode-opentsdb-line
   "Parse an OpenTSDB message string into an event."
@@ -46,10 +44,10 @@
           (throw+ "NaN metric"))
 
     (let [metric (try (Double. metric)
-                      (catch NumberFormatException e
+                      (catch NumberFormatException _
                         (throw+ "invalid metric")))
           timestamp (try (Long. timestamp)
-                         (catch NumberFormatException e
+                         (catch NumberFormatException _
                            (throw+ "invalid timestamp")))
           description service
           service (if-let [tagstr (when-not (empty? tags) (join " " tags))]
@@ -99,7 +97,7 @@
 (defn opentsdb-handler
   "Messages to this handler are either :version or an event. Responds to
   version requests, and applies events to the core."
-  [core stats ^ChannelHandlerContext ctx message]
+  [core _ ^ChannelHandlerContext ctx message]
   (if (= :version message)
     ; Respond with version
     (.writeAndFlush ctx "net.opentsdb\nBuilt on ... (riemann-opentsdb)\n")

--- a/src/riemann/transport/rabbitmq.clj
+++ b/src/riemann/transport/rabbitmq.clj
@@ -9,13 +9,12 @@
             [langohr.basic :as lb]
             [riemann.test :as test]
             [interval-metrics.core :as metrics]
-            [clojure.java.io :as io])
-  (:use [clojure.tools.logging :only [warn info]]
-        [riemann.core :only [stream!]]
-        [riemann.common :only [decode-inputstream encode]]
-        [riemann.instrumentation :only [Instrumented]]
-        [riemann.service :only [Service ServiceEquiv]]
-        [riemann.transport :only [handle]]))
+            [clojure.java.io :as io]
+            [clojure.tools.logging :refer [warn info]]
+            [riemann.common :refer [decode-inputstream encode]]
+            [riemann.instrumentation :refer [Instrumented]]
+            [riemann.service :refer [Service ServiceEquiv]]
+            [riemann.transport :refer [handle]]))
 
 (def ^:no-doc pb->msg
   #(-> % (io/input-stream) (decode-inputstream)))

--- a/src/riemann/transport/rabbitmq.clj
+++ b/src/riemann/transport/rabbitmq.clj
@@ -24,7 +24,7 @@
 
 (defn- gen-message-handler
   [core stats ex-name]
-  (fn [channel {:keys [delivery-tag reply-to correlation-id] :as meta} ^bytes payload]
+  (fn [channel {:keys [delivery-tag reply-to correlation-id]} ^bytes payload]
     (letfn [(reply-with [msg]
               (lb/publish channel ex-name reply-to (msg->pb msg) {:content-type "application/octet-stream" :correlation-id correlation-id}))]
       (try

--- a/src/riemann/transport/sse.clj
+++ b/src/riemann/transport/sse.clj
@@ -5,7 +5,7 @@
             [interval-metrics.core    :as metrics]
             [org.httpkit.server       :as http]
             [riemann.common           :as common]
-            [riemann.test              :as test]
+            [riemann.test             :as test]
             [riemann.pubsub           :refer [subscribe! unsubscribe!]]
             [riemann.instrumentation  :refer [Instrumented]]
             [riemann.service          :refer [Service ServiceEquiv]]
@@ -38,7 +38,7 @@
   "Yield a function that given an incoming event will
    test for a given predicate and when it matches will
    format it for sending it over a SSE channel."
-  [{:keys [out] :as stats} ch pred]
+  [_ ch pred]
   (fn [event]
     ;; Send event to client, measuring write latency
     (when (pred event)
@@ -71,7 +71,7 @@
 
             (http/on-close
              ch
-             (fn [status]
+             (fn [_]
                (info "Closing SSE channel " remote-addr query)
                (unsubscribe! pubsub sub)))))
         (sse-error-uri ch uri)))))

--- a/src/riemann/transport/websockets.clj
+++ b/src/riemann/transport/websockets.clj
@@ -1,29 +1,23 @@
 (ns riemann.transport.websockets
   "Accepts messages from external sources. Associated with a core. Sends
   incoming events to the core's streams, queries the core's index for states."
-  (:require [riemann.query         :as query]
-            [riemann.index         :as index]
-            [riemann.pubsub        :as p]
-            [riemann.test          :as test]
-            [cheshire.core         :as json]
-            [interval-metrics.core :as metrics]
-            [org.httpkit.server    :as http])
-  (:use [riemann.common        :only [event-to-json ensure-event-time]]
-        [riemann.core          :only [stream!]]
-        [riemann.instrumentation :only [Instrumented]]
-        [riemann.service       :only [Service ServiceEquiv]]
-        [riemann.time          :only [unix-time]]
-        [interval-metrics.measure :only [measure-latency]]
-        [clojure.java.io       :only [reader]]
-        [clojure.tools.logging :only [info warn debug]]
-        [clj-http.util         :only [url-decode]]
-        [clojure.string        :only [split]])
-  (:import (java.io OutputStream
-                    BufferedWriter
-                    OutputStreamWriter
-                    InputStreamReader
-                    PipedInputStream
-                    PipedOutputStream)))
+  (:require [riemann.query            :as query]
+            [riemann.index            :as index]
+            [riemann.pubsub           :as p]
+            [riemann.test             :as test]
+            [cheshire.core            :as json]
+            [interval-metrics.core    :as metrics]
+            [org.httpkit.server       :as http]
+            [riemann.common           :refer [event-to-json ensure-event-time]]
+            [riemann.core             :refer [stream!]]
+            [riemann.instrumentation  :refer [Instrumented]]
+            [riemann.service          :refer [Service ServiceEquiv]]
+            [riemann.time             :refer [unix-time]]
+            [interval-metrics.measure :refer [measure-latency]]
+            [clojure.java.io          :refer [reader]]
+            [clojure.tools.logging    :refer [info warn debug]]
+            [clj-http.util            :refer [url-decode]]
+            [clojure.string           :refer [split]]))
 
 (defn http-query-map
   "Converts a URL query string into a map."
@@ -132,9 +126,10 @@
           (recur (.readLine body))))
       (http/close ch))))
 
-(defn ws-handler [core stats]
+(defn ws-handler
   "Returns a function which is called with new websocket connections.
   Responsible for routing requests to the appropriate handler."
+  [core stats]
   (fn handle [req]
     (http/with-channel req ch
       (try

--- a/src/riemann/zabbix.clj
+++ b/src/riemann/zabbix.clj
@@ -2,11 +2,9 @@
   "Forwards events to Zabbix"
   (:require
     [cheshire.core :as json]
-    [clojure.java.io :as io]
-    [clojure.string :as s]
-    [clojure.tools.logging :refer [error]])
+    [clojure.java.io :as io])
   (:import
-    (java.io ByteArrayOutputStream OutputStream)
+    (java.io ByteArrayOutputStream)
     (java.nio ByteBuffer ByteOrder)
     (java.net Socket)))
 
@@ -27,8 +25,9 @@
 ;; In a nutshell, a frame contains a request, which contains one or more
 ;; datapoints.
 
-(defn- long->buf [n]
+(defn- long->buf
   "Converts a long int n to a 64-bit little-endian ByteBuffer."
+  [n]
   (-> (ByteBuffer/wrap (byte-array 8))
       (.order ByteOrder/LITTLE_ENDIAN)
       (.putLong n)
@@ -53,8 +52,9 @@
   {:request "sender data"
    :data datapoints})
 
-(defn make-datapoint [event]
+(defn make-datapoint
   "Converts a Riemann event into a Zabbix datapoint."
+  [event]
   {:host (:host event)
    :key (:service event)
    :value (str (:metric event))


### PR DESCRIPTION
This PR lints Riemann code with [clj-kondo](https://github.com/clj-kondo/clj-kondo) linter. It is integrated with Leiningen, so running `lein lint` will invoke it (it is also integrated with github workflows). I tried to address tons of linting errors and warnings.

@aphyr @jamtur01 the only left thing I didn't fix is [this when-not](https://github.com/riemann/riemann/blob/main/src/riemann/graphite.clj#L85) expression, which I don't quite understaind. What it should evaluate to? Currently it behave just like: `(str frac)`. Is this expected?
