### PR TITLE
fix(transport,rabbitmq): no connection - no instrumentation events

### DIFF
--- a/src/riemann/transport/rabbitmq.clj
+++ b/src/riemann/transport/rabbitmq.clj
@@ -99,18 +99,20 @@
  
   Instrumented
   (events [this]
-    (let [svc (str "riemann transport rabbitmq " (conn->addr @connection))
-          in (metrics/snapshot! stats)
-          base {:state "ok"
-                :tags ["riemann"]
-                :time (:time in)}]
-      (map (partial merge base)
-           (concat [{:service (str svc " in rate")
-                     :metric (:rate in)}]
-                   (map (fn [[q latency]]
-                          {:service (str svc " in latency " q)
-                           :metric latency})
-                        (:latencies in)))))))
+    (if-let [conn @connection]
+      (let [svc (str "riemann transport rabbitmq " (conn->addr conn))
+            in (metrics/snapshot! stats)
+            base {:state "ok"
+                  :tags ["riemann"]
+                  :time (:time in)}]
+        (map (partial merge base)
+             (concat [{:service (str svc " in rate")
+                       :metric (:rate in)}]
+                     (map (fn [[q latency]]
+                            {:service (str svc " in latency " q)
+                             :metric latency})
+                          (:latencies in)))))
+      [])))
 
 (defn rabbitmq-transport
   "Start consuming messages from RabbitMQ, applying them into the current core.

--- a/test/riemann/transport/rabbitmq_test.clj
+++ b/test/riemann/transport/rabbitmq_test.clj
@@ -49,6 +49,11 @@
     (is (service/equiv? one two))
     (is (service/conflict? one two))))
 
+(deftest ^:rabbitmq events-returns-empty-when-connection-is-nil
+  ;; When the transport is not started, connection should be nil, and events should return an empty list.
+  (let [transport (rabbitmq-transport {})]
+    (is (= [] (.events transport)))))
+
 (deftest ^:rabbitmq ^:integration rabbitmq-transport-integration-test
   (riemann.logging/suppress ["riemann.transport"
                              "riemann.pubsub"


### PR DESCRIPTION
Sometimes, when the connection is not yet established, instrumentation kicks in and produces `NullPointerException`'s.
This PR fixes that.