### PR TITLE
Fix: Closing alerts on Opsgenie fails if alias contains special characters

### DIFF
--- a/src/riemann/opsgenie.clj
+++ b/src/riemann/opsgenie.clj
@@ -1,6 +1,7 @@
 (ns riemann.opsgenie
   "Forwards events to OpsGenie"
   (:require [clj-http.client :as client]
+            [clj-http.util :refer [url-encode]]
             [cheshire.core :as json]
             [clojure.string :refer [join]]))
 
@@ -62,7 +63,7 @@
 (defn close-alert
   "Close alert in OpsGenie"
   [api-key event body-fn]
-  (post (str alerts-url "/" (:alias (body-fn event)) "/close?identifierType=alias")
+  (post (str alerts-url "/" (url-encode (str (:alias (body-fn event)))) "/close?identifierType=alias")
         (json/generate-string {:user "Riemann"})
         {"Authorization" (str "GenieKey " api-key)}))
 

--- a/test/riemann/opsgenie_test.clj
+++ b/test/riemann/opsgenie_test.clj
@@ -3,7 +3,8 @@
             [riemann.opsgenie :refer :all]
             [riemann.test-utils :refer [with-mock]]
             [cheshire.core :as json]
-            [clojure.test :refer :all]))
+            [clojure.test :refer :all]
+            [clj-http.util :refer [url-encode]]))
 
 (def service-key (System/getenv "OPSGENIE_SERVICE_KEY"))
 
@@ -50,7 +51,7 @@
         ((:resolve og) event)
         (is (= (first (second @calls))
                (str "https://api.opsgenie.com/v2/alerts/"
-                    (api-alias event)
+                    (url-encode (str (api-alias event)))
                     "/close?identifierType=alias")))
         (is (= (second (second @calls))
                {:body (json/generate-string {:user "Riemann"})
@@ -81,7 +82,7 @@
         ((:resolve og) event)
         (is (= (first (second @calls))
                (str "https://api.opsgenie.com/v2/alerts/"
-                    (:alias (body-fn event))
+                    (url-encode (:alias (body-fn event)))
                     "/close?identifierType=alias")))
         (is (= (second (second @calls))
                {:body (json/generate-string {:user "Riemann"})


### PR DESCRIPTION
An Opsgenie alert can include an arbitrary custom alias (dedup key). The Opsgenie/JSM REST [API for closing alerts](https://docs.opsgenie.com/docs/alert-api#close-alert) supports providing an alias via a path parameter, requiring URL-encoding the alias, otherwise closing alerts can silently fail.