### PR TITLE
Remove text-justify: distribute.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -38,7 +38,6 @@ body {
   font-size: 17px;
   text-shadow: 0px 1px 3px rgba(0,0,0,0.3);
   text-align: justify;
-  text-justify: distribute;
   line-height: 26px;
  
   background: #cf004e; /* Old browsers */


### PR DESCRIPTION
Per <https://developer.mozilla.org/en-US/docs/Web/CSS/text-justify>, "distribute" is deprecated, and has the same effect as inter-character.

Firefox 131.0.3 seems to respect text-justify: distribute. Chromium 129.0.6668.100 seems to ignore text-justify altogether; see <https://caniuse.com/css-text-justify>.

By omitting text-justify: distribute, Firefox and Chrom* ought to use their default justification, which adjusts spacing between words rather than between characters.

---

Subjectively, I think this looks better. e.g. in the second set of screenshots, in the "before", the line of text "bottlenecks in production. For everyone fed up with traditional" stands out oddly.

Screenshots:

| Before | After |
|--------|--------|
| ![Screenshot 2024-10-31 at 10 23 21](https://github.com/user-attachments/assets/c478ecee-9619-4290-8094-264b6102c35d) | ![Screenshot 2024-10-31 at 10 23 43](https://github.com/user-attachments/assets/1dd77540-7d7d-4f02-ab04-ff5624f529a1) |
| ![Screenshot 2024-10-31 at 10 22 30](https://github.com/user-attachments/assets/0b4f1015-2dc4-4514-81d5-5efbea0a7db3) | ![Screenshot 2024-10-31 at 10 22 49](https://github.com/user-attachments/assets/8ce9f719-63b7-453f-a9df-d3fb9a8a1484) | 

